### PR TITLE
Remove nats config from cloud_controller jobs

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -644,11 +644,6 @@ instance_groups:
       app_ssh: &app_ssh
         host_key_fingerprint: "((diego_ssh_proxy_host_key.public_key_fingerprint))"
         oauth_client_id: ssh-proxy
-      nats:
-        machines: *nats_machines
-        password: "((nats_password))"
-        port: 4222
-        user: nats
       uaa:
         ca_cert: "((uaa_ssl.ca))"
         clients:
@@ -778,11 +773,6 @@ instance_groups:
       system_domain_organization: default_org
       app_domains: *app_domains
       app_ssh: *app_ssh
-      nats:
-        machines: *nats_machines
-        password: "((nats_password))"
-        port: 4222
-        user: nats
       uaa:
         ca_cert: "((uaa_ssl.ca))"
         clients:
@@ -868,11 +858,6 @@ instance_groups:
       system_domain_organization: default_org
       app_domains: *app_domains
       app_ssh: *app_ssh
-      nats:
-        machines: *nats_machines
-        password: "((nats_password))"
-        port: 4222
-        user: nats
       uaa:
         ca_cert: "((uaa_ssl.ca))"
         clients:


### PR DESCRIPTION
As of capi-release 0.121.0, cloud_controller jobs can consume nats links.