### PR TITLE
Set router_ssl alternative names

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1425,6 +1425,7 @@ variables:
     common_name: routerSSL
     alternative_names:
     - "((system_domain))"
+    - "*.((system_domain))"
 - name: uaa_ca
   type: certificate
   options:

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1423,7 +1423,7 @@ variables:
   options:
     ca: router_ca
     common_name: routerSSL
-    alternative_domains:
+    alternative_names:
     - "((system_domain))"
 - name: uaa_ca
   type: certificate


### PR DESCRIPTION
We noticed recently that the router_ssl certificate alternative_names were not being set.

Also taking the opportunity to add `*.((system_domain))` so that the certificate is valid for subdomains.

Thanks,

Andrew && Stu