### PR TITLE
Add routing.router_groups.read scope to gorouter UAA client

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -320,7 +320,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: "((uaa_clients_doppler_secret))"
           gorouter:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials,refresh_token
             secret: "((uaa_clients_gorouter_secret))"
           ssh-proxy:


### PR DESCRIPTION
We will need this change as part of this story: [#143355551](https://www.pivotaltracker.com/story/show/143355551) in order to support isolation segments with Gorouter.

@aaronshurley && @flawedmatrix 
