### PR TITLE
tcp-router is scaled down to a single instance when using one az

### DIFF
--- a/operations/scale-to-one-az.yml
+++ b/operations/scale-to-one-az.yml
@@ -44,6 +44,9 @@
 - type: replace
   path: /instance_groups/name=log-api/instances
   value: 1
+- type: replace
+  path: /instance_groups/name=tcp-router/instances
+  value: 1
 
 - type: replace
   path: /instance_groups/name=consul/azs


### PR DESCRIPTION
the tcp-router is enabled by default as part of 0.28.0 but the ops file scale-to-one-az doesn't take this into account.