### PR TITLE
Update network name in Datadog ops-file

### DIFF
--- a/operations/test/add-datadog-firehose-nozzle.yml
+++ b/operations/test/add-datadog-firehose-nozzle.yml
@@ -21,7 +21,7 @@
     vm_type: minimal
     stemcell: default
     networks:
-    - name: private
+    - name: default
     jobs:
     - name: datadog-firehose-nozzle
       release: datadog-firehose-nozzle


### PR DESCRIPTION
PR https://github.com/cloudfoundry/cf-deployment/pull/109 changed the BOSH Lite network name to `default`.