### PR TITLE
Consolidate VMs (implements #173)

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -784,6 +784,8 @@ instance_groups:
   - name: statsd_injector
     release: statsd-injector
     properties: *statsd_injector_properties
+  - name: file_server
+    release: diego
   - name: routing-api
     release: routing
     properties:
@@ -825,6 +827,27 @@ instance_groups:
           ca_cert: ((network_policy_server.ca))
           server_cert: ((network_policy_server.certificate))
           server_key: ((network_policy_server.private_key))
+  - name: stager
+    release: capi
+    properties:
+      capi:
+        stager:
+          bbs: *diego_bbs_client_properties
+          cc:
+            basic_auth_password: "((cc_internal_api_password))"
+  - name: cc_uploader
+    release: capi
+    properties:
+      capi:
+        cc_uploader:
+          cc:
+            ca_cert: "((cc_bridge_cc_uploader.ca))"
+            client_cert: "((cc_bridge_cc_uploader.certificate))"
+            client_key: "((cc_bridge_cc_uploader.private_key))"
+          mutual_tls:
+            ca_cert: "((cc_bridge_cc_uploader_server.ca))"
+            server_cert: "((cc_bridge_cc_uploader_server.certificate))"
+            server_key: "((cc_bridge_cc_uploader_server.private_key))"
 - name: cc-worker
   azs:
   - z1
@@ -890,6 +913,7 @@ instance_groups:
   vm_type: minimal
   vm_extensions:
   - cf-router-network-properties
+  - diego-ssh-proxy-network-properties
   stemcell: default
   update:
     max_in_flight: 1
@@ -932,6 +956,18 @@ instance_groups:
         ca_cert: "((uaa_ssl.ca))"
         ssl:
           port: 8443
+  - name: ssh_proxy
+    release: diego
+    properties:
+      diego:
+        ssh_proxy:
+          enable_cf_auth: true
+          host_key: "((diego_ssh_proxy_host_key.private_key))"
+          uaa_secret: "((uaa_clients_ssh-proxy_secret))"
+          uaa:
+            ca_cert: "((uaa_ssl.ca))"
+            port: 8443
+          bbs: *diego_bbs_client_properties
   - name: metron_agent
     release: loggregator
     properties: *metron_agent_properties
@@ -965,14 +1001,16 @@ instance_groups:
   - name: metron_agent
     release: loggregator
     properties: *metron_agent_properties
-- name: diego-brain
+- name: scheduler
   azs:
   - z1
   - z2
   instances: 2
+  migrated_from:
+  - {name: cc-bridge}
+  - {name: cc-clock}
+  - {name: diego-brain}
   vm_type: minimal
-  vm_extensions:
-  - diego-ssh-proxy-network-properties
   stemcell: default
   update:
     serial: true
@@ -991,20 +1029,6 @@ instance_groups:
       diego:
         cfdot:
           bbs: *diego_bbs_client_properties
-  - name: ssh_proxy
-    release: diego
-    properties:
-      diego:
-        ssh_proxy:
-          enable_cf_auth: true
-          host_key: "((diego_ssh_proxy_host_key.private_key))"
-          uaa_secret: "((uaa_clients_ssh-proxy_secret))"
-          uaa:
-            ca_cert: "((uaa_ssl.ca))"
-            port: 8443
-          bbs: *diego_bbs_client_properties
-  - name: file_server
-    release: diego
   - name: auctioneer
     release: diego
     properties:
@@ -1020,9 +1044,68 @@ instance_groups:
             client_cert: "((diego_rep_client.certificate))"
             client_key: "((diego_rep_client.private_key))"
       loggregator: *diego_loggregator_client_properties
+  - name: cloud_controller_clock
+    release: capi
+    properties:
+      hm9000:
+        port: -1
+      cc:
+        db_encryption_key: "((cc_db_encryption_key))"
+        default_to_diego_backend: true
+        default_running_security_groups: *cc_default_running_security_groups
+        default_staging_security_groups: *cc_default_staging_security_groups
+        security_group_definitions: *cc_security_group_definitions
+        internal_api_password: "((cc_internal_api_password))"
+        bulk_api_password: "((cc_bulk_api_password))"
+        quota_definitions: *quota_definitions
+        staging_upload_user: staging_user
+        staging_upload_password: "((cc_staging_upload_password))"
+        resource_pool: *blobstore-properties
+        packages: *blobstore-properties
+        droplets: *blobstore-properties
+        buildpacks: *blobstore-properties
+        mutual_tls: *cc_mutual_tls
+      ccdb: *ccdb
+      system_domain: "((system_domain))"
+      app_domains: *app_domains
+      routing_api: *routing_api
+      uaa:
+        ca_cert: "((uaa_ssl.ca))"
+        clients:
+          cc-service-dashboards:
+            secret: "((uaa_clients_cc-service-dashboards_secret))"
+          cc_routing:
+            secret: "((uaa_clients_cc-routing_secret))"
+        url: https://uaa.((system_domain))
+        ssl:
+          port: 8443
   - name: metron_agent
     release: loggregator
     properties: *metron_agent_properties
+  - name: statsd_injector
+    release: statsd-injector
+    properties: *statsd_injector_properties
+  - name: nsync
+    release: capi
+    properties:
+      diego:
+        ssl: *ssl
+      capi:
+        nsync:
+          bbs: *diego_bbs_client_properties
+          cc:
+            basic_auth_password: "((cc_internal_api_password))"
+            base_url: https://api.((system_domain))
+  - name: tps
+    release: capi
+    properties:
+      capi:
+        tps:
+          bbs: *diego_bbs_client_properties
+          cc:
+            ca_cert: "((cc_bridge_tps.ca))"
+            client_cert: "((cc_bridge_tps.certificate))"
+            client_key: "((cc_bridge_tps.private_key))"
 - name: diego-cell
   azs:
   - z1
@@ -1127,124 +1210,6 @@ instance_groups:
           client_key: ((silk_daemon.private_key))
   - name: cni
     release: cf-networking
-- name: cc-clock
-  azs:
-  - z1
-  - z2
-  instances: 2
-  vm_type: small
-  stemcell: default
-  networks:
-  - name: default
-  jobs:
-  - name: consul_agent
-    release: consul
-    consumes:
-      consul_common: {from: consul_common_link}
-      consul_server: nil
-      consul_client: {from: consul_client_link}
-  - name: cloud_controller_clock
-    release: capi
-    properties:
-      hm9000:
-        port: -1
-      cc:
-        db_encryption_key: "((cc_db_encryption_key))"
-        default_to_diego_backend: true
-        default_running_security_groups: *cc_default_running_security_groups
-        default_staging_security_groups: *cc_default_staging_security_groups
-        security_group_definitions: *cc_security_group_definitions
-        internal_api_password: "((cc_internal_api_password))"
-        bulk_api_password: "((cc_bulk_api_password))"
-        quota_definitions: *quota_definitions
-        staging_upload_user: staging_user
-        staging_upload_password: "((cc_staging_upload_password))"
-        resource_pool: *blobstore-properties
-        packages: *blobstore-properties
-        droplets: *blobstore-properties
-        buildpacks: *blobstore-properties
-        mutual_tls: *cc_mutual_tls
-      ccdb: *ccdb
-      system_domain: "((system_domain))"
-      app_domains: *app_domains
-      routing_api: *routing_api
-      uaa:
-        ca_cert: "((uaa_ssl.ca))"
-        clients:
-          cc-service-dashboards:
-            secret: "((uaa_clients_cc-service-dashboards_secret))"
-          cc_routing:
-            secret: "((uaa_clients_cc-routing_secret))"
-        url: https://uaa.((system_domain))
-        ssl:
-          port: 8443
-  - name: metron_agent
-    release: loggregator
-    properties: *metron_agent_properties
-  - name: statsd_injector
-    release: statsd-injector
-    properties: *statsd_injector_properties
-- name: cc-bridge
-  azs:
-  - z1
-  - z2
-  instances: 2
-  vm_type: minimal
-  stemcell: default
-  networks:
-  - name: default
-  jobs:
-  - name: consul_agent
-    release: consul
-    consumes:
-      consul_common: {from: consul_common_link}
-      consul_server: nil
-      consul_client: {from: consul_client_link}
-  - name: stager
-    release: capi
-    properties:
-      capi:
-        stager:
-          bbs: *diego_bbs_client_properties
-          cc:
-            basic_auth_password: "((cc_internal_api_password))"
-  - name: nsync
-    release: capi
-    properties:
-      diego:
-        ssl: *ssl
-      capi:
-        nsync:
-          bbs: *diego_bbs_client_properties
-          cc:
-            basic_auth_password: "((cc_internal_api_password))"
-            base_url: https://api.((system_domain))
-  - name: tps
-    release: capi
-    properties:
-      capi:
-        tps:
-          bbs: *diego_bbs_client_properties
-          cc:
-            ca_cert: "((cc_bridge_tps.ca))"
-            client_cert: "((cc_bridge_tps.certificate))"
-            client_key: "((cc_bridge_tps.private_key))"
-  - name: cc_uploader
-    release: capi
-    properties:
-      capi:
-        cc_uploader:
-          cc:
-            ca_cert: "((cc_bridge_cc_uploader.ca))"
-            client_cert: "((cc_bridge_cc_uploader.certificate))"
-            client_key: "((cc_bridge_cc_uploader.private_key))"
-          mutual_tls:
-            ca_cert: "((cc_bridge_cc_uploader_server.ca))"
-            server_cert: "((cc_bridge_cc_uploader_server.certificate))"
-            server_key: "((cc_bridge_cc_uploader_server.private_key))"
-  - name: metron_agent
-    release: loggregator
-    properties: *metron_agent_properties
 - name: log-api
   azs:
   - z1

--- a/operations/aws.yml
+++ b/operations/aws.yml
@@ -1,14 +1,11 @@
 ---
 # --- add vm extensions ---
 - type: replace
-  path: /instance_groups/name=diego-brain/vm_extensions
-  value:
-  - ssh-proxy-lb
-  - 10GB_ephemeral_disk
-- type: replace
   path: /instance_groups/name=router/vm_extensions
   value:
   - router-lb
+  - ssh-proxy-lb
+  - 10GB_ephemeral_disk
 
 # --- changing default ports ---
 - type: replace
@@ -24,8 +21,8 @@
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/logger_endpoint?/port
   value: 4443
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/doppler?/port
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/doppler?/port
   value: 4443
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/logger_endpoint?/port
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/logger_endpoint?/port
   value: 4443

--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -16,7 +16,7 @@
     version: "20"
 
 - type: replace
-  path: /instance_groups/name=cc-bridge/jobs/name=nsync/properties/capi/nsync/diego_privileged_containers?
+  path: /instance_groups/name=scheduler/jobs/name=nsync/properties/capi/nsync/diego_privileged_containers?
   value: true
 
 - type: remove
@@ -103,7 +103,7 @@
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/ccdb
   value: *ccdb
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/ccdb
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb
   value: *ccdb
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb
@@ -173,7 +173,7 @@
   - dns
   - load_balancer
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/default_running_security_groups
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/default_running_security_groups
   value:
   - public_networks
   - dns
@@ -193,40 +193,18 @@
     - destination: 10.244.0.34
       protocol: all
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/security_group_definitions/-
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/security_group_definitions/-
   value:
     name: load_balancer
     rules:
     - destination: 10.244.0.34
       protocol: all
 
-# ----- Move SSH Proxy from diego-brain to router ----
-- type: remove
-  path: /instance_groups/name=diego-brain/vm_extensions
-- type: remove
-  path: /instance_groups/name=diego-brain/jobs/name=ssh_proxy
+# ----- Combine router VM extensions ----
 - type: replace
   path: /instance_groups/name=router/vm_extensions
   value:
   - ssh-proxy-and-router-lb
-- type: replace
-  path: /instance_groups/name=router/jobs/-
-  value:
-    name: ssh_proxy
-    release: diego
-    properties:
-      diego:
-        ssl:
-          skip_cert_verify: true
-        ssh_proxy:
-          enable_cf_auth: true
-          host_key: "((diego_ssh_proxy_host_key.private_key))"
-          uaa_secret: "((uaa_clients_ssh-proxy_secret))"
-          uaa_token_url: "https://uaa.((system_domain))/oauth/token"
-          bbs: &5
-            ca_cert: "((diego_bbs_client.ca))"
-            client_cert: "((diego_bbs_client.certificate))"
-            client_key: "((diego_bbs_client.private_key))"
 
 # ----- Scale Down ------
 - type: replace
@@ -250,7 +228,7 @@
   path: /instance_groups/name=uaa/instances
   value: 1
 - type: replace
-  path: /instance_groups/name=diego-brain/instances
+  path: /instance_groups/name=scheduler/instances
   value: 1
 - type: replace
   path: /instance_groups/name=diego-cell/instances
@@ -269,12 +247,6 @@
   value: 1
 - type: replace
   path: /instance_groups/name=cc-worker/instances
-  value: 1
-- type: replace
-  path: /instance_groups/name=cc-clock/instances
-  value: 1
-- type: replace
-  path: /instance_groups/name=cc-bridge/instances
   value: 1
 - type: replace
   path: /instance_groups/name=doppler/instances

--- a/operations/bypass-cc-bridge.yml
+++ b/operations/bypass-cc-bridge.yml
@@ -54,34 +54,34 @@
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc?/diego?/temporary_droplet_download_mtls?
   value: *temporary_droplet_download_mtls
 
-# cc-clock
+# scheduler
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_staging?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_staging?
   value: *temporary_local_staging
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_apps?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_apps?
   value: *temporary_local_apps
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_tasks?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_tasks?
   value: *temporary_local_tasks
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_sync?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_sync?
   value: *temporary_local_sync
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_tps?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_local_tps?
   value: *temporary_local_tps
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_cc_uploader_mtls?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_cc_uploader_mtls?
   value: *temporary_cc_uploader_mtls
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_droplet_download_mtls?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_droplet_download_mtls?
   value: *temporary_droplet_download_mtls
 
 # cc-bridge
 - type: remove
-  path: /instance_groups/name=cc-bridge/jobs/name=stager
+  path: /instance_groups/name=api/jobs/name=stager
 - type: remove
-  path: /instance_groups/name=cc-bridge/jobs/name=nsync
+  path: /instance_groups/name=scheduler/jobs/name=nsync
 - type: replace
-  path: /instance_groups/name=cc-bridge/jobs/name=tps/properties/capi/tps/listener_enabled?
+  path: /instance_groups/name=scheduler/jobs/name=tps/properties/capi/tps/listener_enabled?
   value: false

--- a/operations/change-logging-port-for-aws-elb.yml
+++ b/operations/change-logging-port-for-aws-elb.yml
@@ -1,13 +1,10 @@
 ---
 # --- add vm extensions ---
 - type: replace
-  path: /instance_groups/name=diego-brain/vm_extensions
-  value:
-  - ssh-proxy-lb
-- type: replace
   path: /instance_groups/name=router/vm_extensions
   value:
   - router-lb
+  - ssh-proxy-lb
 
 # --- changing default ports ---
 - type: replace
@@ -23,8 +20,8 @@
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/logger_endpoint?/port
   value: 4443
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/doppler?/port
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/doppler?/port
   value: 4443
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/logger_endpoint?/port
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/logger_endpoint?/port
   value: 4443

--- a/operations/community/change-metron-agent-deployment.yml
+++ b/operations/community/change-metron-agent-deployment.yml
@@ -20,7 +20,7 @@
   path: /instance_groups/name=consul/jobs/name=metron_agent/properties/metron_agent/deployment
   value: ((metron_agent_deployment))
 - type: replace
-  path: /instance_groups/name=diego-brain/jobs/name=metron_agent/properties/metron_agent/deployment
+  path: /instance_groups/name=scheduler/jobs/name=metron_agent/properties/metron_agent/deployment
   value: ((metron_agent_deployment))
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=metron_agent/properties/metron_agent/deployment
@@ -32,13 +32,7 @@
   path: /instance_groups/name=api/jobs/name=metron_agent/properties/metron_agent/deployment
   value: ((metron_agent_deployment))
 - type: replace
-  path: /instance_groups/name=cc-bridge/jobs/name=metron_agent/properties/metron_agent/deployment
-  value: ((metron_agent_deployment))
-- type: replace
   path: /instance_groups/name=cc-worker/jobs/name=metron_agent/properties/metron_agent/deployment
-  value: ((metron_agent_deployment))
-- type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=metron_agent/properties/metron_agent/deployment
   value: ((metron_agent_deployment))
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=metron_agent/properties/metron_agent/deployment

--- a/operations/community/enable-volume-service-nfs.yml
+++ b/operations/community/enable-volume-service-nfs.yml
@@ -36,7 +36,7 @@
   value: true
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/volume_services_enabled?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/volume_services_enabled?
   value: true
 
 - type: replace

--- a/operations/enable-privileged-container-support.yml
+++ b/operations/enable-privileged-container-support.yml
@@ -1,4 +1,4 @@
 ---
 - type: replace
-  path: /instance_groups/name=cc-bridge/jobs/name=nsync/properties/capi/nsync/diego_privileged_containers?
+  path: /instance_groups/name=scheduler/jobs/name=nsync/properties/capi/nsync/diego_privileged_containers?
   value: true

--- a/operations/experimental/bits-service.yml
+++ b/operations/experimental/bits-service.yml
@@ -75,7 +75,7 @@
   value: *bits-service-config
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/bits_service?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/bits_service?
   value: *bits-service-config
 
 - type: replace

--- a/operations/experimental/disable-consul-service-registrations-bosh-lite.yml
+++ b/operations/experimental/disable-consul-service-registrations-bosh-lite.yml
@@ -1,4 +1,0 @@
----
-- type: replace
-  path: /instance_groups/name=router/jobs/name=ssh_proxy/properties/enable_consul_service_registration?
-  value: false

--- a/operations/experimental/disable-consul-service-registrations.yml
+++ b/operations/experimental/disable-consul-service-registrations.yml
@@ -1,12 +1,12 @@
 ---
 - type: replace
-  path: /instance_groups/name=diego-brain/jobs/name=auctioneer/properties/enable_consul_service_registration?
+  path: /instance_groups/name=scheduler/jobs/name=auctioneer/properties/enable_consul_service_registration?
   value: false
 - type: replace
-  path: /instance_groups/name=diego-brain/jobs/name=ssh_proxy/properties/enable_consul_service_registration?
+  path: /instance_groups/name=router/jobs/name=ssh_proxy/properties/enable_consul_service_registration?
   value: false
 - type: replace
-  path: /instance_groups/name=diego-brain/jobs/name=file_server/properties?/enable_consul_service_registration?
+  path: /instance_groups/name=api/jobs/name=file_server/properties?/enable_consul_service_registration?
   value: false
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/enable_consul_service_registration?

--- a/operations/experimental/enable-locket.yml
+++ b/operations/experimental/enable-locket.yml
@@ -15,10 +15,10 @@
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/locket?/api_location?
   value: "locket.service.cf.internal:8891"
 - type: replace
-  path: /instance_groups/name=diego-brain/jobs/name=auctioneer/properties/diego/auctioneer/locket?/api_location?
+  path: /instance_groups/name=scheduler/jobs/name=auctioneer/properties/diego/auctioneer/locket?/api_location?
   value: "locket.service.cf.internal:8891"
 - type: replace
-  path: /instance_groups/name=cc-bridge/jobs/name=tps/properties/capi/tps/watcher?/locket/api_location
+  path: /instance_groups/name=scheduler/jobs/name=tps/properties/capi/tps/watcher?/locket/api_location
   value: "locket.service.cf.internal:8891"
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/rep/locket?/api_location?

--- a/operations/experimental/skip-consul-locks.yml
+++ b/operations/experimental/skip-consul-locks.yml
@@ -2,12 +2,15 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=routing-api/properties/routing_api/skip_consul_lock?
   value: true
+
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/skip_consul_lock?
   value: true
+
 - type: replace
-  path: /instance_groups/name=diego-brain/jobs/name=auctioneer/properties/diego/auctioneer/skip_consul_lock?
+  path: /instance_groups/name=scheduler/jobs/name=auctioneer/properties/diego/auctioneer/skip_consul_lock?
   value: true
+
 - type: replace
-  path: /instance_groups/name=cc-bridge/jobs/name=tps/properties/capi/tps/watcher?/skip_consul_lock
+  path: /instance_groups/name=scheduler/jobs/name=tps/properties/capi/tps/watcher?/skip_consul_lock
   value: true

--- a/operations/rename-deployment.yml
+++ b/operations/rename-deployment.yml
@@ -10,7 +10,7 @@
   path: /instance_groups/name=api/jobs/name=statsd_injector/properties/statsd_injector/deployment
   value: ((deployment_name))
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=statsd_injector/properties/statsd_injector/deployment
+  path: /instance_groups/name=scheduler/jobs/name=statsd_injector/properties/statsd_injector/deployment
   value: ((deployment_name))
 
 - type: replace
@@ -32,7 +32,7 @@
   path: /instance_groups/name=consul/jobs/name=metron_agent/properties/metron_agent/deployment
   value: ((deployment_name))
 - type: replace
-  path: /instance_groups/name=diego-brain/jobs/name=metron_agent/properties/metron_agent/deployment
+  path: /instance_groups/name=scheduler/jobs/name=metron_agent/properties/metron_agent/deployment
   value: ((deployment_name))
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=metron_agent/properties/metron_agent/deployment
@@ -44,13 +44,7 @@
   path: /instance_groups/name=api/jobs/name=metron_agent/properties/metron_agent/deployment
   value: ((deployment_name))
 - type: replace
-  path: /instance_groups/name=cc-bridge/jobs/name=metron_agent/properties/metron_agent/deployment
-  value: ((deployment_name))
-- type: replace
   path: /instance_groups/name=cc-worker/jobs/name=metron_agent/properties/metron_agent/deployment
-  value: ((deployment_name))
-- type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=metron_agent/properties/metron_agent/deployment
   value: ((deployment_name))
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=metron_agent/properties/metron_agent/deployment

--- a/operations/rename-network.yml
+++ b/operations/rename-network.yml
@@ -47,19 +47,11 @@
   value: ((network_name))
 
 - type: replace
-  path: /instance_groups/name=diego-brain/networks/name=default/name
+  path: /instance_groups/name=scheduler/networks/name=default/name
   value: ((network_name))
 
 - type: replace
   path: /instance_groups/name=diego-cell/networks/name=default/name
-  value: ((network_name))
-
-- type: replace
-  path: /instance_groups/name=cc-clock/networks/name=default/name
-  value: ((network_name))
-
-- type: replace
-  path: /instance_groups/name=cc-bridge/networks/name=default/name
   value: ((network_name))
 
 - type: replace

--- a/operations/scale-to-one-az.yml
+++ b/operations/scale-to-one-az.yml
@@ -24,7 +24,7 @@
   path: /instance_groups/name=consul/instances
   value: 1
 - type: replace
-  path: /instance_groups/name=diego-brain/instances
+  path: /instance_groups/name=scheduler/instances
   value: 1
 - type: replace
   path: /instance_groups/name=diego-cell/instances
@@ -34,12 +34,6 @@
   value: 1
 - type: replace
   path: /instance_groups/name=api/instances
-  value: 1
-- type: replace
-  path: /instance_groups/name=cc-bridge/instances
-  value: 1
-- type: replace
-  path: /instance_groups/name=cc-clock/instances
   value: 1
 - type: replace
   path: /instance_groups/name=cc-worker/instances
@@ -70,7 +64,7 @@
   path: /instance_groups/name=consul/azs
   value: [ z1 ]
 - type: replace
-  path: /instance_groups/name=diego-brain/azs
+  path: /instance_groups/name=scheduler/azs
   value: [ z1 ]
 - type: replace
   path: /instance_groups/name=diego-cell/azs
@@ -80,12 +74,6 @@
   value: [ z1 ]
 - type: replace
   path: /instance_groups/name=api/azs
-  value: [ z1 ]
-- type: replace
-  path: /instance_groups/name=cc-bridge/azs
-  value: [ z1 ]
-- type: replace
-  path: /instance_groups/name=cc-clock/azs
   value: [ z1 ]
 - type: replace
   path: /instance_groups/name=cc-worker/azs

--- a/operations/test/add-persistent-isolation-segment-router.yml
+++ b/operations/test/add-persistent-isolation-segment-router.yml
@@ -93,5 +93,5 @@
   value: "iso-seg.((system_domain))"
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/app_domains/-
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/app_domains/-
   value: "iso-seg.((system_domain))"

--- a/operations/test/use-bosh-dns.yml
+++ b/operations/test/use-bosh-dns.yml
@@ -7,11 +7,11 @@
     properties:
       aliases:
         auctioneer.service.cf.internal:
-        - "*.diego-brain.default.cf.bosh"
+        - "*.scheduler.default.cf.bosh"
         bbs.service.cf.internal:
         - "*.diego-api.default.cf.bosh"
         cc-uploader.service.cf.internal:
-        - "*.cc-bridge.default.cf.bosh"
+        - "*.api.default.cf.bosh"
         cell.service.cf.internal:
         - "*.cell.default.cf.bosh"
         cf-etcd.service.cf.internal:
@@ -23,13 +23,13 @@
         doppler.service.cf.internal:
         - "*.doppler.default.cf.bosh"
         file-server.service.cf.internal:
-        - "*.diego-brain.default.cf.bosh"
+        - "*.api.default.cf.bosh"
         gorouter.service.cf.internal:
         - "*.router.default.cf.bosh"
         loggregator-trafficcontroller.service.cf.internal:
         - "*.log-api.default.cf.bosh"
         nsync.service.cf.internal:
-        - "*.cc-bridge.default.cf.bosh"
+        - "*.scheduler.default.cf.bosh"
         policy-server.service.cf.internal:
         - "*.api.default.cf.bosh"
         routing-api.service.cf.internal:
@@ -37,11 +37,11 @@
         silk-controller.service.cf.internal:
         - "*.diego-api.default.cf.bosh"
         ssh-proxy.service.cf.internal:
-        - "*.diego-brain.default.cf.bosh"
+        - "*.router.default.cf.bosh"
         stager.service.cf.internal:
-        - "*.cc-bridge.default.cf.bosh"
+        - "*.api.default.cf.bosh"
         tps.service.cf.internal:
-        - "*.cc-bridge.default.cf.bosh"
+        - "*.scheduler.default.cf.bosh"
         uaa.service.cf.internal:
         - "*.uaa.default.cf.bosh"
 - type: replace
@@ -72,13 +72,7 @@
   path: /instance_groups/name=cc-worker/jobs/-
   value: *bosh_dns_job
 - type: replace
-  path: /instance_groups/name=diego-brain/jobs/-
-  value: *bosh_dns_job
-- type: replace
-  path: /instance_groups/name=cc-clock/jobs/-
-  value: *bosh_dns_job
-- type: replace
-  path: /instance_groups/name=cc-bridge/jobs/-
+  path: /instance_groups/name=scheduler/jobs/-
   value: *bosh_dns_job
 - type: replace
   path: /instance_groups/name=log-api/jobs/-

--- a/operations/use-azure-storage-blobstore.yml
+++ b/operations/use-azure-storage-blobstore.yml
@@ -21,13 +21,13 @@
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool
 
 - type: remove
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/buildpacks
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks
 - type: remove
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/droplets
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets
 - type: remove
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/packages
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages
 - type: remove
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/resource_pool
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/fog_connection?
@@ -66,19 +66,19 @@
   value: *blobstore-properties
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/buildpacks?/fog_connection?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks?/fog_connection?
   value: *blobstore-properties
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/droplets?/fog_connection?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets?/fog_connection?
   value: *blobstore-properties
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/packages?/fog_connection?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages?/fog_connection?
   value: *blobstore-properties
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/resource_pool?/fog_connection?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool?/fog_connection?
   value: *blobstore-properties
 
 - type: replace
@@ -115,36 +115,36 @@
   value: *webdav_config
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/buildpacks/webdav_config?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/webdav_config?
   value: *webdav_config
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/droplets/webdav_config?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/webdav_config?
   value: *webdav_config
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/packages/webdav_config?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/webdav_config?
   value: *webdav_config
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/resource_pool/webdav_config?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/webdav_config?
   value: *webdav_config
 
 # replace Azure Storage container names
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/buildpacks/buildpack_directory_key?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/buildpack_directory_key?
   value: ((buildpack_directory_key))
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/droplets/droplet_directory_key?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/droplet_directory_key?
   value: ((droplet_directory_key))
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/packages/app_package_directory_key?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/app_package_directory_key?
   value: ((app_package_directory_key))
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/resource_pool/resource_directory_key?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/resource_directory_key?
   value: ((resource_directory_key))
 
 - type: replace

--- a/operations/use-blobstore-cdn.yml
+++ b/operations/use-blobstore-cdn.yml
@@ -20,13 +20,13 @@
   value: ((cdn_private_key))
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/droplets/cdn?/uri
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/cdn?/uri
   value: ((droplets_cdn_uri))
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/droplets/cdn?/key_pair_id
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/cdn?/key_pair_id
   value: ((cdn_key_pair_id))
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/droplets/cdn?/private_key
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/cdn?/private_key
   value: ((cdn_private_key))
 
 - type: replace
@@ -50,11 +50,11 @@
   value: ((cdn_private_key))
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/resource_pool/cdn?/uri
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/cdn?/uri
   value: ((resource_pool_cdn_uri))
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/resource_pool/cdn?/key_pair_id
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/cdn?/key_pair_id
   value: ((cdn_key_pair_id))
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/resource_pool/cdn?/private_key
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/cdn?/private_key
   value: ((cdn_private_key))

--- a/operations/use-external-dbs.yml
+++ b/operations/use-external-dbs.yml
@@ -78,22 +78,22 @@
   value: *cc_db_username
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/ccdb/db_scheme
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/db_scheme
   value: *cc_db_scheme
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/ccdb/port
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/port
   value: *cc_db_port
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/ccdb/databases/tag=cc/name
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/databases/tag=cc/name
   value: *cc_db_name
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/ccdb/address?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/address?
   value: *cc_db_address
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/ccdb/roles/name=cloud_controller/password
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/roles/name=cloud_controller/password
   value: *cc_db_password
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/ccdb/roles/name=cloud_controller/name
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/roles/name=cloud_controller/name
   value: *cc_db_username
 
 - type: replace
@@ -183,7 +183,7 @@
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/consumes?
   value: {database: nil}
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/consumes?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/consumes?
   value: {database: nil}
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=silk-controller/consumes?

--- a/operations/use-postgres.yml
+++ b/operations/use-postgres.yml
@@ -90,7 +90,7 @@
       password: ((cc_database_password))
       tag: admin
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/ccdb
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb
   value:
     databases:
     - name: cloud_controller

--- a/operations/use-s3-blobstore.yml
+++ b/operations/use-s3-blobstore.yml
@@ -21,13 +21,13 @@
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool
 
 - type: remove
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/buildpacks
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks
 - type: remove
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/droplets
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets
 - type: remove
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/packages
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages
 - type: remove
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/resource_pool
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/fog_connection?
@@ -66,19 +66,19 @@
   value: *blobstore-properties
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/buildpacks?/fog_connection?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks?/fog_connection?
   value: *blobstore-properties
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/droplets?/fog_connection?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets?/fog_connection?
   value: *blobstore-properties
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/packages?/fog_connection?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages?/fog_connection?
   value: *blobstore-properties
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/resource_pool?/fog_connection?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool?/fog_connection?
   value: *blobstore-properties
 
 - type: replace
@@ -115,36 +115,36 @@
   value: *webdav_config
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/buildpacks/webdav_config?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/webdav_config?
   value: *webdav_config
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/droplets/webdav_config?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/webdav_config?
   value: *webdav_config
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/packages/webdav_config?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/webdav_config?
   value: *webdav_config
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/resource_pool/webdav_config?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/webdav_config?
   value: *webdav_config
 
 # replace s3 bucket names
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/buildpacks/buildpack_directory_key?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/buildpack_directory_key?
   value: ((buildpack_directory_key))
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/droplets/droplet_directory_key?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/droplet_directory_key?
   value: ((droplet_directory_key))
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/packages/app_package_directory_key?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/app_package_directory_key?
   value: ((app_package_directory_key))
 
 - type: replace
-  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/resource_pool/resource_directory_key?
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/resource_directory_key?
   value: ((resource_directory_key))
 
 - type: replace


### PR DESCRIPTION
- Moves ssh_proxy job to router instance-group
- Moves cc_uploader job to api instance-group
- Moves file_server job to api instance-group
- Consolidates remaining jobs from cc-bridge, cc-clock, and diego-brain instance-groups (cloud_controller_clock; nsync and tps; auctioneer) on new scheduler instance-group