### PR TITLE
Add VM type from bosh-deployment cloud config to bosh lite

### DIFF
--- a/iaas-support/bosh-lite/cloud-config.yml
+++ b/iaas-support/bosh-lite/cloud-config.yml
@@ -17,6 +17,11 @@ disk_types:
   name: 10GB
 - disk_size: 100240
   name: 100GB
+# Note: the "default" disk type is not used in cf-deployment.
+# it is included for compatibility with the bosh-deployment
+# cloud-config.
+- disk_size: 1024
+  name: default
 networks:
 - name: default
   subnets:

--- a/iaas-support/bosh-lite/cloud-config.yml
+++ b/iaas-support/bosh-lite/cloud-config.yml
@@ -57,3 +57,7 @@ vm_types:
 - name: minimal
 - name: small
 - name: small-highmem
+# Note: the "default" vm type is not used in cf-deployment.
+# it is included for compatibility with the bosh-deployment
+# cloud-config.
+- name: default


### PR DESCRIPTION
_As a PM working on a deployment that interacts with cf-deployment,_
_${PM_PERSONA_NAME} would like to be able to use bosh-lite for acceptance without extra steps_
_so that she can accept stories without spending time fixing her environment_

The bosh-lite cloud config [present](https://github.com/cloudfoundry/bosh-deployment/blob/master/warden/cloud-config.yml) in the bosh-deployment repo and specified in the bosh lite [docs](https://bosh.io/docs/bosh-lite) specifies a `default` VM and disk type. These are also present in the bbl cloud config, though cf-deployment doesn't use them.

This PR adds them here, so that work done targeting the default bosh-lite config can coexist on a bosh-lite with cf-d without additional steps on the part of the user.