### PR TITLE
Bump back-and-restore-sdk-release to 1.2.0

### DIFF
--- a/operations/experimental/deploy-bosh-backup-restore.yml
+++ b/operations/experimental/deploy-bosh-backup-restore.yml
@@ -3,9 +3,9 @@
     path: /releases/-
     value:
       name: backup-and-restore-sdk
-      url: https://bosh.io/d/github.com/cloudfoundry-incubator/backup-and-restore-sdk-release?v=1.0.0
-      version: 1.0.0
-      sha1: 3b07fa61f65164927b642ddaa41408c19ec9d457
+      url: https://bosh.io/d/github.com/cloudfoundry-incubator/backup-and-restore-sdk-release?v=1.2.0
+      version: 1.2.0
+      sha1: 2b8330b22a397a1927dad8e3d768eb6897c49601
 
   - type: replace
     path: /instance_groups/-


### PR DESCRIPTION
Hello from London,

The BBR team has cut a new release. Since the release is not automatically bumped in ci, here is the PR to update it 😸

Chunyi && @gcapizzi