### PR TITLE
Fix metron agent cert properties

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -8,9 +8,6 @@ properties_shared_across_every_instance_group:
       deployment: "((metron_agent_deployment_name))"
       protocols:
       - tls
-      tls:
-        client_cert: "((metron_metron_agent_tls_client_cert))"
-        client_key: "((metron_metron_agent_tls_client_key))"
       etcd:
         client_cert: "((etcd_client_cert))"
         client_key: "((etcd_client_key))"
@@ -19,6 +16,9 @@ properties_shared_across_every_instance_group:
     loggregator:
       tls:
         ca_cert: "((loggregator_tls_ca_cert))"
+        metron:
+          cert: "((metron_metron_agent_tls_client_cert))"
+          key: "((metron_metron_agent_tls_client_key))"
       etcd:
         require_ssl: true
         ca_cert: "((etcd_ca_cert))"
@@ -1220,9 +1220,6 @@ instance_groups:
           trafficcontroller:
             cert: "((loggregator_tls_tc_cert))"
             key: "((loggregator_tls_tc_key))"
-          metron:
-            cert: "((metron_metron_agent_tls_client_cert))"
-            key: "((metron_metron_agent_tls_client_key))"
         etcd:
           require_ssl: true
           ca_cert: "((etcd_ca_cert))"


### PR DESCRIPTION
The cert/key for metron agent moved and was causing deployments to fail, with the agent failing to start on the first etcd instance:

See: https://c2c.ci.cf-app.com/teams/main/pipelines/netman/jobs/trucker-test-upgrade/builds/211

```bash
cat /var/vcap/sys/log/metron_agent/metron_agent.stderr.log
...
panic: Could not initialize doppler connection pool: failed to load keypair: tls: failed to find any PEM data in key input
```

Moving these properties to match the most recent release of loggregator fixes the issue:

https://c2c.ci.cf-app.com/teams/main/pipelines/netman/jobs/trucker-test-upgrade/builds/213
