### PR TITLE
Update consul service_ttl to keep positive DNS results longer

### DIFF
--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -17,7 +17,7 @@
         consul:
           agent:
             dns_config:
-              service_ttl: 10s
+              service_ttl: 60s
             node_name_includes_id: true
         syslog_daemon_config:
           enable: false


### PR DESCRIPTION
In some scenarios where the size of the cell is small and there are
concurrent DNS resolutions happening (e.g., running WATS in parallel),
we've noticed that the file-server.cf.internal name was not getting
resolved in time, leading to failed DNS lookups. This fixes this
scenario by making DNS cache entries live longer during the CPU spikes.
