### PR TITLE
Add credhub_ca.certificate to cloud_controller_ng job

### DIFF
--- a/operations/experimental/secure-service-credentials.yml
+++ b/operations/experimental/secure-service-credentials.yml
@@ -78,6 +78,9 @@
     ((application_ca.certificate))
     ((credhub_ca.certificate))
 - type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/credhub_api?/ca_cert?
+  value: "((credhub_ca.certificate))"
+- type: replace
   path: /variables/-
   value:
     name: credhub_encryption_password


### PR DESCRIPTION
Cloud Controller needs the `credhub_ca.certificate` to connect via SSL.

[#150753759](#150753759)

Signed-off-by: Lisa Cho <lcho@pivotal.io>