### PR TITLE
Fix router vm extensions in bosh-lite

### DIFF
--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -208,7 +208,7 @@
 - type: replace
   path: /instance_groups/name=router/vm_extensions/-
   value:
-  - diego-ssh-proxy-network-properties
+    diego-ssh-proxy-network-properties
 - type: replace
   path: /instance_groups/name=router/jobs/-
   value:


### PR DESCRIPTION
`/-` in path appends to array, the value should be scalar.