### PR TITLE
Remove nsync and stager to mirror cf-deployment

### DIFF
--- a/operations/experimental/enable-bpm.yml
+++ b/operations/experimental/enable-bpm.yml
@@ -48,10 +48,6 @@
   value: true
 
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=nsync/properties/bpm?/enabled?
-  value: true
-
-- type: replace
   path: /instance_groups/name=scheduler/jobs/name=tps/properties/bpm?/enabled?
   value: true
 
@@ -61,10 +57,6 @@
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cc_uploader/properties/bpm?/enabled?
-  value: true
-
-- type: replace
-  path: /instance_groups/name=api/jobs/name=stager/properties/bpm?/enabled?
   value: true
 
 - type: replace


### PR DESCRIPTION
The enable-bpm.yml file was not working since it referred to both nsync and stager jobs which have been removed from the cf-deployment.yml

[#152080813] 

- Anoop & Andrew
