### PR TITLE
Implement diego-deployment constraints

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -737,6 +737,8 @@ instance_groups:
   vm_extensions:
   - diego-ssh-proxy-network-properties
   stemcell: default
+  update:
+    serial: true
   networks:
   - name: private
   jobs:


### PR DESCRIPTION
Currently `diego-bbs` and `diego-brain` are being deployed along with the cells, that can (and likely will) cause downtime.
This commit fixes that issue.

Source: https://github.com/cloudfoundry/diego-release/blob/develop/docs/deployment-constraints.md#diego-manifest-jobs