### PR TITLE
Ops file for deploying garden-runc in oci-phase-1

### DIFF
--- a/operations/experimental/enable-oci-phase-1.yml
+++ b/operations/experimental/enable-oci-phase-1.yml
@@ -1,0 +1,33 @@
+---
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/diego?/temporary_oci_buildpack_mode?
+  value: &temporary_oci_buildpack_mode oci-phase-1
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc?/diego?/temporary_oci_buildpack_mode?
+  value: *temporary_oci_buildpack_mode
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_oci_buildpack_mode?
+  value: *temporary_oci_buildpack_mode
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=grootfs/properties/grootfs/remote_layer_tls?
+  value:
+    cert: ((grootfs_remote_layer_tls.certificate))
+    key: ((grootfs_remote_layer_tls.private_key))
+    ca_cert: ((grootfs_remote_layer_tls.ca))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: grootfs_remote_layer_tls
+    type: certificate
+    options:
+      ca: service_cf_internal_ca
+      common_name: cell.service.cf.internal
+      extended_key_usage:
+      - client_auth
+      - server_auth
+      alternative_names: ["*.cell.service.cf.internal"]
+


### PR DESCRIPTION
Deploying with this operation switches garden to creating images in the OCI compatible format.

[#151724164]