### PR TITLE
Remove quota definitions

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -665,13 +665,6 @@ instance_groups:
         internal_api_password: "((cc_internal_api_password))"
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"
-        quota_definitions:
-          default:
-            memory_limit: 102400
-            non_basic_services_allowed: true
-            total_routes: 1000
-            total_services: -1
-            total_reserved_route_ports: 100
         buildpacks: &blobstore-properties
           blobstore_type: webdav
           webdav_config:


### PR DESCRIPTION
capi release contains a default value as of this commit: https://github.com/cloudfoundry/capi-release/commit/c686a4a27112eb0f9749210138e9b6fd5de427bd

Note: Do not merge this PR until cf-deployment bumps capi-release to version 1.45