### PR TITLE
Use gateway for DNS server in windows2016 containers

### DIFF
--- a/operations/experimental/use-bosh-dns-for-windows2016-containers.yml
+++ b/operations/experimental/use-bosh-dns-for-windows2016-containers.yml
@@ -2,4 +2,4 @@
 - type: replace
   path: /instance_groups/name=windows2016-cell/jobs/name=winc-network/properties?/winc_network/dns_servers
   value:
-  - 169.254.0.2
+  - 172.30.0.1


### PR DESCRIPTION
Windows server containers now use 172.30.0.1 as their DNS server instead of 169.254.0.2

This is to enable BOSH DNS for containers via PR: https://github.com/cloudfoundry/bosh-dns-release/pull/14