### PR TITLE
Remove nats config from routing-release components

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -276,7 +276,6 @@ instance_groups:
   - name: gorouter
     release: routing
     properties:
-      nats: *nats_properties
       router:
         enable_ssl: true
         ssl_cert: "((router_ssl.certificate))"
@@ -489,11 +488,6 @@ instance_groups:
           - "*.uaa.((system_domain))"
           - login.((system_domain))
           - "*.login.((system_domain))"
-      nats:
-        machines: *nats_machines
-        password: "((nats_password))"
-        port: 4222
-        user: nats
   - name: metron_agent
     release: loggregator
     properties: *metron_agent_properties
@@ -704,11 +698,6 @@ instance_groups:
             component: blobstore
           uris:
           - blobstore.((system_domain))
-      nats:
-        machines: *nats_machines
-        password: "((nats_password))"
-        port: 4222
-        user: nats
   - name: metron_agent
     release: loggregator
     properties: *metron_agent_properties
@@ -935,11 +924,6 @@ instance_groups:
           port: 9022
           uris:
           - api.((system_domain))
-      nats:
-        machines: *nats_machines
-        password: "((nats_password))"
-        port: 4222
-        user: nats
   - name: statsd-injector
     release: statsd-injector
   - name: metron_agent
@@ -1242,11 +1226,6 @@ instance_groups:
           uris:
           - doppler.((system_domain))
           - "*.doppler.((system_domain))"
-      nats:
-        machines: *nats_machines
-        password: "((nats_password))"
-        port: 4222
-        user: nats
   - name: metron_agent
     release: loggregator
     properties: *metron_agent_properties

--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -188,22 +188,7 @@
   path: /instance_groups/name=log-api/jobs/name=consul_agent/properties/consul/agent/servers/lan
   value: *consul_ips
 - type: replace
-  path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/nats/machines
-  value: *nats_ips
-- type: replace
   path: /instance_groups/name=nats/jobs/name=nats_stream_forwarder/properties/nats/machines
-  value: *nats_ips
-- type: replace
-  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/nats/machines
-  value: *nats_ips
-- type: replace
-  path: /instance_groups/name=api/jobs/name=route_registrar/properties/nats/machines
-  value: *nats_ips
-- type: replace
-  path: /instance_groups/name=blobstore/jobs/name=route_registrar/properties/nats/machines
-  value: *nats_ips
-- type: replace
-  path: /instance_groups/name=router/jobs/name=gorouter/properties/nats/machines
   value: *nats_ips
 - type: replace
   path: /instance_groups/name=route-emitter/jobs/name=route_emitter/properties/diego/route_emitter/nats/machines

--- a/operations/static-ips.yml
+++ b/operations/static-ips.yml
@@ -69,22 +69,7 @@
   path: /instance_groups/name=log-api/jobs/name=consul_agent/properties/consul/agent/servers/lan
   value: *consul_ips
 - type: replace
-  path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/nats/machines
-  value: *nats_ips
-- type: replace
   path: /instance_groups/name=nats/jobs/name=nats_stream_forwarder/properties/nats/machines
-  value: *nats_ips
-- type: replace
-  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/nats/machines
-  value: *nats_ips
-- type: replace
-  path: /instance_groups/name=api/jobs/name=route_registrar/properties/nats/machines
-  value: *nats_ips
-- type: replace
-  path: /instance_groups/name=blobstore/jobs/name=route_registrar/properties/nats/machines
-  value: *nats_ips
-- type: replace
-  path: /instance_groups/name=router/jobs/name=gorouter/properties/nats/machines
   value: *nats_ips
 - type: replace
   path: /instance_groups/name=route-emitter/jobs/name=route_emitter/properties/diego/route_emitter/nats/machines


### PR DESCRIPTION
routing-release 0.144.0 can consume it via links

Signed-off-by: Dan Wendorf <dwendorf@pivotal.io>