### PR TITLE
Defines yml anchor diego_bbs_client_properties before using it

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -722,7 +722,10 @@ instance_groups:
     properties:
       diego:
         cfdot:
-          bbs: *diego_bbs_client_properties
+          bbs: &diego_bbs_client_properties
+            ca_cert: "((diego_bbs_client.ca))"
+            client_cert: "((diego_bbs_client.certificate))"
+            client_key: "((diego_bbs_client.private_key))"
   - name: bbs
     release: diego
     properties:
@@ -795,10 +798,7 @@ instance_groups:
           uaa:
             ca_cert: "((uaa_ssl.ca))"
             port: 8443
-          bbs: &diego_bbs_client_properties
-            ca_cert: "((diego_bbs_client.ca))"
-            client_cert: "((diego_bbs_client.certificate))"
-            client_key: "((diego_bbs_client.private_key))"
+          bbs: *diego_bbs_client_properties
   - name: file_server
     release: diego
   - name: auctioneer


### PR DESCRIPTION
* Otherwise `rq` fails to parse the yaml

Signed-off-by: Emily Casey <ecasey@pivotal.io>