### PR TITLE
Add workaround for Diego memory calculation bug

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1094,6 +1094,9 @@ instance_groups:
   - name: rep
     release: diego
     properties:
+      containers:
+        proxy:
+          additional_memory_allocation_mb: 0
       diego:
         rep:
           bbs: *diego_bbs_client_properties

--- a/operations/experimental/enable-routing-integrity.yml
+++ b/operations/experimental/enable-routing-integrity.yml
@@ -3,6 +3,9 @@
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers?/proxy/enabled
   value: true
 
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers?/proxy/additional_memory_allocation_mb
+
 - type: replace
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router/backends?/enable_tls
   value: true

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -27,6 +27,9 @@
       release: garden-windows
     - name: rep_windows
       properties:
+        containers:
+          proxy:
+            additional_memory_allocation_mb: 0
         diego:
           executor:
             ca_certs_for_downloads: ((blobstore_tls.ca))


### PR DESCRIPTION
From the amended [Diego v1.31.0 release notes](https://github.com/cloudfoundry/diego-release/releases/tag/v1.31.0):

> We have identified an issue with the calculation of the memory container metrics in this version of Diego for those cells that do not enable the container proxy (which is the default configuration). For apps with a memory limit under 18 MB, the miscalculation results in reporting a very large number for the container memory usage, which causes `cf push` to fail when checking on the app instance status with an error of the form `Could not fetch instance count: Invalid JSON response from server: json: cannot unmarshal number 18446744073708089344 into Go struct field .Mem of type int64`. We are currently working to address this issue in [story #153655210](https://www.pivotaltracker.com/story/show/153655210) and will include the fix in a new final Diego release as soon as possible.

> As a workaround, operators should set the `containers.proxy.additional_memory_allocation_mb` property to `0` on the `rep` and `rep_windows` jobs on their Diego cells.

This workaround should be reverted once a new final Diego version exists with a fix for this issue and is included in cf-deployment.