### PR TITLE
Update windows opsfile release versions

### DIFF
--- a/operations/experimental/use-offline-windows2016fs.yml
+++ b/operations/experimental/use-offline-windows2016fs.yml
@@ -2,4 +2,4 @@
   type: replace
   value:
     name: windows2016fs
-    version: 0.0.17
+    version: 0.0.20

--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -130,30 +130,30 @@
   type: replace
   value:
     name: hwc-buildpack
-    sha1: 8f00fbd534a59137b02514127a685408e723f199
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=2.3.11
-    version: 2.3.11
+    sha1: 7f5e6b499ae718ed858d5847190d760dda035714
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=2.3.12
+    version: 2.3.12
 
 - path: /releases/name=winc?
   type: replace
   value:
     name: winc
-    sha1: f9b7f917cd38336717c22c6dae5fcaf0fef3fca7
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/winc-release?v=0.6.0
-    version: 0.6.0
+    sha1: aa6a601adfc54fb9cf9f4200bacf86a4caef2317
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/winc-release?v=0.7.0
+    version: 0.7.0
 
 - path: /releases/name=windows2016fs?
   type: replace
   value:
     name: windows2016fs
-    sha1: 018f2ff24d6f1feaf0366f61e81d803e0bba4d30
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows2016fs-online-release?v=0.0.5
-    version: 0.0.5
+    sha1: f49dd8b947e6f17f81cfb9e77ebfc2a51fb1c6b7
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows2016fs-online-release?v=0.0.7
+    version: 0.0.7
 
 - path: /releases/name=windows-utilities?
   type: replace
   value:
     name: windows-utilities
-    sha1: 2b2cd7e3544804ca15bc7b843d59324c34ee933d
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows-utilities-release?v=0.4.0
-    version: 0.4.0
+    sha1: 71f5617ad2a63a558968854fc20e5fc71b033ebd
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows-utilities-release?v=0.5.0
+    version: 0.5.0

--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -111,9 +111,9 @@
   path: /releases/name=windows-utilities?
   value:
     name: windows-utilities
-    sha1: 2b2cd7e3544804ca15bc7b843d59324c34ee933d
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows-utilities-release?v=0.4.0
-    version: 0.4.0
+    sha1: 71f5617ad2a63a558968854fc20e5fc71b033ebd
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows-utilities-release?v=0.5.0
+    version: 0.5.0
 - type: replace
   path: /stemcells/-
   value:


### PR DESCRIPTION
Updates opsfiles for `windows2016` and `windows2012R2` cells