### PR TITLE
Update vcap de-duplication rule

### DIFF
--- a/operations/addons/enable-component-syslog.yml
+++ b/operations/addons/enable-component-syslog.yml
@@ -11,7 +11,7 @@
           address: ((syslog_address))
           custom_rule: |
             ((syslog_custom_rule))
-            if ($programname startswith "vcap.") then ~
+            if ($programname startswith "vcap.") then stop
           fallback_servers: ((syslog_fallback_servers))
           port: ((syslog_port))
           transport: ((syslog_transport))


### PR DESCRIPTION
Uses stop instead of ~ because Discard(~) is deprecated. 

http://www.rsyslog.com/doc/master/compatibility/v7compatibility.html#omruleset-and-discard-action-are-deprecated

[#155194490]