### PR TITLE
Split CredHub load balancer into separate opsfile

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -34,6 +34,7 @@ and the ops-files will be removed.
 | [`enable-prefer-declarative-healthchecks-windows.yml`](enable-prefer-declarative-healthchecks-windows.yml) | Configure the Rep on the windows 2012 cells to prefer LRP CheckDefinition (a.k.a declarative healthchecks) over the old Monitor action | |
 | [`enable-prefer-declarative-healthchecks-windows2016.yml`](enable-prefer-declarative-healthchecks-windows2016.yml) | Configure the Rep on the windows 2016 cells to prefer LRP CheckDefinition (a.k.a declarative healthchecks) over the old Monitor action | |
 | [`secure-service-credentials.yml`](secure-service-credentials.yml) | Use CredHub for service credentials. | Requires `enable-instance-identity-credentials.yml`. |
+| [`secure-service-credentials-add-load-balancer.yml`](secure-service-credentials-add-load-balancer.yml) | Use load balancer to expose external address for CredHub. | Requires `secure-service-credentials.yml`. |
 | [`secure-service-credentials-external-db.yml`](secure-service-credentials-external-db.yml) | Use external database for CredHub data store. | Requires `secure-service-credentials.yml` and `use-external-dbs.yml`. |
 | [`secure-service-credentials-postgres.yml`](secure-service-credentials-postgres.yml) | Use local postgres database for CredHub data store. | Requires `secure-service-credentials.yml` and `use-postgres.yml`. |
 | [`skip-consul-cell-registrations.yml`](skip-consul-cell-registrations.yml) | Configure the BBS to only use locket to find cells in the deployment | |

--- a/operations/experimental/secure-service-credentials-add-load-balancer.yml
+++ b/operations/experimental/secure-service-credentials-add-load-balancer.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=credhub/vm_extensions?/-
+  value: credhub-lb

--- a/operations/experimental/secure-service-credentials.yml
+++ b/operations/experimental/secure-service-credentials.yml
@@ -63,8 +63,6 @@
     networks:
     - name: default
     stemcell: default
-    vm_extensions:
-    - credhub-lb
     vm_type: minimal
 - type: replace
   path: /instance_groups/name=mysql/jobs/name=mysql/properties/cf_mysql/mysql/seeded_databases/-


### PR DESCRIPTION
@dsabeti 

https://www.pivotaltracker.com/story/show/151777717

[#151777717] Operators can deploy cf-deployment with CredHub without an LB vm extension by default