### PR TITLE
Remove remnants of loggregator shared secret

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -72,8 +72,6 @@ instance_groups:
   - name: metron_agent
     release: loggregator
     properties: &metron_agent_properties
-      metron_endpoint:
-        shared_secret: "((dropsonde_shared_secret))"
       loggregator:
         tls:
           ca_cert: "((loggregator_tls_metron.ca))"
@@ -141,8 +139,6 @@ instance_groups:
           doppler:
             cert: "((loggregator_tls_doppler.certificate))"
             key: "((loggregator_tls_doppler.private_key))"
-      doppler_endpoint:
-        shared_secret: "((dropsonde_shared_secret))"
   - name: adapter
     release: cf-syslog-drain
     properties:
@@ -1350,8 +1346,6 @@ variables:
 - name: router_status_password
   type: password
 - name: cf_admin_password
-  type: password
-- name: dropsonde_shared_secret
   type: password
 - name: router_route_services_secret
   type: password

--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -83,8 +83,6 @@
               key: ((loggregator_tls_metron.private_key))
         metron_agent:
           deployment: ((system_domain))
-        metron_endpoint:
-          shared_secret: ((dropsonde_shared_secret))
         syslog_daemon_config:
           enable: false
       release: loggregator

--- a/operations/non-collocated-cf-syslog-drain.yml
+++ b/operations/non-collocated-cf-syslog-drain.yml
@@ -48,8 +48,6 @@
     - name: metron_agent
       release: loggregator
       properties:
-        metron_endpoint:
-          shared_secret: "((dropsonde_shared_secret))"
         loggregator:
           tls:
             ca_cert: "((loggregator_tls_metron.ca))"

--- a/operations/test/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/test/add-persistent-isolation-segment-diego-cell.yml
@@ -80,8 +80,6 @@
           enable: false
         metron_agent:
           deployment: "((system_domain))"
-        metron_endpoint:
-          shared_secret: "((dropsonde_shared_secret))"
         loggregator:
           tls:
             ca_cert: "((loggregator_tls_metron.ca))"

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -86,8 +86,6 @@
               key: ((loggregator_tls_metron.private_key))
         metron_agent:
           deployment: ((system_domain))
-        metron_endpoint:
-          shared_secret: ((dropsonde_shared_secret))
         syslog_daemon_config:
           enable: false
       release: loggregator

--- a/scripts/fixtures/test-base-vars-store.yml
+++ b/scripts/fixtures/test-base-vars-store.yml
@@ -953,7 +953,6 @@ diego_ssh_proxy_host_key:
   public_key: |
     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3S+xTDIJVx5uLpjr5BUkJrBUAMGNLsqwybFzP9cER7Y9d+m5kStkSBjS1w3JXKacZN3RctYBa1tvHwrjAwg7ra0WU6DJY1BRLq2x28gOfFGois9W0896jWojm0WH9nIv9GBw+blEhUZaff0TRDpSYJqNBkc8TpBi1qZr0rDm00xirNrBetB/IrcxiBONOiY1PqxIuOAasjW4BYRhIOSj9u4ZPO1JN3vDnMnNQo6f9Jn2BCuqp/LwMjgis1Qu2JBarnx+2iG6jixJCoEJ6YYQ8FpQ00Msc1k2GsHJDYo3Wg3v/7ttpplaNjFRRHdkTAK32YKqog64If4kZk/deHn21
   public_key_fingerprint: 51:b1:a4:2f:9f:b9:13:a3:4a:95:86:16:23:10:02:da
-dropsonde_shared_secret: k19kn3yyzp78qqjw9g3f
 loggregator_ca:
   ca: |
     -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
This property was used to sign envelopes going from metron to doppler via UDP. Loggregator removed the `shared_secret` a couple versions ago. 

This PR cleans up remnants of `shared_secret` left in cf-deployment.