### PR TITLE
Fix replacement of vm_extensions on bosh lite

### DIFF
--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -207,8 +207,7 @@
   path: /instance_groups/name=diego-brain/jobs/name=ssh_proxy
 - type: replace
   path: /instance_groups/name=router/vm_extensions/-
-  value:
-  - diego-ssh-proxy-network-properties
+  value: diego-ssh-proxy-network-properties
 - type: replace
   path: /instance_groups/name=router/jobs/-
   value:


### PR DESCRIPTION
Hi @dsabeti, thanks for taking a look at my last PR (#236). Totally see what you're saying - it looks like I'd missed the bosh-lite ops file completely. I was also looking at your master branch instead of develop - seems like things are almost fixed on develop. I just found one small typo in the bosh-lite ops file that prevents the deployment from proceeding - it results in an extra leading `-` ahead of the `diego-ssh-proxy-network-properties` vm_extension. This had me scratching my head for a while since the error message you get back from bosh is to the effect that 'diego-ssh-proxy-network-properties was not found in the cloud-config', which is confusing since it's clearly there. Using `bosh interpolate` to dump out the generated manifest made it clear what was going on though. Anyway, here's the fix. I'll close #236 since it's redundant now.