### PR TITLE
Add adapter to rename-network ops-file

### DIFF
--- a/operations/rename-network.yml
+++ b/operations/rename-network.yml
@@ -11,6 +11,10 @@
   value: ((network_name))
 
 - type: replace
+  path: /instance_groups/name=adapter/networks/name=default/name
+  value: ((network_name))
+
+- type: replace
   path: /instance_groups/name=doppler/networks/name=default/name
   value: ((network_name))
 


### PR DESCRIPTION
We are using rename-network.yml ops-file as our network name differs from default. As adapter a separate job now, I beleive is should be added to rename-network.yml ops-file. 