### PR TITLE
Add ops file to bypass CC bridge

### DIFF
--- a/operations/bypass-cc-bridge.yml
+++ b/operations/bypass-cc-bridge.yml
@@ -1,0 +1,85 @@
+---
+# cloud_controller_ng
+- type: replace
+  temporary_local_staging: &temporary_local_staging true
+  temporary_local_apps: &temporary_local_apps true
+  temporary_local_tasks: &temporary_local_tasks true
+  temporary_local_sync: &temporary_local_sync true
+  temporary_local_tps: &temporary_local_tps true
+  temporary_cc_uploader_mtls: &temporary_cc_uploader_mtls true
+  temporary_droplet_download_mtls: &temporary_droplet_download_mtls true
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/diego?/temporary_local_staging?
+  value: *temporary_local_staging
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/diego?/temporary_local_apps?
+  value: *temporary_local_apps
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/diego?/temporary_local_tasks?
+  value: *temporary_local_tasks
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/diego?/temporary_local_sync?
+  value: *temporary_local_sync
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/diego?/temporary_local_tps?
+  value: *temporary_local_tps
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/diego?/temporary_cc_uploader_mtls?
+  value: *temporary_cc_uploader_mtls
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/diego?/temporary_droplet_download_mtls?
+  value: *temporary_droplet_download_mtls
+
+# cc-worker
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc?/diego?/temporary_local_staging?
+  value: *temporary_local_staging
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc?/diego?/temporary_local_apps?
+  value: *temporary_local_apps
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc?/diego?/temporary_local_tasks?
+  value: *temporary_local_tasks
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc?/diego?/temporary_local_sync?
+  value: *temporary_local_sync
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc?/diego?/temporary_local_tps?
+  value: *temporary_local_tps
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc?/diego?/temporary_cc_uploader_mtls?
+  value: *temporary_cc_uploader_mtls
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc?/diego?/temporary_droplet_download_mtls?
+  value: *temporary_droplet_download_mtls
+
+# cc-clock
+- type: replace
+  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_staging?
+  value: *temporary_local_staging
+- type: replace
+  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_apps?
+  value: *temporary_local_apps
+- type: replace
+  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_tasks?
+  value: *temporary_local_tasks
+- type: replace
+  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_sync?
+  value: *temporary_local_sync
+- type: replace
+  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_tps?
+  value: *temporary_local_tps
+- type: replace
+  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_cc_uploader_mtls?
+  value: *temporary_cc_uploader_mtls
+- type: replace
+  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_droplet_download_mtls?
+  value: *temporary_droplet_download_mtls
+
+# cc-bridge
+- type: remove
+  path: /instance_groups/name=cc-bridge/jobs/name=stager
+- type: remove
+  path: /instance_groups/name=cc-bridge/jobs/name=nsync
+- type: replace
+  path: /instance_groups/name=cc-bridge/jobs/name=tps/properties/capi/tps/listener_enabled?
+  value: false


### PR DESCRIPTION
add ops file to bypass CC bridge

- this enables the temporary flags that enable mTLS communication between
    CC and Diego
- as a result, the stager, nsync, and tps-listener functionalities are now handled by
    CC, so we can remove these jobs from the cc-bridge template
- these flags are turned on in the api, cc-worker, and cc-clock vms

[#139962927]