### PR TITLE
Update bosh-lite-on-gcp-deployment-guide.md

### DIFF
--- a/bosh-lite-on-gcp-deployment-guide.md
+++ b/bosh-lite-on-gcp-deployment-guide.md
@@ -73,8 +73,8 @@ With command line arguments, the `create-env` command will look like this:
 bosh create-env \
   --vars-store /path/to/env-repo/bosh-vars.yml \
   --state /path/to/env-repo/bosh-state.yml \
-  -o bosh-deployment/bosh-lite.yml \
   -o bosh-deployment/gcp/cpi.yml \
+  -o bosh-deployment/bosh-lite.yml \
   -o bosh-deployment/external-ip-not-recommended.yml \
   -o bosh-deployment/gcp/bosh-lite-vm-type.yml \
   -o bosh-deployment/jumpbox-user.yml \
@@ -115,8 +115,8 @@ you can run a simpler command to bootstrap a director:
 bosh create-env \
   --vars-store /path/to/env-repo/bosh-vars.yml \
   --state /path/to/env-repo/bosh-state.json \
-  -o bosh-deployment/bosh-lite.yml \
   -o bosh-deployment/gcp/cpi.yml \
+  -o bosh-deployment/bosh-lite.yml \
   -o bosh-deployment/external-ip-not-recommended.yml \
   -o bosh-deployment/gcp/bosh-lite-vm-type.yml \
   -o bosh-deployment/jumpbox-user.yml \


### PR DESCRIPTION
The `bosh-deployment/gcp/cpi.yml` ops file will set the director's `cpi_job` property to `google_cpi` and overwrite the `cpi_job: warden_cpi` set by the `bosh-deployment/bosh-lite.yml` ops file.

When this happens, uploading a Bosh Lite Warden stemcell will yield an error:

`Error: CPI error 'Bosh::Clouds::CloudError' with message 'Creating stemcell: Invalid 'warden' infrastructure' in 'create_stemcell' CPI method`

Reversing the order of these two ops files fixes the problem.