### PR TITLE
only remove global tcp emitter in linux operations file

### DIFF
--- a/operations/experimental/enable-local-route-emitter-tcp-windows.yml
+++ b/operations/experimental/enable-local-route-emitter-tcp-windows.yml
@@ -8,6 +8,3 @@
   value:
     client_secret: "((uaa_clients_tcp_emitter_secret))"
     ca_cert: "((uaa_ca.certificate))"
-
-- type: remove
-  path: /instance_groups/name=tcp-emitter


### PR DESCRIPTION
* we don't expect users to deploy windows cells without linux cells
* this change allows users to apply both local tcp emitter ops files
  with no error

[#142583351]

Signed-off-by: James Myers <jfmyers9@gmail.com>