### PR TITLE
Create an ASG rule for credhub

### DIFF
--- a/operations/experimental/secure-service-credentials.yml
+++ b/operations/experimental/secure-service-credentials.yml
@@ -83,6 +83,21 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/credhub_api?/ca_cert
   value: ((credhub_tls.ca))
+# Note: these groups are only created on the first deploy, groups must be created manually for existing envs
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/security_group_definitions?/-
+  value:
+    name: credhub
+    rules:
+    - destination: 0.0.0.0/0
+      ports: '8844'
+      protocol: tcp
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_running_security_groups?/-
+  value: credhub
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_staging_security_groups?/-
+  value: credhub
 - type: replace
   path: /variables/-
   value:


### PR DESCRIPTION
- Since the latest recommended approach is to have apps talk directly to
  credhub's internal IP, CF requires an Application Security Group for
  credhub
- Specifying ASGs in the manifest only works on fresh deploys, adding
  this ops file to an existing env will require adding the ASG manually

[#152045213]

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>