### PR TITLE
Allow disable-consul.yml to be used with bosh-lite.yml

### DIFF
--- a/operations/experimental/disable-consul.yml
+++ b/operations/experimental/disable-consul.yml
@@ -39,7 +39,7 @@
   path: /instance_groups/name=scheduler/jobs/name=auctioneer/properties/enable_consul_service_registration?
   value: false
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/enable_consul_service_registration?
+  path: /instance_groups/name=scheduler?/jobs/name=ssh_proxy/properties/enable_consul_service_registration
   value: false
 - type: replace
   path: /instance_groups/name=api/jobs/name=file_server/properties?/enable_consul_service_registration?


### PR DESCRIPTION
Currently they have a dependency on each other.