### PR TITLE
Remove unused property

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -219,7 +219,6 @@ instance_groups:
     release: cf-mysql
     properties:
       cf_mysql:
-        external_host: "((system_domain))"
         proxy:
           api_password: "((cf_mysql_proxy_api_password))"
           consul_enabled: true


### PR DESCRIPTION
The property `external_host` was removed from cf-mysql release in v35 - https://github.com/cloudfoundry/cf-mysql-release/releases/tag/v35

The MySQL team recommends using this ops file if you require a route for the proxy - https://github.com/cloudfoundry/cf-mysql-deployment/blob/develop/operations/register-proxy-route.yml