### PR TITLE
Ignore etcd-release links (for now).

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -144,6 +144,8 @@ instance_groups:
               name: cf-etcd
   - name: etcd
     release: etcd
+    consumes:
+      etcd: nil
     properties:
       etcd:
         advertise_urls_dns_suffix: cf-etcd.service.cf.internal


### PR DESCRIPTION
Hi,

This is the first of a pair of PRs to add support for links in the etcd-release.

This PR ignores the link from etcd-release, which will allow us to cut a new release without breaking users of cf-deployment. We ran it through our CI using my fork and were able to get a successful deployment + CATs run.

Please note that we are blocked on cutting said new release of etcd-release until this PR is merged.

Thanks!
Dave