### PR TITLE
Fix location of cc_uploader server certs

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1017,9 +1017,10 @@ instance_groups:
             ca_cert: "((cc_bridge_cc_uploader.ca))"
             client_cert: "((cc_bridge_cc_uploader.certificate))"
             client_key: "((cc_bridge_cc_uploader.private_key))"
-          ca_cert: "((cc_bridge_cc_uploader_server.ca))"
-          server_cert: "((cc_bridge_cc_uploader_server.certificate))"
-          server_key: "((cc_bridge_cc_uploader_server.private_key))"
+          mutual_tls:
+            ca_cert: "((cc_bridge_cc_uploader_server.ca))"
+            server_cert: "((cc_bridge_cc_uploader_server.certificate))"
+            server_key: "((cc_bridge_cc_uploader_server.private_key))"
       diego:
         ssl: *ssl
   - name: metron_agent


### PR DESCRIPTION
This is a fix to Pr #110 

@anEXPer Turns out, your intuition was right, and the properties were really added one layer deeper (such that the `ca_cert` was not a sibling to `cc`). Our cf-deployment pipeline fortunately caught this mistake. See your comment on the PR: https://github.com/cloudfoundry/cf-deployment/pull/110#issuecomment-291249620