### PR TITLE
Add opsfiles for local-route-emitter mode

### DIFF
--- a/opsfiles/disable-global-route-emitters.yml
+++ b/opsfiles/disable-global-route-emitters.yml
@@ -1,0 +1,8 @@
+---
+# Use the enable-local-route-emitters.yml opsfile to enable
+# local route emitters on your diego cells.
+# If you have windows cells, use the
+# enable-local-route-emitters-windows-cell.yml opsfile.
+
+- type: remove
+  path: /instance_groups/name=route-emitter

--- a/opsfiles/enable-local-route-emitters.yml
+++ b/opsfiles/enable-local-route-emitters.yml
@@ -1,0 +1,21 @@
+---
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/-
+  value:
+    name: route_emitter
+    release: diego
+    properties:
+      diego:
+        route_emitter:
+          local_mode: true
+          bbs:
+            ca_cert: "((diego_bbs.ca))"
+            client_cert: "((diego_bbs_client.certificate))"
+            client_key: "((diego_bbs_client.private_key))"
+          nats:
+            machines:
+            - 10.0.31.191
+            - 10.0.47.191
+            password: "((nats_password))"
+            port: 4222
+            user: nats


### PR DESCRIPTION
- There is an opsfiles for enabling local route emitters on diego cells.
- There is an opsfiles for disabling global route emitters.

cc @genevievelesperance