### PR TITLE
Add open_bindmounts_acl to windows2016-cell

### DIFF
--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -48,6 +48,7 @@
               client_key: ((diego_bbs_client.private_key))
             ca_cert: ((diego_rep_agent.ca))
             enable_legacy_api_endpoints: false
+            open_bindmounts_acl: true
             preloaded_rootfses:
             - windows2016:/var/vcap/packages/windows2016fs/rootfs
             require_tls: true
@@ -132,7 +133,6 @@
   type: replace
   value:
     name: winc
-    version: latest
     sha1: 2e91aaa8cb6d0b678e07fd4d8718c46f9b2bb0f1
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/winc-release?v=0.4.0
     version: 0.4.0


### PR DESCRIPTION
This is necessary due to a PR to diego-release: https://github.com/cloudfoundry/diego-release/pull/366

Also remove a `version: latest` in the winc section that never should
have made it there

[#151704899]