### PR TITLE
Include iso-seg cell DNS record in use-bosh-dns.yml

### DIFF
--- a/operations/experimental/use-bosh-dns.yml
+++ b/operations/experimental/use-bosh-dns.yml
@@ -14,6 +14,7 @@
           _.cell.service.cf.internal:
           - _.diego-cell.default.cf.bosh
           - _.windows-cell.default.cf.bosh
+          - _.isolated-diego-cell.default.cf.bosh
           auctioneer.service.cf.internal:
           - '*.scheduler.default.cf.bosh'
           bbs.service.cf.internal:


### PR DESCRIPTION
- This adds a DNS alias so diego can talk to the iso-seg cell
- Won't hurt anything in non-iso seg environments

[#152045213]

Signed-off-by: Eric Promislow <eric.promislow@suse.com>