### PR TITLE
Add rootless-containers ops file

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -32,6 +32,7 @@ and the ops-files will be removed.
 | [`enable-prefer-declarative-healthchecks.yml`](enable-prefer-declarative-healthchecks.yml) | Configure the Rep on the diego cells to prefer LRP CheckDefinition (a.k.a declarative healthchecks) over the old Monitor action | |
 | [`enable-prefer-declarative-healthchecks-windows.yml`](enable-prefer-declarative-healthchecks-windows.yml) | Configure the Rep on the windows 2012 cells to prefer LRP CheckDefinition (a.k.a declarative healthchecks) over the old Monitor action | |
 | [`enable-prefer-declarative-healthchecks-windows2016.yml`](enable-prefer-declarative-healthchecks-windows2016.yml) | Configure the Rep on the windows 2016 cells to prefer LRP CheckDefinition (a.k.a declarative healthchecks) over the old Monitor action | |
+| [`rootless-containers.yml`](rootless-containers.yml) | Enable rootless garden-runc containers. | Requires garden-runc 1.9.5 or later and grootfs 0.27.0 or later. |
 | [`secure-service-credentials.yml`](secure-service-credentials.yml) | Use CredHub for service credentials. | Requires `enable-instance-identity-credentials.yml`. |
 | [`secure-service-credentials-external-db.yml`](secure-service-credentials-external-db.yml) | Use external database for CredHub data store. | Requires `secure-service-credentials.yml` and `use-external-dbs.yml`. |
 | [`secure-service-credentials-postgres.yml`](secure-service-credentials-postgres.yml) | Use local postgres database for CredHub data store. | Requires `secure-service-credentials.yml` and `use-postgres.yml`. |

--- a/operations/experimental/rootless-containers.yml
+++ b/operations/experimental/rootless-containers.yml
@@ -1,0 +1,15 @@
+# Requires grootfs 0.27.0 or later, and garden-runc 1.9.5 or later.
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/experimental_rootless_mode?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=grootfs/properties/grootfs/skip_mount?
+  value: true
+
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/privileged_image_plugin?
+
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/privileged_image_plugin_extra_args?


### PR DESCRIPTION
We'd like to contribute an opsfile that enables rootless container functionality in garden-runc. This feature is experimental and shouldn't be used in production (yet).

In order to avoid a conflict with the bosh-lite opsfile, we've removed the use of privileged containers for running. This wasn't necessary to enable (for as long as I recall at least), for what it's worth.

This opsfile will only work when running garden-runc 1.9.5+ (unreleased!) and grootfs 0.27.0+ (released very recently). That means it won't be massively useful straight away, but 1.9.5 should be out soon and we wanted to get ahead of it.

Cheers,
@yulianedyalkova & Craig