### PR TITLE
Remove superfluous property from postgres ops-file

### DIFF
--- a/operations/use-postgres.yml
+++ b/operations/use-postgres.yml
@@ -17,7 +17,6 @@
     - name: postgres
     properties:
       databases:
-        address: sql-db.service.cf.internal
         databases:
         - citext: true
           name: cloud_controller


### PR DESCRIPTION
`databases.address` is not a property anywhere in the postgres spec: https://github.com/cloudfoundry/postgres-release/blob/develop/jobs/postgres/spec