### PR TITLE
Provide cloud_controller link for other deployments

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -734,6 +734,8 @@ instance_groups:
         server_key: "((consul_server.private_key))"
   - name: cloud_controller_ng
     release: capi
+    provides:
+      cloud_controller: {as: cloud_controller, shared: true}
     properties:
       router:
         route_services_secret: "((router_route_services_secret))"


### PR DESCRIPTION
Currently gives access to system_domain and app_domains

[finishes #138069149, #138069165]