### PR TITLE
Update disable-router-tls-termination.yml

### DIFF
--- a/operations/disable-router-tls-termination.yml
+++ b/operations/disable-router-tls-termination.yml
@@ -2,6 +2,4 @@
 - type: remove
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router/enable_ssl
 - type: remove
-  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ssl_cert
-- type: remove
-  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ssl_key
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/tls_pem


### PR DESCRIPTION
Fixes #211 

PR #171 changed the manifest but not the ops-file to turn off router tls termination. This PR fixes the ops-file to use the new key name.