### PR TITLE
Use groot on windows

### DIFF
--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -29,14 +29,14 @@
         groot:
           cached_image_uris:
             - oci:///C:/var/vcap/packages/windows2016fs
-          driver_store: "c:\\var\\vcap\\data\\groot"
+          driver_store: "/var/vcap/data/groot"
     - name: garden-windows
       properties:
         garden:
           destroy_containers_on_start: true
           image_plugin: /var/vcap/packages/groot/groot.exe
           image_plugin_extra_args:
-          - --driver-store="c:\\var\\vcap\\data\\groot"
+          - --driver-store=/var/vcap/data/groot
           - --config=/var/vcap/jobs/groot/config/groot.yml
           listen_address: 127.0.0.1:9241
           network_plugin: /var/vcap/packages/winc-network/winc-network.exe
@@ -46,7 +46,7 @@
           nstar_bin: /var/vcap/packages/nstar/nstar.exe
           runtime_plugin: /var/vcap/packages/winc/winc.exe
           runtime_plugin_extra_args:
-          - --image-store="c:\\var\\vcap\\data\\groot"
+          - --image-store=/var/vcap/data/groot
       release: garden-runc
     - name: rep_windows
       properties:

--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -138,9 +138,9 @@
   path: /releases/name=winc?
   value:
     name: winc
-    sha1: 6a43f75228f44eb2571db9e952821e19d6ff8048
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/winc-release?v=0.8.0
-    version: 0.8.0
+    sha1: b1d7188deaf273e5e4c6b83cf65742eb4fd3b3f8
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/winc-release?v=1.0.0
+    version: 1.0.0
 - type: replace
   path: /releases/name=windows2016fs?
   value:

--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -45,8 +45,6 @@
           - --log=/var/vcap/sys/log/winc-network/winc-network.log
           nstar_bin: /var/vcap/packages/nstar/nstar.exe
           runtime_plugin: /var/vcap/packages/winc/winc.exe
-          runtime_plugin_extra_args:
-          - --image-store=/var/vcap/data/groot
       release: garden-runc
     - name: rep_windows
       properties:

--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -29,14 +29,14 @@
         groot:
           cached_image_uris:
             - oci:///C:/var/vcap/packages/windows2016fs
-          driver_store: /var/vcap/data/groot
+          driver_store: "c:\\var\\vcap\\data\\groot"
     - name: garden-windows
       properties:
         garden:
           destroy_containers_on_start: true
           image_plugin: /var/vcap/packages/groot/groot.exe
           image_plugin_extra_args:
-          - --driver-store=/var/vcap/data/groot
+          - --driver-store="c:\\var\\vcap\\data\\groot"
           - --config=/var/vcap/jobs/groot/config/groot.yml
           listen_address: 127.0.0.1:9241
           network_plugin: /var/vcap/packages/winc-network/winc-network.exe
@@ -46,7 +46,7 @@
           nstar_bin: /var/vcap/packages/nstar/nstar.exe
           runtime_plugin: /var/vcap/packages/winc/winc.exe
           runtime_plugin_extra_args:
-          - --image-store=/var/vcap/data/groot
+          - --image-store="c:\\var\\vcap\\data\\groot"
       release: garden-runc
     - name: rep_windows
       properties:

--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -147,9 +147,9 @@
   path: /releases/name=windows2016fs?
   value:
     name: windows2016fs
-    sha1: 2acb5eeba5d474ccba404e7a3d74895f0a2f3700
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows2016fs-online-release?v=0.0.11
-    version: 0.0.11
+    sha1: 11448aec0c05e13d99552045637a403df9e610de
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows2016fs-online-release?v=1.0.0
+    version: 1.0.0
 - type: replace
   path: /releases/name=windows-utilities?
   value:

--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -19,19 +19,25 @@
       release: consul
     - name: winc
       release: winc
-    - name: winc-image
-      release: winc
     - name: winc-network
       release: winc
     - name: windows2016fs
       release: windows2016fs
+    - name: groot
+      release: winc
+      properties:
+        groot:
+          cached_image_uris:
+            - oci:///C:/var/vcap/packages/windows2016fs
+          driver_store: /var/vcap/data/groot
     - name: garden-windows
       properties:
         garden:
           destroy_containers_on_start: true
-          image_plugin: /var/vcap/packages/winc-image/winc-image.exe
+          image_plugin: /var/vcap/packages/groot/groot.exe
           image_plugin_extra_args:
-          - --log=/var/vcap/sys/log/winc-image/winc-image.log
+          - --driver-store=/var/vcap/data/groot
+          - --config=/var/vcap/jobs/groot/config/groot.yml
           listen_address: 127.0.0.1:9241
           network_plugin: /var/vcap/packages/winc-network/winc-network.exe
           network_plugin_extra_args:
@@ -39,6 +45,8 @@
           - --log=/var/vcap/sys/log/winc-network/winc-network.log
           nstar_bin: /var/vcap/packages/nstar/nstar.exe
           runtime_plugin: /var/vcap/packages/winc/winc.exe
+          runtime_plugin_extra_args:
+          - --image-store=/var/vcap/data/groot
       release: garden-runc
     - name: rep_windows
       properties:
@@ -56,7 +64,7 @@
               api_location: locket.service.cf.internal:8891
             open_bindmounts_acl: true
             preloaded_rootfses:
-            - windows2016:/var/vcap/packages/windows2016fs/rootfs
+            - windows2016:oci:///C:/var/vcap/packages/windows2016fs
             require_tls: true
             server_cert: ((diego_rep_agent_v2.certificate))
             server_key: ((diego_rep_agent_v2.private_key))


### PR DESCRIPTION
This PR updates the `windows2016-cell` to use `groot-windows` instead of the `winc-image` Garden image plugin (which no longer exists).