### PR TITLE
Allow secure communication between rep_windows and the file server by default

### DIFF
--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -46,6 +46,8 @@
         syslog_daemon_config:
           enable: false
         diego:
+          executor:
+            ca_certs_for_downloads: "((blobstore_tls.ca))"
           rep:
             bbs:
               ca_cert: "((diego_bbs_client.ca))"

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -56,8 +56,6 @@
             require_tls: false
             preloaded_rootfses:
             - windows2012R2:/tmp/windows2012R2
-          ssl:
-            skip_cert_verify: true
     - name: metron_agent_windows
       release: loggregator
       properties:


### PR DESCRIPTION
The `ca_certs_for_downloads` property was missing from the `rep_windows` job. It is needed to be able to set `diego.ssl.skip_cert_verify` to `false` and have the rep be able to talk to the file server. 

This PR also sets `diego.ssl.skip_cert_verify` to the default (false) so it verifies by default.