### PR TITLE
Make variable names more specific

### DIFF
--- a/runtime-configs/enable-component-syslog.yml
+++ b/runtime-configs/enable-component-syslog.yml
@@ -5,11 +5,11 @@ addons:
     release: syslog
   properties:
     syslog:
-      address: ((address))
-      port: ((port))
-      transport: ((transport))
-      fallback_servers: ((fallback_servers))
-      custom_rule: ((custom_rule))
+      address: ((syslog_address))
+      port: ((syslog_port))
+      transport: ((syslog_transport))
+      fallback_servers: ((syslog_fallback_servers))
+      custom_rule: ((syslog_custom_rule))
 
 releases:
 - name: syslog


### PR DESCRIPTION
If we want to store these variables in a shared var store, it is helpful for them to be less generically named.

https://www.pivotaltracker.com/story/show/151811590

[#151811590]