### PR TITLE
cf-mysql consul properties

### DIFF
--- a/operations/experimental/disable-consul.yml
+++ b/operations/experimental/disable-consul.yml
@@ -10,6 +10,10 @@
 - type: remove
   path: /instance_groups/name=database?/jobs/name=consul_agent
 - type: remove
+  path: /instance_groups/name=database?/jobs/name=proxy/properties/cf_mysql/proxy/consul_enabled
+- type: remove
+  path: /instance_groups/name=database?/jobs/name=proxy/properties/cf_mysql/proxy/consul_service_name
+- type: remove
   path: /instance_groups/name=diego-api/jobs/name=consul_agent
 - type: remove
   path: /instance_groups/name=uaa/jobs/name=consul_agent


### PR DESCRIPTION
Disabling consul for cf-mysql requires a few more changes. The base manifest [enables consul](https://github.com/cloudfoundry/cf-deployment/blob/43e9eb3fa9ab4f1e16659f6ec8f38811e12023a9/cf-deployment.yml#L212) for the mysql proxy, which we do not want in a deployment without consul.

This PR removes the consul specific properties from the proxy job.