### PR TITLE
Allow consul to consume its own link

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -21,20 +21,18 @@ instance_groups:
     serial: true
   networks:
   - name: private
-    static_ips: &consul_ips
-    - 10.0.31.190
-    - 10.0.47.190
-    - 10.0.63.190
   jobs:
   - name: consul_agent
     release: consul
+    consumes:
+      consul: {from: consul_server}
+    provides:
+      consul: {as: consul_server}
     properties:
       consul:
         agent:
           mode: server
           domain: cf.internal
-          servers: &consul_machines
-            lan: *consul_ips
         encrypt_keys:
         - "((consul_encrypt_key))"
         agent_cert: "((consul_agent.certificate))"
@@ -80,19 +78,8 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
-    properties:
-      consul:
-        agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
+    consumes:
+      consul: {from: consul_server}
   - name: nats
     release: nats
     provides:
@@ -127,21 +114,13 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
+    consumes:
+      consul: {from: consul_server}
     properties:
       consul:
         agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
           services:
             etcd: {}
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
   - name: etcd
     release: etcd
     properties:
@@ -191,19 +170,8 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
-    properties:
-      consul:
-        agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
+    consumes:
+      consul: {from: consul_server}
   - name: mysql
     release: cf-mysql
     properties:
@@ -248,21 +216,13 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
+    consumes:
+      consul: {from: consul_server}
     properties:
       consul:
         agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
           services:
             gorouter: {}
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
   - name: gorouter
     release: routing
     properties:
@@ -297,19 +257,8 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
-    properties:
-      consul:
-        agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
+    consumes:
+      consul: {from: consul_server}
   - name: bbs
     release: diego
     properties:
@@ -355,21 +304,13 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
+    consumes:
+      consul: {from: consul_server}
     properties:
       consul:
         agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
           services:
             uaa: {}
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
   - name: uaa
     release: uaa
     properties:
@@ -506,19 +447,8 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
-    properties:
-      consul:
-        agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
+    consumes:
+      consul: {from: consul_server}
   - name: ssh_proxy
     release: diego
     properties:
@@ -562,19 +492,8 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
-    properties:
-      consul:
-        agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
+    consumes:
+      consul: {from: consul_server}
   - name: cflinuxfs2-rootfs-setup
     release: cflinuxfs2-rootfs
   - name: garden
@@ -621,19 +540,8 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
-    properties:
-      consul:
-        agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
+    consumes:
+      consul: {from: consul_server}
   - name: route_emitter
     release: diego
     properties:
@@ -666,21 +574,13 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
+    consumes:
+      consul: {from: consul_server}
     properties:
       consul:
         agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
           services:
             blobstore: {}
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
   - name: blobstore
     release: capi
     properties:
@@ -724,21 +624,13 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
+    consumes:
+      consul: {from: consul_server}
     properties:
       consul:
         agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
           services:
             cloud_controller_ng: {}
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
   - name: cloud_controller_ng
     release: capi
     properties:
@@ -952,19 +844,8 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
-    properties:
-      consul:
-        agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
+    consumes:
+      consul: {from: consul_server}
   - name: cloud_controller_clock
     release: capi
     properties:
@@ -1027,19 +908,8 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
-    properties:
-      consul:
-        agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
+    consumes:
+      consul: {from: consul_server}
   - name: stager
     release: capi
     properties:
@@ -1096,22 +966,14 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
+    consumes:
+      consul: {from: consul_server}
     properties:
       consul:
         agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
           services:
             doppler:
               name: doppler
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
   - name: doppler
     release: loggregator
     properties:
@@ -1179,21 +1041,13 @@ instance_groups:
   jobs:
   - name: consul_agent
     release: consul
+    consumes:
+      consul: {from: consul_server}
     properties:
       consul:
         agent:
-          mode: client
-          domain: cf.internal
-          servers: *consul_machines
           services:
             loggregator_trafficcontroller: {}
-        encrypt_keys:
-        - "((consul_encrypt_key))"
-        agent_cert: "((consul_agent.certificate))"
-        agent_key: "((consul_agent.private_key))"
-        ca_cert: "((consul_agent.ca))"
-        server_cert: "((consul_server.certificate))"
-        server_key: "((consul_server.private_key))"
   - name: loggregator_trafficcontroller
     release: loggregator
     properties:

--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -5,10 +5,6 @@
   - name: private
     static_ips: [10.244.0.34]
 - type: replace
-  path: /instance_groups/name=consul/networks/name=private/static_ips
-  value: &consul_ips
-  - 10.244.0.2
-- type: replace
   path: /instance_groups/name=nats/networks/name=private/static_ips
   value: &nats_ips
   - 10.244.0.6
@@ -139,54 +135,6 @@
   path: /instance_groups/name=log-api/instances
   value: 1
 # --------------------------------------------------------------------------------------------
-- type: replace
-  path: /instance_groups/name=consul/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=etcd/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=nats/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=mysql/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=diego-bbs/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=diego-brain/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=router/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=uaa/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=route-emitter/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=blobstore/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=cc_clock/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=api/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=cc_bridge/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=doppler/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=log-api/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
 - type: replace
   path: /instance_groups/name=route-emitter/jobs/name=route_emitter/properties/diego/route_emitter/nats/machines
   value: *nats_ips

--- a/operations/static-ips.yml
+++ b/operations/static-ips.yml
@@ -1,10 +1,4 @@
 - type: replace
-  path: /instance_groups/name=consul/networks/name=private/static_ips
-  value: &consul_ips
-  - CONSUL_STATIC_IP_1
-  - CONSUL_STATIC_IP_2
-  - CONSUL_STATIC_IP_3
-- type: replace
   path: /instance_groups/name=nats/networks/name=private/static_ips
   value: &nats_ips
   - NATS_STATIC_IP_1
@@ -17,57 +11,6 @@
 
 # ---------------------------------------------------------------------------------------------
 
-- type: replace
-  path: /instance_groups/name=consul/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=etcd/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=nats/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=mysql/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=diego-bbs/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=diego-brain/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=router/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=uaa/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=tcp-router/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=route-emitter/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=blobstore/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=cc_clock/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=api/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=cc_bridge/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=doppler/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
-- type: replace
-  path: /instance_groups/name=log-api/jobs/name=consul_agent/properties/consul/agent/servers/lan
-  value: *consul_ips
 - type: replace
   path: /instance_groups/name=route-emitter/jobs/name=route_emitter/properties/diego/route_emitter/nats/machines
   value: *nats_ips

--- a/operations/tcp-routing-gcp.yml
+++ b/operations/tcp-routing-gcp.yml
@@ -17,23 +17,8 @@
     jobs:
     - name: consul_agent
       release: consul
-      properties:
-        consul:
-          agent:
-            mode: client
-            domain: cf.internal
-            servers:
-              lan: &consul_machines
-              - 10.0.31.190
-              - 10.0.47.190
-              - 10.0.63.190
-          encrypt_keys:
-          - "((consul_encrypt_key))"
-          agent_cert: "((consul_agent.certificate))"
-          agent_key: "((consul_agent.private_key))"
-          ca_cert: "((consul_agent.ca))"
-          server_cert: "((consul_server.certificate))"
-          server_key: "((consul_server.private_key))"
+      consumes:
+        consul: {from: consul_server}
     - name: tcp_router
       release: routing
       properties:
@@ -84,20 +69,8 @@
     jobs:
     - name: consul_agent
       release: consul
-      properties:
-        consul:
-          agent:
-            mode: client
-            domain: cf.internal
-            servers:
-              lan: *consul_machines
-          encrypt_keys:
-          - "((consul_encrypt_key))"
-          agent_cert: "((consul_agent.certificate))"
-          agent_key: "((consul_agent.private_key))"
-          ca_cert: "((consul_agent.ca))"
-          server_cert: "((consul_server.certificate))"
-          server_key: "((consul_server.private_key))"
+      consumes:
+        consul: {from: consul_server}
     - name: tcp_emitter
       release: routing
       properties:

--- a/operations/test/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/test/add-persistent-isolation-segment-diego-cell.yml
@@ -15,23 +15,8 @@
     jobs:
     - name: consul_agent
       release: consul
-      properties:
-        consul:
-          agent:
-            mode: client
-            domain: cf.internal
-            servers:
-              lan:
-              - 10.0.31.190
-              - 10.0.47.190
-              - 10.0.63.190
-          encrypt_keys:
-          - "((consul_encrypt_key))"
-          agent_cert: "((consul_agent.certificate))"
-          agent_key: "((consul_agent.private_key))"
-          ca_cert: "((consul_agent.ca))"
-          server_cert: "((consul_server.certificate))"
-          server_key: "((consul_server.private_key))"
+      consumes:
+        consul: {from: consul_server}
     - name: cflinuxfs2-rootfs-setup
       release: cflinuxfs2-rootfs
     - name: garden

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -16,26 +16,14 @@
     jobs:
     - name: consul_agent_windows
       release: consul
+      consumes:
+        consul: {from: consul_server}
       properties:
         syslog_daemon_config:
           enable: false
         consul:
           agent:
             require_ssl: true
-            mode: client
-            domain: cf.internal
-            servers:
-              lan:
-              - 10.0.31.190
-              - 10.0.47.190
-              - 10.0.63.190
-          encrypt_keys:
-          - "((consul_encrypt_key))"
-          agent_cert: "((consul_agent.certificate))"
-          agent_key: "((consul_agent.private_key))"
-          ca_cert: "((consul_agent.ca))"
-          server_cert: "((consul_server.certificate))"
-          server_key: "((consul_server.private_key))"
     - name: garden-windows
       release: garden-windows
       properties:


### PR DESCRIPTION
Consul can be run in two modes, server or client. We only want the
server-mode consul jobs to provide a link, but due to the nature of bosh
links, all consul jobs provide the link. Therefore, we need to select
the correct link.

Note: This PR should not be merged until cf-deployment is consuming a consul-release that includes cloudfoundry-incubator/consul-release#64, which will presumably be consul-release v153.