### PR TITLE
add experimental ops files for deploying locket component

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -236,6 +236,64 @@ instance_groups:
   - name: metron_agent
     release: loggregator
     properties: *metron_agent_properties
+- name: diego-bbs
+  azs:
+  - z1
+  - z2
+  instances: 2
+  vm_type: m3.large
+  stemcell: default
+  update:
+    serial: true
+  networks:
+  - name: default
+  jobs:
+  - name: consul_agent
+    release: consul
+    consumes:
+      consul: {from: consul_server}
+  - name: cfdot
+    release: diego
+    properties:
+      diego:
+        cfdot:
+          bbs: *diego_bbs_client_properties
+  - name: bbs
+    release: diego
+    properties:
+      diego:
+        bbs:
+          active_key_label: key-2016-06
+          encryption_keys:
+          - label: key-2016-06
+            passphrase: "((diego_bbs_encryption_keys_passphrase))"
+          sql:
+            db_host: sql-db.service.cf.internal
+            db_port: 3306
+            db_schema: diego
+            db_username: diego
+            db_password: "((diego_database_password))"
+            db_driver: mysql
+          etcd:
+            machines: []
+            ca_cert: nil
+            client_cert: nil
+            client_key: nil
+          ca_cert: "((diego_bbs_server.ca))"
+          auctioneer: &diego_auctioneer_client_properties
+            ca_cert: "((diego_auctioneer_client.ca))"
+            client_cert: "((diego_auctioneer_client.certificate))"
+            client_key: "((diego_auctioneer_client.private_key))"
+          server_cert: "((diego_bbs_server.certificate))"
+          server_key: "((diego_bbs_server.private_key))"
+          rep:
+            require_tls: true
+            ca_cert: "((diego_rep_client.ca))"
+            client_cert: "((diego_rep_client.certificate))"
+            client_key: "((diego_rep_client.private_key))"
+  - name: metron_agent
+    release: loggregator
+    properties: *metron_agent_properties
 - name: uaa
   azs:
   - z1
@@ -700,62 +758,6 @@ instance_groups:
         ca_cert: "((uaa_ssl.ca))"
         ssl:
           port: 8443
-  - name: metron_agent
-    release: loggregator
-    properties: *metron_agent_properties
-- name: diego-bbs
-  azs:
-  - z1
-  - z2
-  instances: 2
-  vm_type: m3.large
-  stemcell: default
-  networks:
-  - name: default
-  jobs:
-  - name: consul_agent
-    release: consul
-    consumes:
-      consul: {from: consul_server}
-  - name: cfdot
-    release: diego
-    properties:
-      diego:
-        cfdot:
-          bbs: *diego_bbs_client_properties
-  - name: bbs
-    release: diego
-    properties:
-      diego:
-        bbs:
-          active_key_label: key-2016-06
-          encryption_keys:
-          - label: key-2016-06
-            passphrase: "((diego_bbs_encryption_keys_passphrase))"
-          sql:
-            db_host: sql-db.service.cf.internal
-            db_port: 3306
-            db_schema: diego
-            db_username: diego
-            db_password: "((diego_database_password))"
-            db_driver: mysql
-          etcd:
-            machines: []
-            ca_cert: nil
-            client_cert: nil
-            client_key: nil
-          ca_cert: "((diego_bbs_server.ca))"
-          auctioneer: &diego_auctioneer_client_properties
-            ca_cert: "((diego_auctioneer_client.ca))"
-            client_cert: "((diego_auctioneer_client.certificate))"
-            client_key: "((diego_auctioneer_client.private_key))"
-          server_cert: "((diego_bbs_server.certificate))"
-          server_key: "((diego_bbs_server.private_key))"
-          rep:
-            require_tls: true
-            ca_cert: "((diego_rep_client.ca))"
-            client_cert: "((diego_rep_client.certificate))"
-            client_key: "((diego_rep_client.private_key))"
   - name: metron_agent
     release: loggregator
     properties: *metron_agent_properties

--- a/operations/experimental/locket-postgres.yml
+++ b/operations/experimental/locket-postgres.yml
@@ -1,0 +1,10 @@
+---
+- type: replace
+  path: /instance_groups/name=diego-bbs/jobs/name=locket/properties/diego/locket/sql
+  value:
+    db_host: sql-db.service.cf.internal
+    db_port: 5524
+    db_schema: diego
+    db_username: diego
+    db_password: "((diego_database_password))"
+    db_driver: postgres

--- a/operations/experimental/locket.yml
+++ b/operations/experimental/locket.yml
@@ -1,0 +1,41 @@
+---
+- type: replace
+  path: /instance_groups/name=diego-bbs/jobs/-
+  value:
+    name: locket
+    release: diego
+- type: replace
+  path: /instance_groups/name=diego-bbs/jobs/name=bbs/properties/diego/bbs/locket?/api_location?
+  value: "locket.service.cf.internal:8891"
+- type: replace
+  path: /instance_groups/name=diego-brain/jobs/name=auctioneer/properties/diego/auctioneer/locket?/api_location?
+  value: "locket.service.cf.internal:8891"
+- type: replace
+  path: /instance_groups/name=diego-bbs/jobs/name=locket/properties?
+  value:
+    tls:
+      ca_cert: "((diego_locket_server.ca))"
+      cert: "((diego_locket_server.certificate))"
+      key: "((diego_locket_server.private_key))"
+    diego:
+      locket:
+        sql:
+          db_host: sql-db.service.cf.internal
+          db_port: 3306
+          db_schema: diego
+          db_username: diego
+          db_password: "((diego_database_password))"
+          db_driver: mysql
+- type: replace
+  path: /variables/-
+  value:
+    name: diego_locket_server
+    type: certificate
+    options:
+      ca: service_cf_internal_ca
+      common_name: locket.service.cf.internal
+      extended_key_usage:
+      - server_auth
+      alternative_names:
+      - "*.locket.service.cf.internal"
+      - locket.service.cf.internal


### PR DESCRIPTION
- Defaults database to mysql
- Uses diego_database_password for DB permissions
- Includes locket-postgres.yml file to work with postgres job
- Moves diego-bbs instance up in deployment order

[#143336051]

Signed-off-by: Stephen Carter <scarter@pivotal.io>