### PR TITLE
Switch addon test to use example vars

### DIFF
--- a/operations/addons/example-vars-files/vars-enable-component-syslog.yml
+++ b/operations/addons/example-vars-files/vars-enable-component-syslog.yml
@@ -1,0 +1,6 @@
+---
+syslog_address: papertrail-address.com
+syslog_port: 5473
+syslog_transport: tcp
+syslog_fallback_servers: []
+syslog_custom_rule: ""

--- a/scripts/test-addons-ops.sh
+++ b/scripts/test-addons-ops.sh
@@ -6,7 +6,7 @@ test_addons_ops() {
 
   pushd ${home} > /dev/null
     pushd operations/addons > /dev/null
-      check_interpolation "enable-component-syslog.yml" "-v syslog_address=papertrail-address.com" "-v syslog_port=5473" "-v syslog_transport=tcp" "-v syslog_fallback_servers=[]" "-v syslog_custom_rule=\"\""
+      check_interpolation "enable-component-syslog.yml" "-l example-vars-files/vars-enable-component-syslog.yml"
     popd > /dev/null # operations/addons
   popd > /dev/null
   exit $exit_code


### PR DESCRIPTION
I wanted a nice example to use as a vars file in CI,
(the cf-deployment-concourse-tasks require files,
not command line arguments)
but none existed.

Now one does!

Other interpolation tests use vars files,
and now this one does too!