### PR TITLE
Update garden-windows-bosh-release to the latest

### DIFF
--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -70,9 +70,9 @@
   path: /releases/-
   value:
     name: garden-windows
-    version: 0.2.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-windows-bosh-release?v=0.2.0
-    sha1: 971fa08613da97015f94da55a9520b389b0867d0
+    version: 0.3.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-windows-bosh-release?v=0.3.0
+    sha1: d6aa7b91b13ef480c4630f11fc8fe044ebc4eebf
 
 - type: replace
   path: /stemcells/-


### PR DESCRIPTION
We cut a new release of garden-windows, this PR reflects the version bump.

Can we automate the bump of this release in CI?