### PR TITLE
Fix vm type for bits-service

### DIFF
--- a/operations/experimental/bits-service.yml
+++ b/operations/experimental/bits-service.yml
@@ -13,7 +13,7 @@
     name: bits-service
     instances: 1
     azs: [z1]
-    vm_type: m3.medium
+    vm_type: minimal
     persistent_disk: 6064
     stemcell: default
     networks:


### PR DESCRIPTION
Since the last pull-request cloudfoundry/cf-deployment#206 was filed, the types of VMs used in deployment changed, which breaks bits-service operations file. This fix makes it use the new VM type.