### PR TITLE
Add ops file for cf-networking with postgres

### DIFF
--- a/operations/experimental/use-cf-networking-postgres.yml
+++ b/operations/experimental/use-cf-networking-postgres.yml
@@ -1,0 +1,66 @@
+# add this opsfile after use-cf-networking.yml
+
+# add network policy db to bosh-lite postgres
+- type: replace
+  path: /instance_groups/name=postgres/jobs/name=postgres/properties/databases/roles/-
+  value:
+    name: network_policy
+    password: "((network_policy_database_password))"
+    tag: admin
+
+- type: replace
+  path: /instance_groups/name=postgres/jobs/name=postgres/properties/databases/databases/-
+  value:
+    citext: false
+    name: network_policy
+    tag: networkpolicy
+
+# add overlay network db to postgres
+- type: replace
+  path: /instance_groups/name=postgres/jobs/name=postgres/properties/databases/roles/-
+  value:
+    name: network_connectivity
+    password: "((network_connectivity_database_password))"
+    tag: admin
+
+- type: replace
+  path: /instance_groups/name=postgres/jobs/name=postgres/properties/databases/databases/-
+  value:
+    citext: false
+    name: network_connectivity
+    tag: networkconnectivity
+
+# policy server vm
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/cf_networking/policy_server/database
+  value:
+    type: postgres
+    username: network_policy
+    password: "((network_policy_database_password))"
+    host: sql-db.service.cf.internal
+    port: 5524
+    name: network_policy
+
+# silk controller
+- type: replace
+  path: /instance_groups/name=diego-bbs/jobs/name=silk-controller/properties/cf_networking/silk_controller/database
+  value:
+    type: postgres
+    username: network_connectivity
+    password: "((network_connectivity_database_password))"
+    host: sql-db.service.cf.internal
+    port: 5524
+    name: network_connectivity
+
+# variables
+- type: replace
+  path: /variables/-
+  value:
+    name: network_policy_database_password
+    type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: network_connectivity_database_password
+    type: password


### PR DESCRIPTION
Useful for BOSH-lite in particular.

This ops file should be used in combination with the
use-cf-networking.yml ops file, and applied after it.

[#145777061]

Signed-off-by: David McClure <dmcclure@pivotal.io>