### PR TITLE
Updating backup-restore opsfile to use bosh.io url

### DIFF
--- a/operations/experimental/deploy-bosh-backup-restore.yml
+++ b/operations/experimental/deploy-bosh-backup-restore.yml
@@ -3,9 +3,9 @@
     path: /releases/-
     value:
       name: backup-and-restore-sdk
-      url: https://github.com/cloudfoundry-incubator/backup-and-restore-sdk-release/releases/download/v1.0.0/backup-and-restore-sdk-1.0.0.tgz
+      url: https://bosh.io/d/github.com/cloudfoundry-incubator/backup-and-restore-sdk-release?v=1.0.0
       version: 1.0.0
-      sha1: 71d32592f34f75531936c0f6517a8be196ec6611
+      sha1: 3b07fa61f65164927b642ddaa41408c19ec9d457
 
   - type: replace
     path: /instance_groups/-


### PR DESCRIPTION
As mentioned in https://github.com/cloudfoundry/cf-deployment/pull/193