### PR TITLE
Rename the alias for the old consul link

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -50,12 +50,12 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
     provides:
-      consul: {as: consul_server, shared: true}
+      consul: {as: consul_link, shared: true}
     properties:
       consul:
         agent:
@@ -99,7 +99,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -136,7 +136,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -196,7 +196,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -263,7 +263,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -327,7 +327,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -482,7 +482,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -534,7 +534,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -734,7 +734,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -800,7 +800,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -853,7 +853,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -909,7 +909,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -978,7 +978,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -1039,7 +1039,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -1105,7 +1105,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil
@@ -1179,7 +1179,7 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: {from: consul_server}
+      consul: {from: consul_link}
       consul_common: nil
       consul_server: nil
       consul_client: nil


### PR DESCRIPTION
Hi,

Sorry to do this to y'all, but apparently our local testing of our last PR wasn't thorough enough to catch a problem with a collision between the alias we had used for the old consul link and the name of one of the new consul links. This PR changes the alias used for the old single link from consul-release. We have carefully tested a deployment with this change and confirmed that it works as desired.

Thanks!
Dave