### PR TITLE
cc-worker has properties to use routing api

### DIFF
--- a/operations/tcp-routing-gcp.yml
+++ b/operations/tcp-routing-gcp.yml
@@ -139,6 +139,16 @@
     enabled: true
 
 - type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/routing_api?
+  value:
+    enabled: true
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/uaa/clients/cc_routing?
+  value:
+    secret: "((uaa_clients_cc-routing_secret))"
+
+- type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ssl?/skip_cert_verify
   value: true
 


### PR DESCRIPTION
When I am deploying with tcp routing, I want the cc worker to be able to speak to the routing api.  This commit adds the necessary properties to the cc-worker job.

Story:
https://www.pivotaltracker.com/story/show/143322377