### PR TITLE
Set default app memory to 256M on bosh-lite

### DIFF
--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -242,3 +242,8 @@
 - type: replace
   path: /instance_groups/name=log-api/instances
   value: 1
+
+# ----- Reduce default app memory to 256M ------
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_app_memory?
+  value: 256


### PR DESCRIPTION
This is what the cf-release bosh-lite manifest templates use.