### PR TITLE
Add bits-service operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,10 @@ Here's an (alphabetical) summary:
 - `operations/windows-cell.yml` -
   deploys a windows diego cell,
   adds releases necessary for windows.
+- `operations/experimental/bits-service.yml` - adds the [bits-service](https://github.com/cloudfoundry-incubator/bits-service)
+  job and enables it in the cloud-controller. It also requires one of
+  `bits-service-{local,webdav,s3}.yml` from the same directory. For S3,
+  `use-s3-blobstore.yml` is also required.
 
 ### A note on `experimental` and `test` ops-files
 The `operations` directory includes two subdirectories

--- a/operations/experimental/bits-service-local.yml
+++ b/operations/experimental/bits-service-local.yml
@@ -1,0 +1,23 @@
+---
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/app_stash
+  value:
+    directory_key: app_stash
+    fog_connection: &fog-connection
+      provider: "local"
+      local_root: "/var/vcap/store/bits-service/"
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/buildpacks
+  value:
+    directory_key: buildpacks
+    fog_connection: *fog-connection
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/droplets
+  value:
+    directory_key: droplets
+    fog_connection: *fog-connection
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/packages
+  value:
+    directory_key: packages
+    fog_connection: *fog-connection

--- a/operations/experimental/bits-service-s3.yml
+++ b/operations/experimental/bits-service-s3.yml
@@ -1,0 +1,25 @@
+---
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/app_stash
+  value:
+    directory_key: "((resource_directory_key))"
+    fog_connection: &aws-config
+      provider: "AWS"
+      aws_access_key_id: "((blobstore_access_key_id))"
+      aws_secret_access_key: "((blobstore_secret_access_key))"
+      region: "((aws_region))"
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/buildpacks
+  value:
+    directory_key: "((buildpack_directory_key))"
+    fog_connection: *aws-config
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/droplets
+  value:
+    directory_key: "((droplet_directory_key))"
+    fog_connection: *aws-config
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/packages
+  value:
+    directory_key: "((app_package_directory_key))"
+    fog_connection: *aws-config

--- a/operations/experimental/bits-service-webdav.yml
+++ b/operations/experimental/bits-service-webdav.yml
@@ -1,0 +1,30 @@
+---
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/app_stash
+  value:
+    blobstore_type: webdav
+    directory_key: app_stash
+    webdav_config: &webdav-config
+      ca_cert: "((blobstore_tls.ca))"
+      password: "((blobstore_admin_users_password))"
+      private_endpoint: https://blobstore.service.cf.internal:4443
+      public_endpoint: https://blobstore.((system_domain))
+      username: blobstore-user
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/buildpacks
+  value:
+    blobstore_type: webdav
+    directory_key: buildpacks
+    webdav_config: *webdav-config
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/droplets
+  value:
+    blobstore_type: webdav
+    directory_key: droplets
+    webdav_config: *webdav-config
+- type: replace
+  path: /instance_groups/name=bits-service/jobs/name=bits-service/properties/bits-service/packages
+  value:
+    blobstore_type: webdav
+    directory_key: packages
+    webdav_config: *webdav-config

--- a/operations/experimental/bits-service.yml
+++ b/operations/experimental/bits-service.yml
@@ -1,0 +1,98 @@
+---
+# Summary
+# --------
+# TODO
+#
+# Optional properties:
+#
+# - TODO
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: bits-service
+    instances: 1
+    azs: [z1]
+    vm_type: m3.medium
+    persistent_disk: 6064
+    stemcell: default
+    networks:
+      - name: default
+    jobs:
+      - name: bits-service
+        release: bits-service
+        properties:
+          bits-service:
+            private_endpoint: http://bits-service.service.cf.internal
+            public_endpoint: http://bits-service.((system_domain))
+            secret: "((bits_service_secret))"
+            signing_users:
+              - username: admin
+                password: "((bits_service_signing_password))"
+            app_stash:
+            buildpacks:
+            droplets:
+            packages:
+            cc_updates:
+              ca_cert: "((cc_tls.ca))"
+              client_cert: "((cc_tls.certificate))"
+              client_key: "((cc_tls.private_key))"
+      - name: consul_agent
+        release: consul
+        consumes:
+          consul_common: {from: consul_common_link}
+          consul_server: nil
+          consul_client: {from: consul_client_link}
+        properties:
+          consul:
+            agent:
+              services:
+                bits-service: {}
+      - name: route_registrar
+        release: routing
+        properties:
+          route_registrar:
+            routes:
+              - name: bits-service
+                port: 80
+                registration_interval: 20s
+                uris:
+                  - bits-service.((system_domain))
+                tags:
+                  component: bits-service
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/bits_service?
+  value: &bits-service-config
+    enabled: true
+    public_endpoint: http://bits-service.((system_domain))
+    private_endpoint: http://bits-service.service.cf.internal
+    username: admin
+    password: "((bits_service_signing_password))"
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/bits_service?
+  value: *bits-service-config
+
+- type: replace
+  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/cc/bits_service?
+  value: *bits-service-config
+
+- type: replace
+  path: /variables/-
+  value:
+    name: bits_service_secret
+    type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: bits_service_signing_password
+    type: password
+
+- type: replace
+  path: /releases/-
+  value:
+    name: bits-service
+    version: latest
+    # TODO: get a URL


### PR DESCRIPTION
Here is the first attempt to add bits-service to cf-deployment.

We could not find a way to make sure bits-service job is available before cloud controller is updated with the new config. In spruce we would just insert it somewhere before api job, but ops files syntax only supports appending to arrays for now. As a workaround, we used a two step deployment process: first time we add bits-service job without changing CC config. After bits-service VM is up and running, we update CC config with the second deployment.

As a side note, when changing from one blobstore type to another, we had to manually kick off `rake buildpacks:install` in order to re-create them immediately.

Signed-off-by: Alexander Egurnov <egurnov@de.ibm.com>
Signed-off-by: Steffen Uhlig <Steffen.Uhlig@de.ibm.com>

[#149718555]