### PR TITLE
Require mutual TLS for Windows consul agent API

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1386,6 +1386,8 @@ variables:
     ext_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - 127.0.0.1
 - name: consul_server
   type: certificate
   options:
@@ -1428,6 +1430,13 @@ variables:
     alternative_names:
     - "*.bbs.service.cf.internal"
     - bbs.service.cf.internal
+- name: diego_consul_client
+  type: certificate
+  options:
+    ca: consul_agent_ca
+    common_name: diego consul client
+    ext_key_usage:
+    - client_auth
 - name: loggregator_ca
   type: certificate
   options:

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -21,6 +21,7 @@
           enable: false
         consul:
           agent:
+            require_ssl: true
             mode: client
             domain: cf.internal
             servers:
@@ -51,6 +52,11 @@
               ca_cert: "((diego_bbs_client.ca))"
               client_cert: "((diego_bbs_client.certificate))"
               client_key: "((diego_bbs_client.private_key))"
+            consul:
+              ca_cert: "((consul_agent.ca))"
+              client_cert: "((diego_consul_client.certificate))"
+              client_key: "((diego_consul_client.private_key))"
+              require_tls: true
             require_tls: false
             preloaded_rootfses:
             - windows2012R2:/tmp/windows2012R2


### PR DESCRIPTION
This change requires TLS between the rep and the consul agent on Windows. Note that this can't be merged until https://github.com/cloudfoundry/diego-release/pull/253 is merged, but we're sending it now so that it can be merged when everything is in place.