### PR TITLE
Be more precise on where to find bosh-lite CA cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ For a full guide to getting set up on GCP, look at [this guide](gcp-deployment-g
 If you're deploying against a local bosh-lite,
 you'll need to take the following steps before deploying:
 ```
-export BOSH_CA_CERT=$PWD/bosh-lite/ca/certs/ca.crt
+export BOSH_CA_CERT=<PATH-TO-BOSH-LITE-REPO>/ca/certs/ca.crt
 bosh -e 192.168.50.4 update-cloud-config bosh-lite/cloud-config.yml
 ```
 


### PR DESCRIPTION
Before this change, the README referenced `$PWD` without mentioning which directory the user should be in when running that comand.