### PR TITLE
Add `url` and `sha1` properties for syslog release

### DIFF
--- a/runtime-configs/enable-component-syslog.yml
+++ b/runtime-configs/enable-component-syslog.yml
@@ -14,3 +14,5 @@ addons:
 releases:
 - name: syslog
   version: '11'
+  url: https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11
+  sha1: 332ac15609b220a3fdf5efad0e0aa069d8235788


### PR DESCRIPTION
As is, when we try to use the syslog runtime config in a new director the following error occurs:

```bash
Task 307 | 21:05:05 | Preparing deployment: Preparing deployment (00:00:00)
                    L Error: Release 'syslog' doesn't exist
Task 307 | 21:05:05 | Error: Release 'syslog' doesn't exist
```

As the message says, the error occurs because the syslog release is still not present in the director.

In order to avoid manually uploading the release, I'm proposing that we take advantage of the [`url` and `sha1` properties available in the Releases Block of Manifest v2 Schema](https://bosh.io/docs/manifest-v2.html#releases). By doing that, BOSH will automatically upload the syslog release.

Also worth pointing out that the same pattern [is used elsewhere](https://github.com/dlresende/cf-deployment/blob/master/cf-deployment.yml#L1631-L1723) in this repository.