### PR TITLE
Add opsfiles for local-route-emitter mode

### DIFF
--- a/opsfiles/enable-local-route-emitters-windows-cell.yml
+++ b/opsfiles/enable-local-route-emitters-windows-cell.yml
@@ -1,0 +1,21 @@
+---
+- type: replace
+  path: /instance_groups/name=windows-cell/jobs/-
+  value:
+    name: route_emitter
+    release: diego
+    properties:
+      diego:
+        route_emitter:
+          local_mode: true
+          bbs:
+            ca_cert: "((diego_bbs.ca))"
+            client_cert: "((diego_bbs_client.certificate))"
+            client_key: "((diego_bbs_client.private_key))"
+          nats:
+            machines:
+            - 10.0.31.191
+            - 10.0.47.191
+            password: "((nats_password))"
+            port: 4222
+            user: nats

--- a/opsfiles/enable-local-route-emitters.yml
+++ b/opsfiles/enable-local-route-emitters.yml
@@ -1,0 +1,21 @@
+---
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/-
+  value:
+    name: route_emitter
+    release: diego
+    properties:
+      diego:
+        route_emitter:
+          local_mode: true
+          bbs:
+            ca_cert: "((diego_bbs.ca))"
+            client_cert: "((diego_bbs_client.certificate))"
+            client_key: "((diego_bbs_client.private_key))"
+          nats:
+            machines:
+            - 10.0.31.191
+            - 10.0.47.191
+            password: "((nats_password))"
+            port: 4222
+            user: nats

--- a/opsfiles/use-only-local-route-emitters-windows-cell.yml
+++ b/opsfiles/use-only-local-route-emitters-windows-cell.yml
@@ -1,0 +1,24 @@
+---
+- type: replace
+  path: /instance_groups/name=windows-cell/jobs/-
+  value:
+    name: route_emitter
+    release: diego
+    properties:
+      diego:
+        route_emitter:
+          local_mode: true
+          bbs:
+            ca_cert: "((diego_bbs.ca))"
+            client_cert: "((diego_bbs_client.certificate))"
+            client_key: "((diego_bbs_client.private_key))"
+          nats:
+            machines:
+            - 10.0.31.191
+            - 10.0.47.191
+            password: "((nats_password))"
+            port: 4222
+            user: nats
+
+- type: remove
+  path: /instance_groups/name=route-emitter

--- a/opsfiles/use-only-local-route-emitters.yml
+++ b/opsfiles/use-only-local-route-emitters.yml
@@ -1,0 +1,24 @@
+---
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/-
+  value:
+    name: route_emitter
+    release: diego
+    properties:
+      diego:
+        route_emitter:
+          local_mode: true
+          bbs:
+            ca_cert: "((diego_bbs.ca))"
+            client_cert: "((diego_bbs_client.certificate))"
+            client_key: "((diego_bbs_client.private_key))"
+          nats:
+            machines:
+            - 10.0.31.191
+            - 10.0.47.191
+            password: "((nats_password))"
+            port: 4222
+            user: nats
+
+- type: remove
+  path: /instance_groups/name=route-emitter


### PR DESCRIPTION
- There is an opsfile for enabling local route emitters on diego cells
*and* removing global route emitters.
- There is an opsfile for enabling local route emitters on diego cells.

There is duplicate code between these opsfiles. We debated some sort of assertion logic that would validate that the local route emitters were enabled if global route emitters were to be disabled. This seemed rather brittle. After discussion with RelInt, we figured the duplicate code would eventually be refactored in favor of some sort of assertion in the opsfile.

cc @genevievelesperance