### PR TITLE
Update version of backup and restore sdk

### DIFF
--- a/operations/experimental/enable-backup-restore.yml
+++ b/operations/experimental/enable-backup-restore.yml
@@ -3,9 +3,9 @@
     path: /releases/-
     value:
       name: backup-and-restore-sdk
-      url: https://bosh.io/d/github.com/cloudfoundry-incubator/backup-and-restore-sdk-release?v=1.3.0
-      version: 1.3.0
-      sha1: 03ddf5b41f1f594b735f104f5151b47696d7a19a
+      url: https://bosh.io/d/github.com/cloudfoundry-incubator/backup-and-restore-sdk-release?v=1.4.0
+      version: 1.4.0
+      sha1: 4eea4ee0902a11c88a7d83ed106d5e33d0a6686f
 
   - type: replace
     path: /instance_groups/-


### PR DESCRIPTION
New version has support for MySQL 5.5, 5.6 and 5.7