### PR TITLE
Update tls_pem to support new format

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -901,7 +901,8 @@ instance_groups:
         ssl_skip_validation: true
         enable_ssl: true
         tls_pem:
-        - "((router_ssl.certificate))((router_ssl.private_key))"
+        - cert_chain: "((router_ssl.certificate))"
+          private_key: "((router_ssl.private_key))"
         status:
           password: "((router_status_password))"
           user: router-status

--- a/operations/test/add-persistent-isolation-segment-router.yml
+++ b/operations/test/add-persistent-isolation-segment-router.yml
@@ -54,7 +54,8 @@
           ssl_skip_validation: true
           enable_ssl: true
           tls_pem:
-          - "((router_ssl.certificate))((router_ssl.private_key))"
+          - cert_chain: "((router_ssl.certificate))"
+            key_chain: "((router_ssl.private_key))"
           status:
             password: "((router_status_password))"
             user: router-status


### PR DESCRIPTION
- Now cert_chain and private_key must be specified when providing tls_pem
- This PR must be bumped with corresponding change in routing release

[#150267695]

Signed-off-by: Edwin Xie <exie@pivotal.io>