### PR TITLE
Fix invalid admin password in use-haproxy ops file

### DIFF
--- a/operations/community/use-haproxy.yml
+++ b/operations/community/use-haproxy.yml
@@ -49,7 +49,7 @@
           api: "https://api.((system_domain))"
           apps_domain: "((system_domain))"
           user: admin
-          password: "((uaa_scim_users_admin_password))"
+          password: "((cf_admin_password))"
           org: cf_smoke_tests_org
           space: cf_smoke_tests_space
           cf_dial_timeout_in_seconds: 300


### PR DESCRIPTION
Fixes wrong credentials when running smoke-tests errand
```
[2017-07-20 13:26:01.74 (UTC)]> cf auth admin [REDACTED]
API endpoint: https://api.xxx
Authenticating...
FAILED
Credentials were rejected, please try again.
```