### PR TITLE
Use windows2016fs-online-release for windows 2016 rootfs

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -44,4 +44,4 @@ and the ops-files will be removed.
 | [`use-bosh-dns-for-containers.yml`](use-bosh-dns-for-containers.yml) | Sets the DNS server of application containers to the address of the local `bosh-dns` job. | Requires `use-bosh-dns.yml` |
 | [`use-grootfs.yml`](use-grootfs.yml) | Enable grootfs on diego cells. | |
 | [`use-latest-windows2016-stemcell.yml`](use-latest-windows2016-stemcell.yml) | Use the latest `windows2016` stemcell available on your BOSH director instead of the one in `windows2016-cell.yml` | Requires `windows2016-cell.yml` |
-| [`windows2016-cell.yml`](windows2016-cell.yml) | Deploys a windows 2016 diego cell, adds releases necessary for windows. |  |
+| [`windows2016-cell.yml`](windows2016-cell.yml) | Deploys a windows 2016 diego cell, adds releases necessary for windows. | Requires compilation VMs to have internet access. |

--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -24,6 +24,8 @@
       release: winc
     - name: winc-network
       release: winc
+    - name: windows2016fs
+      release: windows2016fs
     - name: garden-windows
       properties:
         garden:
@@ -133,6 +135,14 @@
   type: replace
   value:
     name: winc
-    sha1: 2e91aaa8cb6d0b678e07fd4d8718c46f9b2bb0f1
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/winc-release?v=0.4.0
-    version: 0.4.0
+    sha1: ac219d33a4d3df9f0866c23699e879be75e60562
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/winc-release?v=0.5.0
+    version: 0.5.0
+
+- path: /releases/name=windows2016fs?
+  type: replace
+  value:
+    name: windows2016fs
+    sha1: 7b490aea78f5fb9f53fb9117ca777db9d35672d8
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows2016fs-online-release?v=0.0.1
+    version: 0.0.1


### PR DESCRIPTION
This release downloads the required rootfs (`cloudfoundry/windows2016fs` on Docker hub) and installs it on the `windows2016` cell (previously the image was provided in the stemcell). It requires a CF foundation with internet access.

**Note:** There will be a subsequent PR with support for an *offline* release and we will specify the manual steps required to deploy that in the experimental opsfile `README`