### PR TITLE
add hwc-buildpack to windows-cell ops file

### DIFF
--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -102,3 +102,23 @@
       description: "Cloud Foundry Linux-based filesystem"
     - name: "windows2012R2"
       description: "Windows Server 2012 R2"
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: hwc_buildpack
+    package: hwc-buildpack
+
+- type: replace
+  path: /instance_groups/name=api/jobs/-
+  value:
+    name: hwc-buildpack
+    release: hwc-buildpack
+
+- type: replace
+  path: /releases/-
+  value:
+    name: hwc-buildpack
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=2.1.0
+    version: 2.1.0
+    sha: 6f56a52a04de8df70b1b506782868cf6b336ea7b

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -119,6 +119,6 @@
   path: /releases/-
   value:
     name: hwc-buildpack
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=2.1.2
-    version: 2.1.2
-    sha: 63b92915a629c4d809db451ba4b65cf06024c220
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=2.2.0
+    version: 2.2.0
+    sha: d4f5df07a76fba0324dc6d9e708e7989e3ff2f38

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -119,6 +119,6 @@
   path: /releases/-
   value:
     name: hwc-buildpack
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=2.1.0
-    version: 2.1.0
-    sha: 6f56a52a04de8df70b1b506782868cf6b336ea7b
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=2.1.2
+    version: 2.1.2
+    sha: 63b92915a629c4d809db451ba4b65cf06024c220


### PR DESCRIPTION
Windows operations file should pull in HWC buildpack from bosh.io by default. As of version `2.2.0` hwc-buildpack-release now has a linux specific job/package as well as the support for a windows errand.

https://github.com/cloudfoundry/cf-deployment/pull/66