### PR TITLE
Add opsfile to use offline windows2016fs-release

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -44,4 +44,5 @@ and the ops-files will be removed.
 | [`use-bosh-dns-for-containers.yml`](use-bosh-dns-for-containers.yml) | Sets the DNS server of application containers to the address of the local `bosh-dns` job. | Requires `use-bosh-dns.yml` |
 | [`use-grootfs.yml`](use-grootfs.yml) | Enable grootfs on diego cells. | |
 | [`use-latest-windows2016-stemcell.yml`](use-latest-windows2016-stemcell.yml) | Use the latest `windows2016` stemcell available on your BOSH director instead of the one in `windows2016-cell.yml` | Requires `windows2016-cell.yml` |
+| [`use-offline-windows2016fs.yml`](use-offline-windows2016fs.yml) | Use the offline version of [windows2016fs-release](https://github.com/cloudfoundry-incubator/windows2016fs-release) | Requires `windows2016-cell.yml`. Suitable for environments without internet access. Follow instructions [here](https://github.com/cloudfoundry-incubator/windows2016fs-release/blob/master/README.md) to upload the release prior to deploying. |
 | [`windows2016-cell.yml`](windows2016-cell.yml) | Deploys a windows 2016 diego cell, adds releases necessary for windows. |  |

--- a/operations/experimental/use-offline-windows2016fs.yml
+++ b/operations/experimental/use-offline-windows2016fs.yml
@@ -1,0 +1,5 @@
+- path: /releases/name=windows2016fs?
+  type: replace
+  value:
+    name: windows2016fs
+    version: 0.0.13

--- a/scripts/test
+++ b/scripts/test
@@ -127,6 +127,7 @@ test_experimental_ops() {
       fi
       check_interpolation "windows2016-cell.yml"
       check_interpolation "name: operations/windows-cell.yml windows2016-cell.yml" "${home}/operations/windows-cell.yml" "-o windows2016-cell.yml"
+      check_interpolation "name: use-offline-windows2016fs.yml" "windows2016-cell.yml" "-o use-offline-windows2016fs.yml"
     popd > /dev/null # operations/experimental
   popd > /dev/null
 }


### PR DESCRIPTION
Note that the release cannot be hosted on bosh.io. In order to use this
opsfile, a copy of the release must already be uploaded to the director