### PR TITLE
Add secure-service-credentials ops file

### DIFF
--- a/operations/experimental/secure-service-credentials.yml
+++ b/operations/experimental/secure-service-credentials.yml
@@ -4,9 +4,9 @@
   path: /releases/-
   value:
     name: credhub
-    url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=1.1.2
-    version: 1.1.2
-    sha1: 1ceacbbcb877a9b591a60a5f8f6f868d3147545a
+    url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=1.2.0
+    version: 1.2.0
+    sha1: b28b53dc55c1f1c8ef37edddc9ecad76e16f7d77
 
 - type: replace
   path: /instance_groups/-

--- a/operations/experimental/secure-service-credentials.yml
+++ b/operations/experimental/secure-service-credentials.yml
@@ -1,0 +1,125 @@
+---
+# CredHub instance group
+- type: replace
+  path: /releases/-
+  value:
+    name: credhub
+    url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=1.1.2
+    version: 1.1.2
+    sha1: 1ceacbbcb877a9b591a60a5f8f6f868d3147545a
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: credhub
+    azs:
+    - z1
+    - z2
+    instances: 2
+    vm_type: m3.medium
+    vm_extensions:
+    - credhub-lb
+    stemcell: default
+    networks:
+    - name: private
+    jobs:
+    - name: consul_agent
+      release: consul
+      consumes:
+        consul_common: {from: consul_common_link}
+        consul_server: nil
+        consul_client: {from: consul_client_link}
+    - name: credhub
+      release: credhub
+      properties:
+        credhub:
+          data_storage:
+            type: mysql
+            username: credhub
+            password: "((credhub_database_password))"
+            host: sql-db.service.cf.internal
+            port: 3306
+            database: credhub
+            require_tls: false
+          authentication:
+            uaa:
+              url: "https://uaa.service.cf.internal:8443"
+              verification_key: "((uaa_jwt_signing_key.public_key))"
+              ca_certs:
+              - "((uaa_ssl.ca))"
+            mutual_tls:
+              trusted_cas:
+              - "((instance_identity_ca.certificate))"
+          tls: "((credhub_tls))"
+          authorization:
+            acls:
+              enabled: true
+          encryption:
+            keys:
+            - provider_name: internal-provider
+              encryption_password: "((credhub_encryption_password))"
+              active: true
+            providers:
+            - name: internal-provider
+              type: internal
+
+# Add Database for CredHub
+- type: replace
+  path: /instance_groups/name=mysql/jobs/name=mysql/properties/cf_mysql/mysql/seeded_databases/-
+  value:
+    name: credhub
+    username: credhub
+    password: "((credhub_database_password))"
+
+# Enable Instance Identity on Diego
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/executor?
+  value:
+    instance_identity_ca_cert: "((instance_identity_ca.certificate))"
+    instance_identity_key: "((instance_identity_ca.private_key))"
+
+# Add CredHub's server CA to the container's trusted CAs
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup/properties?/cflinuxfs2-rootfs
+  value:
+    trusted_certs: "((credhub_ca.certificate))"
+
+# Variables
+- type: replace
+  path: /variables/-
+  value:
+    name: credhub_encryption_password
+    type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: credhub_database_password
+    type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: credhub_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: credhubServerCa
+
+- type: replace
+  path: /variables/-
+  value:
+    name: credhub_tls
+    type: certificate
+    options:
+      ca: credhub_ca
+      common_name: credhub.((system_domain))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: instance_identity_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: instanceIdentityCA


### PR DESCRIPTION
This PR adds an ops file, which enables secure service credentials delivery with CredHub.