### PR TITLE
Increase of small flavor ephemeral disk size to 14GB

### DIFF
--- a/iaas-support/openstack/README.md
+++ b/iaas-support/openstack/README.md
@@ -11,7 +11,7 @@ You'll need to following to proceed:
 -------|------|-----------|-----------------|----------------------|
 | sharedcpu | 1 | 2048 | 3 | 10 |
 | minimal | 1 | 3840 | 3 | 10 |
-| small | 2 | 7680 | 3 | 10 |
+| small | 2 | 7680 | 3 | 14 |
 | small-50GB-ephemeral-disk | 2 | 7680 | 3 | 50 |
 | small-highmem | 4 | 31232 | 3 | 10 |
 | small-highmem-100GB-ephemeral-disk | 4 | 31232 | 3 | 100 |

--- a/iaas-support/openstack/flavors.yml
+++ b/iaas-support/openstack/flavors.yml
@@ -6,7 +6,7 @@
 - name: small
   ram: 7680
   vcpus: 2
-  ephemeral: 10
+  ephemeral: 14
 - name: small-highmem
   ram: 31232
   vcpus: 4


### PR DESCRIPTION
due to deploy error:
`Error: CPI error 'Bosh::Clouds::CloudError' with message 'Flavor 'small' should have at least 14Gb of ephemeral disk' in 'create_vm' CPI method`