### PR TITLE
Fix clients that failed uaa manifest validation

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -305,6 +305,7 @@ instance_groups:
             override: true
             refresh-token-validity: 2592000
             scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write
+            secret: ''
           cloud_controller_username_lookup:
             authorities: scim.userids
             authorized-grant-types: client_credentials
@@ -316,7 +317,7 @@ instance_groups:
             secret: "((uaa_clients_doppler_secret))"
           gorouter:
             authorities: routing.routes.read
-            authorized-grant-types: client_credentials,refresh_token
+            authorized-grant-types: client_credentials
             secret: "((uaa_clients_gorouter_secret))"
           ssh-proxy:
             authorized-grant-types: authorization_code
@@ -327,11 +328,11 @@ instance_groups:
             secret: "((uaa_clients_ssh-proxy_secret))"
           tcp_emitter:
             authorities: routing.routes.write,routing.routes.read,routing.router_groups.read
-            authorized-grant-types: client_credentials,refresh_token
+            authorized-grant-types: client_credentials
             secret: "((uaa_clients_tcp_emitter_secret))"
           tcp_router:
             authorities: routing.routes.read,routing.router_groups.read
-            authorized-grant-types: client_credentials,refresh_token
+            authorized-grant-types: client_credentials
             secret: "((uaa_clients_tcp_router_secret))"
       uaadb:
         address: sql-db.service.cf.internal


### PR DESCRIPTION
Update uaa configuration to pass new configuration validations

These changes follow those previously submitted for cf-release 
https://github.com/cf-identity/cf-release/commit/de6f6f0612dfe8a77333bc422167e6dc25db166c

[#141162355] https://www.pivotaltracker.com/story/show/141162355

Signed-off-by: bsekar <bharath.sekar@ge.com>