### PR TITLE
Configure garden to clean up on each container destroy

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -538,6 +538,7 @@ instance_groups:
     properties:
       garden:
         default_container_grace_time: 0
+        graph_cleanup_threshold_in_mb: 0
         deny_networks:
         - 0.0.0.0/0
         persistent_image_list:


### PR DESCRIPTION
The default in the garden release is `-1` which means garden's disk usage will indefinitely grow. @jfmyers9 informed me that `0` was the default in the diego manifest generation.