### PR TITLE
bbl create-lbs is not a valid command

### DIFF
--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -30,6 +30,10 @@ See [IaaS Support](iaas-support/README.md)
 The CF Routers need a way to receive traffic.
 The most common way to accomplish this is to configure load balancers
 to route traffic to them.
+While we cannot offer help for each IaaS specifically,
+for IaaSes like AWS, GCP, and Azure
+you can use `bbl` to create load balancers
+by running `bbl plan --lb-type cf`.
 
 #### On certificates
 Before you can create your load balancers,

--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -30,11 +30,6 @@ See [IaaS Support](iaas-support/README.md)
 The CF Routers need a way to receive traffic.
 The most common way to accomplish this is to configure load balancers
 to route traffic to them.
-While we cannot offer help for each IaaS specifically,
-for IaaSes like AWS and GCP,
-you can use `bbl` to create load balancers
-by running `bbl create-lbs --type cf --domain <SYSTEM_DOMAIN>`.
-(`bbl` support for creating load balancer on Azure is coming soon.)
 
 #### On certificates
 Before you can create your load balancers,


### PR DESCRIPTION
@genevieve mentioned on Slack that the correct way to do this is to follow the steps listed [here.](https://github.com/cloudfoundry/bosh-bootloader#generic-steps-for-cloud-foundry-deployment)