### PR TITLE
Add api route emitter health check

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -764,6 +764,10 @@ instance_groups:
           port: 9022
           uris:
           - api.((system_domain))
+          health_check:
+            name: api-health-check
+            script_path: "/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check"
+            timeout: 3s
         - name: policy-server
           port: 4002
           registration_interval: 20s


### PR DESCRIPTION
This depends on the next version of CAPI Release (1.39.0).