### PR TITLE
Don't hard code stemcell version, please

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1550,4 +1550,4 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-trusty
-  version: "3363.14"
+  version: latest


### PR DESCRIPTION
Since bosh cannot download the stemcell, it makes documentation awkward (and eternally wrong/needing updates) if we force a specific version of the stemcell here. Can we please not hardcode the stemcell version?