### PR TITLE
Use port 80 for TCP health check

### DIFF
--- a/operations/tcp-routing-gcp.yml
+++ b/operations/tcp-routing-gcp.yml
@@ -24,7 +24,7 @@
       properties:
         tcp_router:
           oauth_secret: "((uaa_clients_tcp_router_secret))"
-          health_check_port: 8080
+          health_check_port: 80
         uaa:
           ca_cert: "((uaa_ca.certificate))"
           tls_port: 8443


### PR DESCRIPTION
Hi, 

Currently TCP health check port is set to ephemeral port( `8080`) by default but it is recommended for operators to use reserved port(`80`). If port `8080` is used for health check it could potentially be a clash with router groups. 

Story: https://www.pivotaltracker.com/story/show/141653531

Regards
Shash
