### PR TITLE
Update service names for nats, mysql, cc_clock

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -89,7 +89,7 @@ instance_groups:
           domain: cf.internal
           servers: *3
           services:
-            etcd: {}
+            nats: {}
         encrypt_keys: "((consul_encrypt_keys))"
         agent_cert: "((consul_agent_cert))"
         agent_key: "((consul_agent_agent_key))"
@@ -210,7 +210,7 @@ instance_groups:
           domain: cf.internal
           servers: *3
           services:
-            etcd: {}
+            mysql: {}
         encrypt_keys: "((consul_encrypt_keys))"
         agent_cert: "((consul_agent_cert))"
         agent_key: "((consul_agent_agent_key))"
@@ -981,7 +981,7 @@ instance_groups:
           domain: cf.internal
           servers: *3
           services:
-            etcd: {}
+            cc_clock: {}
         encrypt_keys: "((consul_encrypt_keys))"
         agent_cert: "((consul_agent_cert))"
         agent_key: "((consul_agent_agent_key))"


### PR DESCRIPTION
Fresh deployments using `cf-deployment` were failing.

`metron_agent` logs on the consul instances pointed to issues reaching `etcd`.

Updating the service names below fixed the issue for us.

/cc @zankich @rosenhouse 
