### PR TITLE
Update bosh-lite.md

### DIFF
--- a/bosh-lite.md
+++ b/bosh-lite.md
@@ -14,7 +14,6 @@
 For `AWS`, you will need:
 - bosh-lite.yml
 - bosh-lite-runc.yml
-- jumpbox-user.yml
 
 For `GCP`, you will need the above and also:
 -  gcp/bosh-lite-vm-type.yml


### PR DESCRIPTION
If you include the jumpbox operation when bbl'ing using v3.2.6 it will fail. Seems like bbl already creates a jump box user for you.