### PR TITLE
add experimental ops files for local route emitter emitting TCP routes

### DIFF
--- a/operations/experimental/enable-local-route-emitter-tcp-windows.yml
+++ b/operations/experimental/enable-local-route-emitter-tcp-windows.yml
@@ -1,0 +1,13 @@
+---
+- type: replace
+  path: /instance_groups/name=windows-cell/jobs/name=route_emitter_windows/properties/tcp?/enabled?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=windows-cell/jobs/name=route_emitter_windows/properties/uaa?
+  value:
+    client_secret: "((uaa_clients_tcp_emitter_secret))"
+    ca_cert: "((uaa_ca.certificate))"
+
+- type: remove
+  path: /instance_groups/name=tcp-emitter

--- a/operations/experimental/enable-local-route-emitter-tcp.yml
+++ b/operations/experimental/enable-local-route-emitter-tcp.yml
@@ -1,0 +1,13 @@
+---
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/tcp?/enabled?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/uaa?
+  value:
+    client_secret: "((uaa_clients_tcp_emitter_secret))"
+    ca_cert: "((uaa_ca.certificate))"
+
+- type: remove
+  path: /instance_groups/name=tcp-emitter


### PR DESCRIPTION
There are a number of dependencies for these ops files.

- Both depend on operations/tcp-routing-gcp.yml
- operations/enable-local-route-emitters.yml for
enable-local-route-emitters-tcp.yml
- windows-cell.yml and local-route-emitter-windows ops files for windows
tcp ops file.

[This PR](https://github.com/cloudfoundry/cf-deployment/pull/130) should take care of the local-route-emitter dependencies.

This also does not currently work on bosh-lite out of the box, since the
bosh-lite cloud config does not have the VM extension
`internet-required`


[#142583351]

Signed-off-by: Chris Piraino <cpiraino@pivotal.io>