### PR TITLE
Add asset TLS credentials to Diego ops-files.

### DIFF
--- a/operations/test/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/test/add-persistent-isolation-segment-diego-cell.yml
@@ -52,6 +52,10 @@
             server_key: "((diego_rep_agent.private_key))"
           ssl:
             skip_cert_verify: true
+        tls:
+          ca_cert: "((diego_rep_agent.ca))"
+          cert: "((diego_rep_agent.certificate))"
+          key: "((diego_rep_agent.private_key))"
     - name: metron_agent
       release: loggregator
       properties:

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -46,6 +46,10 @@
               client_key: "((diego_bbs_client.private_key))"
             preloaded_rootfses:
             - windows2012R2:/tmp/windows2012R2
+        tls:
+          ca_cert: "((diego_rep_agent.ca))"
+          cert: "((diego_rep_agent.certificate))"
+          key: "((diego_rep_agent.private_key))"
     - name: metron_agent_windows
       release: loggregator
       properties:


### PR DESCRIPTION
Related to [cf-deployment/113](https://github.com/cloudfoundry/cf-deployment/pull/113), this applies the new asset upload/download credentials to a couple of ops-files that move the Diego rep job to a different location.


[finishes #141164981]

Signed-off-by: Danny Cao <dcao@us.ibm.com>