### PR TITLE
fix enable-service-discovery.yml

### DIFF
--- a/operations/experimental/enable-service-discovery.yml
+++ b/operations/experimental/enable-service-discovery.yml
@@ -62,7 +62,7 @@
       - client_auth
     type: certificate
 - type: replace
-  path: /releases/-
+  path: /releases/name=cf-app-sd?
   value:
     name: cf-app-sd
     sha1: d0a22be980ddf2e0484489208c7de7719c6a0c30


### PR DESCRIPTION
- only create a new release named cf-app-sd if one does
  not already exist

[#154971628]

Signed-off-by: Amelia Downs <adowns@pivotal.io>