### PR TITLE
Split router.tls_pem into two properties

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -901,7 +901,8 @@ instance_groups:
         ssl_skip_validation: true
         enable_ssl: true
         tls_pem:
-        - "((router_ssl.certificate))((router_ssl.private_key))"
+        - cert_chain: "((router_ssl.certificate))"
+          private_key: "((router_ssl.private_key))"
         status:
           password: "((router_status_password))"
           user: router-status

--- a/operations/test/add-persistent-isolation-segment-router.yml
+++ b/operations/test/add-persistent-isolation-segment-router.yml
@@ -54,7 +54,8 @@
           ssl_skip_validation: true
           enable_ssl: true
           tls_pem:
-          - "((router_ssl.certificate))((router_ssl.private_key))"
+          - cert_chain: "((router_ssl.certificate))"
+            private_key: "((router_ssl.private_key))"
           status:
             password: "((router_status_password))"
             user: router-status


### PR DESCRIPTION
- Instead of a single string, we are separating tls_pem to include cert_chain
  and private_key.

[#150451369]

Signed-off-by: Gabriel Rosenhouse <grosenhouse@pivotal.io>