### PR TITLE
router does not need to skip ssl validation

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -873,7 +873,6 @@ instance_groups:
     release: routing
     properties:
       router:
-        ssl_skip_validation: true
         enable_ssl: true
         tls_pem:
         - cert_chain: "((router_ssl.certificate))"


### PR DESCRIPTION
this property override is no longer necessary for CATS or RATS to pass.

[#152444671]