### PR TITLE
deploy route-emitters in local mode by default

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -911,33 +911,16 @@ instance_groups:
       diego:
         cfdot:
           bbs: *diego_bbs_client_properties
-- name: route-emitter
-  azs:
-  - z1
-  - z2
-  instances: 2
-  vm_type: m3.medium
-  stemcell: default
-  networks:
-  - name: default
-  jobs:
-  - name: consul_agent
-    release: consul
-    consumes:
-      consul: {from: consul_server}
   - name: route_emitter
     release: diego
     properties:
       diego:
         route_emitter:
+          local_mode: true
           bbs:
             ca_cert: "((diego_bbs_client.ca))"
             client_cert: "((diego_bbs_client.certificate))"
             client_key: "((diego_bbs_client.private_key))"
-            require_ssl: true
-  - name: metron_agent
-    release: loggregator
-    properties: *metron_agent_properties
 - name: cc-clock
   azs:
   - z1

--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -236,13 +236,6 @@
   path: /instance_groups/name=router/instances
   value: 1
 - type: replace
-  path: /instance_groups/name=route-emitter/azs
-  value:
-  - z1
-- type: replace
-  path: /instance_groups/name=route-emitter/instances
-  value: 1
-- type: replace
   path: /instance_groups/name=api/instances
   value: 1
 - type: replace

--- a/operations/enable-local-route-emitters-windows-cell.yml
+++ b/operations/enable-local-route-emitters-windows-cell.yml
@@ -1,14 +1,2 @@
 ---
-- type: replace
-  path: /instance_groups/name=windows-cell/jobs/-
-  value:
-    name: route_emitter_windows
-    release: diego
-    properties:
-      diego:
-        route_emitter:
-          local_mode: true
-          bbs:
-            ca_cert: "((diego_bbs_client.ca))"
-            client_cert: "((diego_bbs_client.certificate))"
-            client_key: "((diego_bbs_client.private_key))"
+[]

--- a/operations/enable-local-route-emitters.yml
+++ b/operations/enable-local-route-emitters.yml
@@ -1,14 +1,2 @@
 ---
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/-
-  value:
-    name: route_emitter
-    release: diego
-    properties:
-      diego:
-        route_emitter:
-          local_mode: true
-          bbs:
-            ca_cert: "((diego_bbs_client.ca))"
-            client_cert: "((diego_bbs_client.certificate))"
-            client_key: "((diego_bbs_client.private_key))"
+[]

--- a/operations/use-only-local-route-emitters-windows-cell.yml
+++ b/operations/use-only-local-route-emitters-windows-cell.yml
@@ -1,17 +1,2 @@
 ---
-- type: replace
-  path: /instance_groups/name=windows-cell/jobs/-
-  value:
-    name: route_emitter
-    release: diego
-    properties:
-      diego:
-        route_emitter:
-          local_mode: true
-          bbs:
-            ca_cert: "((diego_bbs_client.ca))"
-            client_cert: "((diego_bbs_client.certificate))"
-            client_key: "((diego_bbs_client.private_key))"
-
-- type: remove
-  path: /instance_groups/name=route-emitter
+[]

--- a/operations/use-only-local-route-emitters.yml
+++ b/operations/use-only-local-route-emitters.yml
@@ -1,17 +1,2 @@
 ---
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/-
-  value:
-    name: route_emitter
-    release: diego
-    properties:
-      diego:
-        route_emitter:
-          local_mode: true
-          bbs:
-            ca_cert: "((diego_bbs_client.ca))"
-            client_cert: "((diego_bbs_client.certificate))"
-            client_key: "((diego_bbs_client.private_key))"
-
-- type: remove
-  path: /instance_groups/name=route-emitter
+[]

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -43,6 +43,16 @@
           cert: ((diego_rep_agent.certificate))
           key: ((diego_rep_agent.private_key))
       release: diego
+    - name: route_emitter_windows
+      release: diego
+      properties:
+        diego:
+          route_emitter:
+            local_mode: true
+            bbs:
+              ca_cert: "((diego_bbs_client.ca))"
+              client_cert: "((diego_bbs_client.certificate))"
+              client_key: "((diego_bbs_client.private_key))"
     - name: metron_agent_windows
       properties:
         loggregator:


### PR DESCRIPTION
* empty out existing operations files for backwards compatibility

[#142672579]

Signed-off-by: James Myers <jfmyers9@gmail.com>