### PR TITLE
Fixes reference to CA for Route Integrity

### DIFF
--- a/operations/experimental/enable-routing-integrity.yml
+++ b/operations/experimental/enable-routing-integrity.yml
@@ -9,4 +9,4 @@
 
 - type: replace
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router?/ca_certs
-  value: ((application_ca.ca))
+  value: ((application_ca.certificate))


### PR DESCRIPTION
Given the reference is to a CA certificate, the referenced BOSH
variable field needs to be `.certificate` rather than `.ca`.

Note that, while the BOSH CLI will generate the same value for
the two fields when generating root CAs, the same is not true when
working with a CredHub BOSH config server. Specifically, the `.ca`
field is `null` for root CAs.

In this specific case, the `null` value means that the CA certificate
is not rendered for the Gorouter job and, therefore, routing fails
with "526 Invalid SSL Certificate".

Switching to `application_ca.certificate` resolves that issue.

This approach is also in line with the PR/suggestion submitted here:
https://github.com/cloudfoundry/cf-deployment/pull/305