### PR TITLE
Update Postgres version in bosh-lite opsfile

### DIFF
--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -11,9 +11,9 @@
   path: /releases/-
   value:
     name: postgres
-    url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=16
-    sha1: b114fa78c017c7b6752e83c4d1e5d92309164e61
-    version: "16"
+    url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=18
+    sha1: ad62d5d7e4b7875316ecd5b972f26ee842c4b605
+    version: "18"
 
 - type: replace
   path: /instance_groups/name=cc-bridge/jobs/name=nsync/properties/capi/nsync/diego_privileged_containers?


### PR DESCRIPTION
Make the bosh-lite Postgres version match the [use-postgres.yml](https://github.com/cloudfoundry/cf-deployment/blob/develop/operations/use-postgres.yml) opsfile.

We would like to use this version since it supports SSL.

Thanks!
@tcdowney && @jenspinney 