### PR TITLE
Add missing sha1 for bits-service

### DIFF
--- a/operations/experimental/bits-service.yml
+++ b/operations/experimental/bits-service.yml
@@ -71,3 +71,4 @@
     name: bits-service
     version: latest
     url: https://github.com/cloudfoundry-incubator/bits-service-release/releases/download/1.0.0-dev.592/bits-service-1.0.0-dev.592.tgz
+    sha1: 2a7cf364b7a4bad2cfd7f6653905521cdbd27d26


### PR DESCRIPTION
Although https://bosh.io/docs/manifest-v2.html#releases says that this is optional, it looks like with BOSH CLI v1 this breaks (no data about BOSH CLI v2). To be safe, adding it here.