### PR TITLE
Disable mutual TLS for Windows consul agent

### DIFF
--- a/opsfiles/windows-cell.yml
+++ b/opsfiles/windows-cell.yml
@@ -21,6 +21,7 @@
           enable: false
         consul:
           agent:
+            require_ssl: false
             mode: client
             domain: cf.internal
             servers:


### PR DESCRIPTION
We're introducing mutual TLS for the consul agent HTTP API, but it's been defaulted to true for Windows and the release is out in the wild. This is causing existing Windows cells to fail with the latest release of consul because we don't have certs in place yet nor do we have a rep release that knows how to talk to consul over mutual TLS.

This disables mutual TLS for the consul HTTP API for now.