### PR TITLE
add the cfdot job to diego-cells

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -610,6 +610,12 @@ instance_groups:
   - name: metron_agent
     release: loggregator
     properties: *metron_agent_properties
+  - name: cfdot
+    release: diego
+    properties:
+      diego:
+        cfdot:
+          bbs: *diego_bbs_client_properties
 - name: route-emitter
   azs:
   - z1


### PR DESCRIPTION
The PR makes cfdot available to diego cells, making it easier to interact with diego components.

Signed-off-by: Brandon Shroyer <bshroyer@pivotal.io>