### PR TITLE
add hwc-buildpack to windows-cell ops file

### DIFF
--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -102,3 +102,23 @@
       description: "Cloud Foundry Linux-based filesystem"
     - name: "windows2012R2"
       description: "Windows Server 2012 R2"
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: hwc_buildpack
+    package: hwc-buildpack
+
+- type: replace
+  path: /instance_groups/name=api/jobs/-
+  value:
+    name: hwc-buildpack
+    release: hwc-buildpack
+
+- type: replace
+  path: /releases/-
+  value:
+    name: hwc-buildpack
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=2.1.0
+    version: 2.1.0
+    sha: 6f56a52a04de8df70b1b506782868cf6b336ea7b

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -119,6 +119,6 @@
   path: /releases/-
   value:
     name: hwc-buildpack
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=2.1.0
-    version: 2.1.0
-    sha: 6f56a52a04de8df70b1b506782868cf6b336ea7b
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=2.1.2
+    version: 2.1.2
+    sha: 63b92915a629c4d809db451ba4b65cf06024c220


### PR DESCRIPTION
The hwc-buildpack is now on bosh.io and can be used with windows deployments. The release can be found here: https://bosh.io/releases/github.com/cloudfoundry-incubator/hwc-buildpack-release?version=2.1.0