### PR TITLE
Extend diego bbs server cert to be a client

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1407,6 +1407,7 @@ variables:
     common_name: bbs.service.cf.internal
     ext_key_usage:
     - server_auth
+    - client_auth
     alternative_names:
     - "*.bbs.service.cf.internal"
     - bbs.service.cf.internal


### PR DESCRIPTION
* Diego is also a client to Cloud Controller when handling callbacks (such as Task
completion).

[#133804829]

Signed-off-by: Chunyi Lyu <clyu@pivotal.io>