### PR TITLE
Add more certs for cc-uploader <-> diego mTLS

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1013,6 +1013,9 @@ instance_groups:
             ca_cert: "((cc_bridge_cc_uploader.ca))"
             client_cert: "((cc_bridge_cc_uploader.certificate))"
             client_key: "((cc_bridge_cc_uploader.private_key))"
+          ca_cert: "((cc_bridge_cc_uploader_server.ca))"
+          server_cert: "((cc_bridge_cc_uploader_server.certificate))"
+          server_key: "((cc_bridge_cc_uploader_server.private_key))"
       diego:
         ssl: *ssl
   - name: metron_agent
@@ -1452,6 +1455,15 @@ variables:
     common_name: cc_uploader
     extended_key_usage:
     - client_auth
+- name: cc_bridge_cc_uploader_server
+  type: certificate
+  options:
+    ca: service_cf_internal_ca
+    common_name: cc_uploader
+    extended_key_usage:
+    - server_auth
+    alternative_names:
+    - cc-uploader.service.cf.internal
 
 releases:
 - name: binary-buildpack

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1459,11 +1459,9 @@ variables:
   type: certificate
   options:
     ca: service_cf_internal_ca
-    common_name: cc_uploader
+    common_name: cc-uploader.service.cf.internal
     extended_key_usage:
     - server_auth
-    alternative_names:
-    - cc-uploader.service.cf.internal
 
 releases:
 - name: binary-buildpack


### PR DESCRIPTION
This adds the server certs required to mTLS communication between Diego's Reps and CC-Uploader. The Rep is already configured with certs of the same CA (the client cert is `diego_rep_client`).

The added properties will be required in an upcoming CAPI release.

https://www.pivotaltracker.com/story/show/142166993

Side note:

- We were unsure what conventions have been set for `common_name`