### PR TITLE
Use bosh-dns-aliases to allow pre-existing BOSH DNS addons

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -1,6 +1,6 @@
 # cf-deployment Experimental Ops-files
 
-This is the README for Experimental Ops-files. To learn more about `cf-deployment`, go to the main [README](../README.md). 
+This is the README for Experimental Ops-files. To learn more about `cf-deployment`, go to the main [README](../README.md).
 
 - For general Ops-files, check out the [Ops-file README](../README.md).
 - For Legacy Ops-files, check out the [Legacy Ops-file README](../legacy/README.md).
@@ -50,7 +50,8 @@ and the ops-files will be removed.
 | [`secure-service-credentials-postgres.yml`](secure-service-credentials-postgres.yml) | Use local postgres database for CredHub data store. | Requires `secure-service-credentials.yml` and `use-postgres.yml`. |
 | [`skip-consul-cell-registrations.yml`](skip-consul-cell-registrations.yml) | Configure the BBS to only use Locket to find registered Diego cells | |
 | [`skip-consul-locks.yml`](skip-consul-locks.yml) | Prevent several components from also attempting to claim a lock in Consul | |
-| [`use-bosh-dns.yml`](use-bosh-dns.yml) | Adds `bosh-dns` job to all instance groups running ubuntu-trusty via Bosh Addon. | Aliases `service.cf.internal` domains to their `bosh-dns` equivalents. |
+| [`use-bosh-dns.yml`](use-bosh-dns.yml) | Adds `bosh-dns` job to all instance groups running ubuntu-trusty via Bosh Addon. Assumes BOSH environment does not have `runtime-config` adding `bosh-dns` job to all instances. | Aliases `service.cf.internal` domains to their `bosh-dns` equivalents. |
+| [`use-bosh-dns-aliases.yml`](use-bosh-dns-aliases.yml) | Alternative to `use-bosh-dns.yml` when BOSH environment has `runtime-config` to add `bosh-dns` job to all instance. | Aliases `service.cf.internal` domains to their `bosh-dns` equivalents. |
 | [`use-bosh-dns-for-containers.yml`](use-bosh-dns-for-containers.yml) | Sets the DNS server of application containers to the address of the local `bosh-dns` job. | Requires `use-bosh-dns.yml` |
 | [`use-bosh-dns-for-windows2016-containers.yml`](use-bosh-dns-for-windows2016-containers.yml) | Sets the DNS server of application containers (on windows2016 cell) to the address of the local `bosh-dns` job. | Requires `use-bosh-dns.yml` |
 | [`use-grootfs.yml`](use-grootfs.yml) | Enable grootfs on diego cells. | |

--- a/operations/experimental/use-bosh-dns-aliases.yml
+++ b/operations/experimental/use-bosh-dns-aliases.yml
@@ -1,0 +1,290 @@
+---
+- type: replace
+  path: /addons?/-
+  value:
+    name: cf-dns-aliases
+    include:
+      stemcell:
+      - os: ubuntu-trusty
+    jobs:
+    - name: bosh-dns-aliases
+      release: bosh-dns-aliases
+      properties:
+        aliases:
+        - domain: _.cell.service.cf.internal
+          targets:
+          - target: '_.diego-cell.default.cf.bosh'
+          - target: '_.windows-cell.default.cf.bosh'
+          - target: '_.windows2016-cell.default.cf.bosh'
+          - target: '_.isolated-diego-cell.default.cf.bosh'
+        - domain: auctioneer.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: bbs.service.cf.internal
+          targets:
+          - target: '*.diego-api.default.cf.bosh'
+        - domain: blobstore.service.cf.internal
+          targets:
+          - target: '*.blobstore.default.cf.bosh'
+          - target: '*.singleton-blobstore.default.cf.bosh'
+        - domain: cc-uploader.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: cf-etcd.service.cf.internal
+          targets:
+          - target: '*.etcd.default.cf.bosh'
+        - domain: cloud-controller-ng.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: consul.service.cf.internal
+          targets:
+          - target: '*.consul.default.cf.bosh'
+        - domain: credhub.service.cf.internal
+          targets:
+          - target: '*.credhub.default.cf.bosh'
+        - domain: doppler.service.cf.internal
+          targets:
+          - target: '*.doppler.default.cf.bosh'
+        - domain: file-server.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: gorouter.service.cf.internal
+          targets:
+          - target: '*.router.default.cf.bosh'
+        - domain: locket.service.cf.internal
+          targets:
+          - target: '*.diego-api.default.cf.bosh'
+        - domain: loggregator-trafficcontroller.service.cf.internal
+          targets:
+          - target: '*.log-api.default.cf.bosh'
+        - domain: nsync.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: policy-server.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: reverse-log-proxy.service.cf.internal
+          targets:
+          - target: '*.log-api.default.cf.bosh'
+        - domain: routing-api.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: silk-controller.service.cf.internal
+          targets:
+          - target: '*.diego-api.default.cf.bosh'
+        - domain: sql-db.service.cf.internal
+          targets:
+          - target: '*.mysql.default.cf.bosh'
+          - target: '*.postgres.default.cf.bosh'
+          - target: '*.database.default.cf.bosh'
+        - domain: ssh-proxy.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: stager.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: tcp-router.service.cf.internal
+          targets:
+          - target: '*.tcp-router.default.cf.bosh'
+        - domain: tps.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: uaa.service.cf.internal
+          targets:
+          - target: '*.uaa.default.cf.bosh'
+
+- type: replace
+  path: /addons/-
+  value:
+    name: cf-windows2012-dns-aliases
+    include:
+      stemcell:
+      - os: windows2012R2
+    jobs:
+    - name: bosh-dns-aliases
+      release: bosh-dns-aliases
+      properties:
+        aliases:
+        - domain: _.cell.service.cf.internal
+          targets:
+          - _.diego-cell.default.cf.bosh
+          - _.windows-cell.default.cf.bosh
+          - _.windows2016-cell.default.cf.bosh
+          - _.isolated-diego-cell.default.cf.bosh
+        - domain: auctioneer.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: bbs.service.cf.internal
+          targets:
+          - target: '*.diego-api.default.cf.bosh'
+        - domain: blobstore.service.cf.internal
+          targets:
+          - target: '*.blobstore.default.cf.bosh'
+          - target: '*.singleton-blobstore.default.cf.bosh'
+        - domain: cc-uploader.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: cf-etcd.service.cf.internal
+          targets:
+          - target: '*.etcd.default.cf.bosh'
+        - domain: cloud-controller-ng.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: consul.service.cf.internal
+          targets:
+          - target: '*.consul.default.cf.bosh'
+        - domain: credhub.service.cf.internal
+          targets:
+          - target: '*.credhub.default.cf.bosh'
+        - domain: doppler.service.cf.internal
+          targets:
+          - target: '*.doppler.default.cf.bosh'
+        - domain: file-server.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: gorouter.service.cf.internal
+          targets:
+          - target: '*.router.default.cf.bosh'
+        - domain: locket.service.cf.internal
+          targets:
+          - target: '*.diego-api.default.cf.bosh'
+        - domain: loggregator-trafficcontroller.service.cf.internal
+          targets:
+          - target: '*.log-api.default.cf.bosh'
+        - domain: nsync.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: policy-server.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: reverse-log-proxy.service.cf.internal
+          targets:
+          - target: '*.log-api.default.cf.bosh'
+        - domain: routing-api.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: silk-controller.service.cf.internal
+          targets:
+          - target: '*.diego-api.default.cf.bosh'
+        - domain: sql-db.service.cf.internal
+          targets:
+          - target: '*.mysql.default.cf.bosh'
+          - target: '*.postgres.default.cf.bosh'
+          - target: '*.database.default.cf.bosh'
+        - domain: ssh-proxy.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: stager.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: tcp-router.service.cf.internal
+          targets:
+          - target: '*.tcp-router.default.cf.bosh'
+        - domain: tps.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: uaa.service.cf.internal
+          targets:
+          - target: '*.uaa.default.cf.bosh'
+
+- type: replace
+  path: /addons/-
+  value:
+    name: cf-windows2016-dns-aliases
+    include:
+      stemcell:
+      - os: windows2016
+    jobs:
+    - name: bosh-dns-aliases
+      release: bosh-dns-aliases
+      properties:
+        aliases:
+        - domain: _.cell.service.cf.internal
+          targets:
+          - _.diego-cell.default.cf.bosh
+          - _.windows-cell.default.cf.bosh
+          - _.windows2016-cell.default.cf.bosh
+          - _.isolated-diego-cell.default.cf.bosh
+        - domain: auctioneer.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: bbs.service.cf.internal
+          targets:
+          - target: '*.diego-api.default.cf.bosh'
+        - domain: blobstore.service.cf.internal
+          targets:
+          - target: '*.blobstore.default.cf.bosh'
+          - target: '*.singleton-blobstore.default.cf.bosh'
+        - domain: cc-uploader.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: cf-etcd.service.cf.internal
+          targets:
+          - target: '*.etcd.default.cf.bosh'
+        - domain: cloud-controller-ng.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: consul.service.cf.internal
+          targets:
+          - target: '*.consul.default.cf.bosh'
+        - domain: credhub.service.cf.internal
+          targets:
+          - target: '*.credhub.default.cf.bosh'
+        - domain: doppler.service.cf.internal
+          targets:
+          - target: '*.doppler.default.cf.bosh'
+        - domain: file-server.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: gorouter.service.cf.internal
+          targets:
+          - target: '*.router.default.cf.bosh'
+        - domain: locket.service.cf.internal
+          targets:
+          - target: '*.diego-api.default.cf.bosh'
+        - domain: loggregator-trafficcontroller.service.cf.internal
+          targets:
+          - target: '*.log-api.default.cf.bosh'
+        - domain: nsync.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: policy-server.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: reverse-log-proxy.service.cf.internal
+          targets:
+          - target: '*.log-api.default.cf.bosh'
+        - domain: routing-api.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: silk-controller.service.cf.internal
+          targets:
+          - target: '*.diego-api.default.cf.bosh'
+        - domain: sql-db.service.cf.internal
+          targets:
+          - target: '*.mysql.default.cf.bosh'
+          - target: '*.postgres.default.cf.bosh'
+          - target: '*.database.default.cf.bosh'
+        - domain: ssh-proxy.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: stager.service.cf.internal
+          targets:
+          - target: '*.api.default.cf.bosh'
+        - domain: tcp-router.service.cf.internal
+          targets:
+          - target: '*.tcp-router.default.cf.bosh'
+        - domain: tps.service.cf.internal
+          targets:
+          - target: '*.scheduler.default.cf.bosh'
+        - domain: uaa.service.cf.internal
+          targets:
+          - target: '*.uaa.default.cf.bosh'
+
+- type: replace
+  path: /releases/-
+  value:
+    name: bosh-dns-aliases
+    version: latest
+    # url: git+https://github.com/cloudfoundry/bosh-dns-aliases-release
+    # version: 0.0.1

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -39,6 +39,7 @@ test_experimental_ops() {
       check_interpolation "skip-consul-cell-registrations.yml"
       check_interpolation "skip-consul-locks.yml"
       check_interpolation "use-bosh-dns.yml"
+      check_interpolation "use-bosh-dns-aliases.yml"
       check_interpolation "use-bosh-dns-for-containers.yml"
       check_interpolation "name: use-bosh-dns-for-windows2016-containers.yml" "windows2016-cell.yml" "-o use-bosh-dns.yml" "-o use-bosh-dns-for-windows2016-containers.yml"
       check_interpolation "use-grootfs.yml"


### PR DESCRIPTION
* [ ] waiting for https://github.com/cloudfoundry/bosh-dns-aliases-release/pull/3 to be accepted/merged
* [ ] waiting for v0.0.2 of https://github.com/cloudfoundry/bosh-dns-aliases-release
* [ ] update PR to use 0.0.2

To test this PR today, you'll need to use a dev release based off  https://github.com/cloudfoundry/bosh-dns-aliases-release/pull/3