### PR TITLE
Add error messages to locket-related ops-files

### DIFF
--- a/operations/experimental/enable-locket-postgres.yml
+++ b/operations/experimental/enable-locket-postgres.yml
@@ -1,6 +1,7 @@
 ---
 - type: replace
   path: /instance_groups/name=postgres/jobs/name=postgres/properties/databases/databases/-
+  error: "You must apply the `use-postgres.yml` ops-file first."
   value:
     citext: true
     name: locket
@@ -13,6 +14,7 @@
     password: "((locket_database_password))"
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql
+  error: "You must apply the `enable-locket.yml` ops-file first."
   value:
     db_host: sql-db.service.cf.internal
     db_port: 5524

--- a/operations/experimental/enable-locket.yml
+++ b/operations/experimental/enable-locket.yml
@@ -6,6 +6,7 @@
     release: diego
 - type: replace
   path: /instance_groups/name=mysql/jobs/name=mysql/properties/cf_mysql/mysql/seeded_databases/-
+  error: "It looks like you've removed the mysql job. If you're using postgres or external databases, make sure to apply `use-postgres.yml` or `use-external-dbs.yml` (respectively) after applying this ops-file."
   value:
     name: locket
     username: locket

--- a/operations/experimental/use-external-locket-db.yml
+++ b/operations/experimental/use-external-locket-db.yml
@@ -1,6 +1,7 @@
 ---
 - type: remove
   path: /variables/name=locket_database_password
+  error: "It seems you haven't applied `enable-locket.yml` yet. Make sure to apply that ops-file first."
 
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql


### PR DESCRIPTION
This allows us to define custom error messages. I'm hoping we can use this to guide deployers towards applying ops-files in the right order.