### PR TITLE
Use specific windows stemcell version

### DIFF
--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -98,7 +98,7 @@
   value:
     alias: windows
     os: windows2012R2
-    version: latest
+    version: '1089.0'
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks?
   value:


### PR DESCRIPTION
Now that Window stemcells are available on bosh.io the Windows opsfile can be versioned with a specific stemcell version that is known to work

This update should probably correspond to bumping the opsfile stemcell automatically when there are new releases of the stemcell

(GCP stemcell can be found [here](http://bosh.io/stemcells/bosh-google-kvm-windows2012R2-go_agent))