### PR TITLE
Set routing_api.auth_disabled to false explicitly

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -957,6 +957,7 @@ instance_groups:
         - name: default-tcp
           type: tcp
           reservable_ports: 1024-65535
+        auth_disabled: false
       skip_ssl_validation: true
       uaa:
         tls_port: 8443


### PR DESCRIPTION
This is the default behavior.  Adding it in just allows bosh ops to be run against it.

[#132676971]

Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>