### PR TITLE
Expose consul as cross deployment link

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -52,7 +52,7 @@ instance_groups:
     consumes:
       consul: {from: consul_server}
     provides:
-      consul: {as: consul_server}
+      consul: {as: consul_server, shared: true}
     properties:
       consul:
         agent:


### PR DESCRIPTION
As an operator I would like to be able to run the `consul_agent` in other deployments without needing to configure IP information. Exposing the cf consul_server link allows me to use links to solve this issue.