### PR TITLE
Disable legacy unsecured endpoints on the rep API

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -821,6 +821,7 @@ instance_groups:
           ca_cert: "((diego_rep_server.ca))"
           server_cert: "((diego_rep_server.certificate))"
           server_key: "((diego_rep_server.private_key))"
+          enable_legacy_api_endpoints: false
   - name: metron_agent
     release: loggregator
     properties: *metron_agent_properties

--- a/operations/test/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/test/add-persistent-isolation-segment-diego-cell.yml
@@ -41,6 +41,7 @@
               ca_cert: "((diego_bbs_client.ca))"
               client_cert: "((diego_bbs_client.certificate))"
               client_key: "((diego_bbs_client.private_key))"
+            enable_legacy_api_endpoints: false
             preloaded_rootfses:
             - cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs
             placement_tags:

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -39,6 +39,7 @@
             ca_cert: "((diego_rep_server.ca))"
             server_cert: "((diego_rep_server.certificate))"
             server_key: "((diego_rep_server.private_key))"
+            enable_legacy_api_endpoints: false
             bbs:
               ca_cert: "((diego_bbs_client.ca))"
               client_cert: "((diego_bbs_client.certificate))"


### PR DESCRIPTION
This change configures the rep to serve only its administrative
endpoints (/ping, /evacuate) over plain HTTP. This change also
configures this plain-HTTP server to listen only on localhost
and not a remotely routable IP.

[#140322915]