### PR TITLE
vm_extensions required by cf on bosh-lite

### DIFF
--- a/bosh-lite/cloud-config.yml
+++ b/bosh-lite/cloud-config.yml
@@ -45,6 +45,8 @@ vm_extensions:
     - host: 80
     - host: 443
     - host: 2222
+- name: cf-router-network-properties
+- name: diego-ssh-proxy-network-properties
 - name: cf-tcp-router-network-properties
   cloud_properties:
     ports:


### PR DESCRIPTION
Hi cf-deployment,

Following the [instructions in the README](https://github.com/cloudfoundry/cf-deployment#step-1-pave-your-iaas-and-get-a-bosh-director) for using cf-deployment on bosh-lite, I found that the provided cloud-config.yml is missing a couple of required vm_extensions. Hope this helps.