### PR TITLE
Enable garden debug server

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -841,6 +841,7 @@ instance_groups:
     release: garden-runc
     properties:
       garden:
+        debug_listen_address: 127.0.0.1:17019
         default_container_grace_time: 0
         destroy_containers_on_start: true
         graph_cleanup_threshold_in_mb: 0


### PR DESCRIPTION
Enabling the server allows the operator to collect profiling data
from the Golang runtime and to change the lager log-level dynamically.
The port (17019) is in the conventional 170xx range and will not
collide with an existing known port.