### PR TITLE
Update main manifest with new networking-release job

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1058,6 +1058,8 @@ instance_groups:
         client_secret: "((uaa_clients_tcp_emitter_secret))"
   - name: garden-cni
     release: cf-networking
+  - name: iptables-logger
+    release: cf-networking
   - name: netmon
     release: cf-networking
   - name: vxlan-policy-agent


### PR DESCRIPTION
[#149092065]

This should not be merged until a new cf-networking-release version is cut (in this case, v1.3.0).

Thanks!
Angela