### PR TITLE
consistent 'default' name for all things: 'private' network now 'default'

### DIFF
--- a/bosh-lite/cloud-config.yml
+++ b/bosh-lite/cloud-config.yml
@@ -4,7 +4,7 @@ azs:
 - name: z3
 compilation:
   az: z1
-  network: private
+  network: default
   reuse_compilation_vms: true
   vm_type: m3.medium
   workers: 6
@@ -18,13 +18,13 @@ disk_types:
 - disk_size: 100240
   name: 100GB
 networks:
-- name: private
+- name: default
   subnets:
   - azs: [z1, z2, z3]
     cloud_properties:
       name: random
     gateway: 10.244.0.1
-    range: 10.244.0.0/22
+    range: 10.244.0.0/19
     reserved:
     - 10.244.0.1
     static:
@@ -50,6 +50,7 @@ vm_extensions:
     ports:
     - host: 1024-1123
 vm_types:
+- name: default
 - name: m3.medium
 - name: m3.large
 - name: m3.xlarge

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -18,7 +18,7 @@ instance_groups:
     max_in_flight: 1
     serial: true
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: smoke_tests
     release: cf-smoke-tests
@@ -45,7 +45,7 @@ instance_groups:
     max_in_flight: 1
     serial: true
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -91,7 +91,7 @@ instance_groups:
   - 10GB_ephemeral_disk
   stemcell: default
   networks:
-  - name: private
+  - name: default
     static_ips: &nats_machines
     - 10.0.31.191
     - 10.0.47.191
@@ -130,7 +130,7 @@ instance_groups:
     serial: true
     max_in_flight: 1
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -185,7 +185,7 @@ instance_groups:
   update:
     serial: true
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -194,7 +194,7 @@ instance_groups:
   - name: mysql
     release: cf-mysql
     properties:
-      network_name: private
+      network_name: default
       cf_mysql:
         mysql:
           galera_healthcheck:
@@ -244,7 +244,7 @@ instance_groups:
   - 10GB_ephemeral_disk
   stemcell: default
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -389,7 +389,7 @@ instance_groups:
   persistent_disk_type: 100GB
   stemcell: default
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -439,7 +439,7 @@ instance_groups:
   - 50GB_ephemeral_disk
   stemcell: default
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -612,7 +612,7 @@ instance_groups:
   - 10GB_ephemeral_disk
   stemcell: default
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -670,7 +670,7 @@ instance_groups:
     max_in_flight: 1
     serial: true
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -713,7 +713,7 @@ instance_groups:
   vm_type: m3.large
   stemcell: default
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -774,7 +774,7 @@ instance_groups:
   update:
     serial: true
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -830,7 +830,7 @@ instance_groups:
   - 100GB_ephemeral_disk
   stemcell: default
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -885,7 +885,7 @@ instance_groups:
   vm_type: m3.medium
   stemcell: default
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -913,7 +913,7 @@ instance_groups:
   - 10GB_ephemeral_disk
   stemcell: default
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -971,7 +971,7 @@ instance_groups:
   - 10GB_ephemeral_disk
   stemcell: default
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -1035,7 +1035,7 @@ instance_groups:
   - 10GB_ephemeral_disk
   stemcell: default
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul
@@ -1106,7 +1106,7 @@ instance_groups:
     max_in_flight: 1
     serial: true
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: consul_agent
     release: consul

--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -3,12 +3,12 @@
 - type: replace
   path: /instance_groups/name=router/networks
   value:
-  - name: private
+  - name: default
     static_ips: [10.244.0.34]
 
 # --- Remove unnecessary static ips for nats_machines ---
 - type: remove
-  path: /instance_groups/name=nats/networks/name=private/static_ips
+  path: /instance_groups/name=nats/networks/name=default/static_ips
 
 # --- Replace MySQL job with Postgres ---
 - type: replace

--- a/operations/scale-to-one-az.yml
+++ b/operations/scale-to-one-az.yml
@@ -4,7 +4,7 @@
 # in a single Availability Zone.
 ## Note: This also reduces the static IPs used by nats.
 - type: remove
-  path: /instance_groups/name=nats/networks/name=private/static_ips?/1
+  path: /instance_groups/name=nats/networks/name=default/static_ips?/1
 
 - type: replace
   path: /instance_groups/name=consul/instances

--- a/operations/tcp-routing-gcp.yml
+++ b/operations/tcp-routing-gcp.yml
@@ -13,7 +13,7 @@
     - internet-required
     - cf-tcp-router-network-properties
     networks:
-    - name: private
+    - name: default
     jobs:
     - name: consul_agent
       release: consul
@@ -65,7 +65,7 @@
     - internet-required
     stemcell: default
     networks:
-    - name: private
+    - name: default
     jobs:
     - name: consul_agent
       release: consul

--- a/operations/test/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/test/add-persistent-isolation-segment-diego-cell.yml
@@ -11,7 +11,7 @@
     - 100GB_ephemeral_disk
     stemcell: default
     networks:
-    - name: private
+    - name: default
     jobs:
     - name: consul_agent
       release: consul

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -12,7 +12,7 @@
     - 100GB_ephemeral_disk
     stemcell: windows
     networks:
-    - name: private
+    - name: default
     jobs:
     - name: consul_agent_windows
       release: consul


### PR DESCRIPTION
I've sanity tested this change by upgrading my cloud-config + deploying: all ok.