### PR TITLE
Remove nats_stream_forwarder

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -95,14 +95,6 @@ instance_groups:
         ca_cert: "((consul_agent.ca))"
         server_cert: "((consul_server.certificate))"
         server_key: "((consul_server.private_key))"
-  - name: nats_stream_forwarder
-    release: nats
-    properties:
-      nats: &nats_properties
-        machines: *nats_machines
-        password: "((nats_password))"
-        port: 4222
-        user: nats
   - name: nats
     release: nats
     provides:

--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -191,9 +191,6 @@
   path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/nats/machines
   value: *nats_ips
 - type: replace
-  path: /instance_groups/name=nats/jobs/name=nats_stream_forwarder/properties/nats/machines
-  value: *nats_ips
-- type: replace
   path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/nats/machines
   value: *nats_ips
 - type: replace

--- a/operations/static-ips.yml
+++ b/operations/static-ips.yml
@@ -72,9 +72,6 @@
   path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/nats/machines
   value: *nats_ips
 - type: replace
-  path: /instance_groups/name=nats/jobs/name=nats_stream_forwarder/properties/nats/machines
-  value: *nats_ips
-- type: replace
   path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/nats/machines
   value: *nats_ips
 - type: replace


### PR DESCRIPTION
We are working under the assumption that it is not necessary in the
current cf-deployment universe where nats is used much less. If this
turns out not to be the case, we can bring it back.

Note: nats_stream_forwarder does not currently consume the nats link,
so if it is brought back, the release should be updated first.

Signed-off-by: Derek Richard <drichard@pivotal.io>