### PR TITLE
Introduce a shutdown delay when running in HA mode

### DIFF
--- a/operations/scale-database-cluster.yml
+++ b/operations/scale-database-cluster.yml
@@ -5,3 +5,6 @@
 - type: replace
   path: /instance_groups/name=database/azs
   value: [z1, z2, z3]
+- type: replace
+  path: /instance_groups/name=database/jobs/name=proxy/properties/cf_mysql/proxy/shutdown_delay?
+  value: 30


### PR DESCRIPTION
 - BOSH DNS polls for health every 20s based on the monit status of an
 instance group. The proxy process should stay healthy for longer than it reports as healthy to
 give it time to be removed from the DNS pool.

Signed-off-by: Nitya Dhanushkodi <ndhanushkodi@pivotal.io>