### PR TITLE
Adds `consumes.nats` to `route_emitter` job

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -912,6 +912,8 @@ instance_groups:
           bbs: *diego_bbs_client_properties
   - name: route_emitter
     release: diego
+    consumes:
+      nats: {from: nats}
     properties:
       diego:
         route_emitter:


### PR DESCRIPTION
This addition makes it simple to provide an ops file that updates only
the `deployment` key, when deploying the `diego-cell` instance group as
a separate deployment, with cross-deployment links.