### PR TITLE
Ops file for deploying garden-runc in oci-phase-1

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -46,5 +46,6 @@ and the ops-files will be removed.
 | [`use-bosh-dns-for-containers.yml`](use-bosh-dns-for-containers.yml) | Sets the DNS server of application containers to the address of the local `bosh-dns` job. | Requires `use-bosh-dns.yml` |
 | [`use-bosh-dns-for-windows2016-containers.yml`](use-bosh-dns-for-windows2016-containers.yml) | Sets the DNS server of application containers (on windows2016 cell) to the address of the local `bosh-dns` job. | Requires `use-bosh-dns.yml` |
 | [`use-grootfs.yml`](use-grootfs.yml) | Enable grootfs on diego cells. | |
+| [`enable-oci-phase-1.yml`](enable-oci-phase-1.yml) | Configure Garden to create OCI compatible images. | Requires `use-grootfs.yml` |
 | [`use-latest-windows2016-stemcell.yml`](use-latest-windows2016-stemcell.yml) | Use the latest `windows2016` stemcell available on your BOSH director instead of the one in `windows2016-cell.yml` | Requires `windows2016-cell.yml` |
 | [`windows2016-cell.yml`](windows2016-cell.yml) | Deploys a windows 2016 diego cell, adds releases necessary for windows. | Requires compilation VMs to have internet access. |

--- a/operations/experimental/enable-oci-phase-1.yml
+++ b/operations/experimental/enable-oci-phase-1.yml
@@ -1,0 +1,33 @@
+---
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc?/diego?/temporary_oci_buildpack_mode?
+  value: &temporary_oci_buildpack_mode oci-phase-1
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc?/diego?/temporary_oci_buildpack_mode?
+  value: *temporary_oci_buildpack_mode
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc?/diego?/temporary_oci_buildpack_mode?
+  value: *temporary_oci_buildpack_mode
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=grootfs/properties/grootfs/remote_layer_tls?
+  value:
+    cert: ((grootfs_remote_layer_tls.certificate))
+    key: ((grootfs_remote_layer_tls.private_key))
+    ca_cert: ((grootfs_remote_layer_tls.ca))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: grootfs_remote_layer_tls
+    type: certificate
+    options:
+      ca: service_cf_internal_ca
+      common_name: cell.service.cf.internal
+      extended_key_usage:
+      - client_auth
+      - server_auth
+      alternative_names: ["*.cell.service.cf.internal"]
+

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -33,6 +33,7 @@ test_experimental_ops() {
       check_interpolation "use-bosh-dns-for-containers.yml"
       check_interpolation "name: use-bosh-dns-for-windows2016-containers.yml" "windows2016-cell.yml" "-o use-bosh-dns.yml" "-o use-bosh-dns-for-windows2016-containers.yml"
       check_interpolation "use-grootfs.yml"
+      check_interpolation "name: enable-oci-phase-1.yml" "use-grootfs.yml" "-o enable-oci-phase-1.yml"
       version=$(bosh interpolate ${home}/cf-deployment.yml -o windows2016-cell.yml -o use-latest-windows2016-stemcell.yml --path=/stemcells/alias=windows2016/version)
       if [ "${version}" == "latest" ]; then
         pass "use-latest-windows2016-stemcell.yml"


### PR DESCRIPTION
Deploying with this operation switches garden to creating images in the OCI compatible format.

[#151724164]