### PR TITLE
Add enable bosh-ssh to windows2016 opsfile

### DIFF
--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -88,6 +88,8 @@
         syslog_daemon_config:
           enable: false
       release: loggregator
+    - name: enable_ssh
+      release: windows-utilities
     name: windows2016-cell
     networks:
     - name: default
@@ -144,3 +146,11 @@
     sha1: 7b490aea78f5fb9f53fb9117ca777db9d35672d8
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows2016fs-online-release?v=0.0.1
     version: 0.0.1
+
+- path: /releases/name=windows-utilities?
+  type: replace
+  value:
+    name: windows-utilities
+    sha1: 2b2cd7e3544804ca15bc7b843d59324c34ee933d
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows-utilities-release?v=0.4.0
+    version: 0.4.0

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -105,7 +105,7 @@
     sha1: 2bf457f3c18cd8586f183d84cac31a9571dec559
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/garden-windows-bosh-release?v=0.10.0
     version: 0.10.0
-- path: /releases/-
+- path: /releases/name=windows-utilities?
   type: replace
   value:
     name: windows-utilities


### PR DESCRIPTION
Uses the [windows-utilities-release](https://github.com/cloudfoundry-incubator/windows-utilities-release) to enable the experimental BOSH ssh feature on windows cells (2012R2 and 2016 separately).