### PR TITLE
Add cc-clock in the scale-to-one-az operation file

### DIFF
--- a/operations/scale-to-one-az.yml
+++ b/operations/scale-to-one-az.yml
@@ -39,6 +39,9 @@
   path: /instance_groups/name=cc-bridge/instances
   value: 1
 - type: replace
+  path: /instance_groups/name=cc-clock/instances
+  value: 1
+- type: replace
   path: /instance_groups/name=cc-worker/instances
   value: 1
 - type: replace
@@ -80,6 +83,9 @@
   value: [ z1 ]
 - type: replace
   path: /instance_groups/name=cc-bridge/azs
+  value: [ z1 ]
+- type: replace
+  path: /instance_groups/name=cc-clock/azs
   value: [ z1 ]
 - type: replace
   path: /instance_groups/name=cc-worker/azs


### PR DESCRIPTION
When cc-clock job was added it was left out of the `scale-to-one-az` operation file, because of that our CI, which has only one az, broke. This should fix it. 

