### PR TITLE
Fix typo for 'commonname' field in recipe

### DIFF
--- a/cf-filler/recipe-cf-deployment.yml
+++ b/cf-filler/recipe-cf-deployment.yml
@@ -79,7 +79,7 @@ basic_key_pairs:
 cert_sets:
 - ca:
     varname_ca: etcd_ca_cert
-    commonName: etcdCA
+    commonname: etcdCA
   certkeypairs:
   - varname_cert: etcd_server_cert
     varname_key:  etcd_server_key


### PR DESCRIPTION
Most components seem ok without having a 'commonname' set
but flanneld (part of netman-release) fails to connect to etcd
when the commonname is not present.

/cc @rosenhouse @markstgodard