### PR TITLE
Add use-latest-stemcell opsfiles for windows

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -45,4 +45,5 @@ This is the README for Ops-files. To learn more about `cf-deployment`, go to the
 | [`use-postgres.yml`](use-postgres.yml) | Replaces the MySQL instance group with a postgres instance group. **Warning**: this will lead to total data loss if applied to an existing deployment with MySQL or removed from an existing deployment with postgres. |  |
 | [`use-compiled-releases.yml`](use-compiled-releases.yml) | Instead of having your BOSH Director compile each release, use this ops-file to use pre-compiled releases for a deployment speed improvement. |  |
 | [`use-latest-stemcell.yml`](use-latest-stemcell.yml) | Use the latest stemcell available on your BOSH director instead of the one in `cf-deployment.yml` |  |
+| [`use-latest-windows-stemcell.yml`](use-latest-windows-stemcell.yml) | Use the latest `windows2012R2` stemcell available on your BOSH director instead of the one in `windows-cell.yml` | Requires `windows-cell.yml` |
 | [`windows-cell.yml`](windows-cell.yml) | Deploys a windows 2012 diego cell, adds releases necessary for windows. |  |

--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -47,4 +47,5 @@ and the ops-files will be removed.
 | [`use-external-cf-networking-dbs.yml`](use-external-cf-networking-dbs.yml) | Intentionally left blank for backwards compatibility. | Previously: "Allowed `user-cf-networking.yml` to work with external database." `cf-deployment.yml` plus `use-external-dbs.yml` now does this by default.
 | [`use-external-locket-db.yml`](use-external-locket-db.yml) | Allows `enable-locket.yml` to work with external database. | Requires `enable-locket.yml` |
 | [`use-grootfs.yml`](use-grootfs.yml) | Enable grootfs on diego cells. | |
+| [`use-latest-windows2016-stemcell.yml`](use-latest-windows2016-stemcell.yml) | Use the latest `windows2016` stemcell available on your BOSH director instead of the one in `windows2016-cell.yml` | Requires `windows2016-cell.yml` |
 | [`windows2016-cell.yml`](windows2016-cell.yml) | Deploys a windows 2016 diego cell, adds releases necessary for windows. |  |

--- a/operations/experimental/use-latest-windows2016-stemcell.yml
+++ b/operations/experimental/use-latest-windows2016-stemcell.yml
@@ -1,0 +1,3 @@
+- path: /stemcells/alias=windows2016/version
+  type: replace
+  value: latest

--- a/operations/use-latest-windows-stemcell.yml
+++ b/operations/use-latest-windows-stemcell.yml
@@ -1,0 +1,3 @@
+- path: /stemcells/alias=windows2012R2/version
+  type: replace
+  value: latest

--- a/scripts/test
+++ b/scripts/test
@@ -290,10 +290,22 @@ function test_opsfile_interpolation() {
     else
       fail "operations/windows-cell.yml"
     fi
+    version=$(bosh interpolate cf-deployment.yml -o operations/windows-cell.yml -o operations/use-latest-windows-stemcell.yml --path=/stemcells/alias=windows2012R2/version)
+    if [ "${version}" == "latest" ]; then
+      echo -e "${GREEN}PASS${NOCOLOR} - operations/use-latest-windows-stemcell.yml"
+    else
+      fail "operations/use-latest-windows-stemcell.yml, expected 'latest' but got '${version}'"
+    fi
     if interpolate "-o operations/experimental/windows2016-cell.yml"; then
       echo -e "${GREEN}PASS${NOCOLOR} - operations/experimental/windows2016-cell.yml"
     else
       fail "operations/experimental/windows2016-cell.yml"
+    fi
+    version=$(bosh interpolate cf-deployment.yml -o operations/experimental/windows2016-cell.yml -o operations/experimental/use-latest-windows2016-stemcell.yml --path=/stemcells/alias=windows2016/version)
+    if [ "${version}" == "latest" ]; then
+      echo -e "${GREEN}PASS${NOCOLOR} - operations/experimental/use-latest-windows2016-stemcell.yml"
+    else
+      fail "operations/experimental/use-latest-windows2016-stemcell.yml, expected 'latest' but got '${version}'"
     fi
     if interpolate "-o operations/windows-cell.yml -o operations/experimental/windows2016-cell.yml"; then
       echo -e "${GREEN}PASS${NOCOLOR} - operations/windows-cell.yml operations/experimental/windows2016-cell.yml"


### PR DESCRIPTION
Mirrors the existing `use-latest-stemcell` opsfile for the `default` stemcell

Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>