### PR TITLE
Remove read scope from gorouter & tcp-router

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -382,7 +382,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: "((uaa_clients_doppler_secret))"
           gorouter:
-            authorities: routing.routes.read,routing.router_groups.read
+            authorities: routing.routes.read
             authorized-grant-types: client_credentials
             secret: "((uaa_clients_gorouter_secret))"
           ssh-proxy:
@@ -397,7 +397,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: "((uaa_clients_tcp_emitter_secret))"
           tcp_router:
-            authorities: routing.routes.read,routing.router_groups.read
+            authorities: routing.routes.read
             authorized-grant-types: client_credentials
             secret: "((uaa_clients_tcp_router_secret))"
       uaadb:


### PR DESCRIPTION
This is no longer needed due to the new way of doing routing isolation segments.

See story at:
https://www.pivotaltracker.com/story/show/143925653

Signed-off-by: Jonathan Berkhahn <jaberkha@us.ibm.com>