### PR TITLE
Rename GrootFS BOSH properties

### DIFF
--- a/operations/experimental/enable-oci-phase-1.yml
+++ b/operations/experimental/enable-oci-phase-1.yml
@@ -12,7 +12,7 @@
   value: *temporary_oci_buildpack_mode
 
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=grootfs/properties/grootfs/remote_layer_tls?
+  path: /instance_groups/name=diego-cell/jobs/name=grootfs/properties/tls?
   value:
     cert: ((grootfs_remote_layer_tls.certificate))
     key: ((grootfs_remote_layer_tls.private_key))

--- a/operations/experimental/use-grootfs.yml
+++ b/operations/experimental/use-grootfs.yml
@@ -3,6 +3,7 @@
   value:
     name: grootfs
     properties:
+      tls:
     release: grootfs
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/image_plugin?

--- a/operations/experimental/use-grootfs.yml
+++ b/operations/experimental/use-grootfs.yml
@@ -3,12 +3,6 @@
   value:
     name: grootfs
     properties:
-      grootfs:
-        driver: overlay-xfs
-        graph_cleanup_threshold_in_mb: 0
-        log_level: debug
-        persistent_image_list:
-        - /var/vcap/packages/cflinuxfs2/rootfs.tar
     release: grootfs
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/image_plugin?


### PR DESCRIPTION
`grootfs.remote_layer_tls.*` got renamed to `tls.*` in GrootFS [v0.29.0](https://github.com/cloudfoundry/grootfs-release/releases/tag/v0.29.0).