### PR TITLE
Add credhub-lb vm_extension to bosh-lite cloud-config

### DIFF
--- a/bosh-lite/cloud-config.yml
+++ b/bosh-lite/cloud-config.yml
@@ -49,6 +49,10 @@ vm_extensions:
   cloud_properties:
     ports:
     - host: 1024-1123
+- name: credhub-lb
+  cloud_properties:
+    ports:
+    - host: 8844
 vm_types:
 - name: minimal
 - name: small


### PR DESCRIPTION
- Any traffic received by the bosh-lite VM on port 8844 will be routed
  to the container with the credhub-lb vm_extension
- This will allow us to test runtime credhub integrations on a bosh-lite

[#150753759](https://www.pivotaltracker.com/story/show/150753759)

Thanks!
Tim && @ljfranklin 