### PR TITLE
add a 'default' disk_type

### DIFF
--- a/bosh-lite/cloud-config.yml
+++ b/bosh-lite/cloud-config.yml
@@ -9,6 +9,8 @@ compilation:
   vm_type: m3.medium
   workers: 6
 disk_types:
+- disk_size: 10240
+  name: default
 - disk_size: 1024
   name: 1GB
 - disk_size: 5120


### PR DESCRIPTION
cf-deployment's bosh-lite/cloud-config.yml will be a defacto cloud-config; to allow all 3rd party manifests to "just work", we'll includes a 'default' for all cloud-config entities

From my "BOSH 2.0" talk in Toronto and at today's CAB call:

![screen shot 2017-04-19 at 9 26 35 am](https://cloud.githubusercontent.com/assets/108/25182350/4fd516ac-24e2-11e7-9e80-3ff4517275ce.png)

Sorry I missed this in https://github.com/cloudfoundry/cf-deployment/pull/109