### PR TITLE
Remove reference to monolthic consul link

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -50,7 +50,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: {from: consul_server_link}
       consul_client: {from: consul_client_link}
@@ -101,7 +100,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -138,7 +136,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -198,7 +195,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -264,7 +260,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -328,7 +323,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -481,7 +475,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -533,7 +526,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -730,7 +722,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -794,7 +785,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -847,7 +837,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -903,7 +892,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -972,7 +960,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -1031,7 +1018,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -1096,7 +1082,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
@@ -1170,7 +1155,6 @@ instance_groups:
   - name: consul_agent
     release: consul
     consumes:
-      consul: nil
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}

--- a/operations/experimental/use-cf-networking.yml
+++ b/operations/experimental/use-cf-networking.yml
@@ -124,7 +124,6 @@
     - name: consul_agent
       release: consul
       consumes:
-        consul: nil
         consul_client: {from: consul_client_link}
         consul_common: {from: consul_common_link}
         consul_server: nil

--- a/operations/tcp-routing-gcp.yml
+++ b/operations/tcp-routing-gcp.yml
@@ -18,7 +18,6 @@
     - name: consul_agent
       release: consul
       consumes:
-        consul: nil
         consul_common: {from: consul_common_link}
         consul_server: nil
         consul_client: {from: consul_client_link}
@@ -73,7 +72,6 @@
     - name: consul_agent
       release: consul
       consumes:
-        consul: nil
         consul_common: {from: consul_common_link}
         consul_server: nil
         consul_client: {from: consul_client_link}

--- a/operations/test/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/test/add-persistent-isolation-segment-diego-cell.yml
@@ -16,7 +16,6 @@
     - name: consul_agent
       release: consul
       consumes:
-        consul: nil
         consul_common: {from: consul_common_link}
         consul_server: nil
         consul_client: {from: consul_client_link}

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -7,7 +7,6 @@
     instances: 1
     jobs:
     - consumes:
-        consul: nil
         consul_client:
           from: consul_client_link
         consul_common:


### PR DESCRIPTION
Following up this PR: https://github.com/cloudfoundry/cf-deployment/pull/151

[Consul-release v167](https://github.com/cloudfoundry-incubator/consul-release/releases/tag/v167) no longer provides/consumes monolithic `consul` link. We can now remove the `consul` link from the manifest.

Thanks,
Christian