### PR TITLE
Add sha1 to etcd release when not using 'director-latest'

### DIFF
--- a/spec/prepare_deployments_spec.rb
+++ b/spec/prepare_deployments_spec.rb
@@ -651,6 +651,24 @@ HEREDOC
     end
     describe 'print_releases_stub' do
       context 'everything is provided' do
+        let(:command) { ". ./tools/prepare-deployments && print_releases_stub 1 banana 1 banana 'sha1: 1234edf'" }
+        it 'prints stemcell stub' do
+          expect(result).to be_success
+          expect(stdout).to eq(<<HEREDOC
+---
+releases:
+  - name: cf
+    version: 1
+    url: banana
+  - name: etcd
+    version: 1
+    url: banana
+    sha1: 1234edf
+HEREDOC
+)
+        end
+      end
+      context 'no sha1 for etcd is provided' do
         let(:command) { ". ./tools/prepare-deployments && print_releases_stub 1 banana 1 banana" }
         it 'prints stemcell stub' do
           expect(result).to be_success
@@ -663,11 +681,11 @@ releases:
   - name: etcd
     version: 1
     url: banana
+    
 HEREDOC
 )
         end
       end
-
     end
   end
 

--- a/tools/prepare-deployments
+++ b/tools/prepare-deployments
@@ -156,6 +156,18 @@ determine_stemcell_sha1() {
   esac
 }
 
+determine_release_sha1() {
+  case "${1}" in
+    "director-latest")
+      printf ""
+    ;;
+
+    *)
+      printf "sha1: \"%s\"" "$(jq -r ".releases[] | select (.name == \"${2}\") | .sha1" blessed_versions.json)"
+    ;;
+  esac
+}
+
 determine_stemcell_location() {
   case "${1}" in
      "integration-latest")
@@ -343,6 +355,7 @@ print_releases_stub() {
   local cf_release_location="${2}"
   local etcd_version="${3}"
   local etcd_release_location="${4}"
+  local etcd_release_sha1="${5}"
 
   cat <<EOF
 ---
@@ -353,6 +366,7 @@ releases:
   - name: etcd
     version: ${etcd_version}
     url: ${etcd_release_location}
+    ${etcd_release_sha1}
 EOF
 }
 
@@ -386,6 +400,7 @@ main() {
 
   local etcd_version="$(determine_release_version "${etcd_release_variant}" 'etcd')"
   local etcd_release_location="$(determine_release_location "${etcd_release_variant}" 'etcd')"
+  local etcd_release_sha1="$(determine_release_sha1 "${etcd_release_variant}" 'etcd')"
 
   local cf_release_variant="$(determine_variant "${config_file_path}" "cf")"
 
@@ -407,8 +422,8 @@ main() {
   local intermediate_dir="${intermediate_dir}"
   mkdir -p "${intermediate_dir}"
 
-  echo "$(print_stemcells_stub "${stemcell_name}" "${stemcell_version}" "${stemcell_location}" "${stemcell_sha1}")" > "${intermediate_dir}/stemcells.yml" 
-  echo "$(print_releases_stub "${cf_version}" "${cf_release_filepath}" "${etcd_version}" "${etcd_release_location}")"  > "${intermediate_dir}/releases.yml"
+  echo "$(print_stemcells_stub "${stemcell_name}" "${stemcell_version}" "${stemcell_location}" "${stemcell_sha1}")" > "${intermediate_dir}/stemcells.yml"
+  echo "$(print_releases_stub "${cf_version}" "${cf_release_filepath}" "${etcd_version}" "${etcd_release_location}" "${etcd_release_sha1}")"  > "${intermediate_dir}/releases.yml"
 
   if [ "${infrastructure}" = "bosh-lite" ]; then
     infrastructure="warden"


### PR DESCRIPTION
Not done in this change: When local .tgz can be given as
the etcd release path, you also don't need a sha1.

[fixes #6]