### PR TITLE
Add bosh-lite iaas-support ops file for softlayer

### DIFF
--- a/iaas-support/softlayer/README.md
+++ b/iaas-support/softlayer/README.md
@@ -1,0 +1,13 @@
+# Deploy Cloud Foundry on a Softlayer Bosh-Lite Director
+
+To deploy Cloud Foundry on a Softlayer VM with a Bosh-Lite director, you will need to follow the default Bosh-Lite instructions with one addition. As the director is public the `system_domain` property cannot be `bosh-lite.com`. You will need to replace the `system_domain` with your own either static or dynamic DNS domain (which should point to the director VM). It is required to deploy Cloud Foundry with the [Bosh-DNS](https://github.com/cloudfoundry/bosh-dns-release) addon and add the alias for you `system_domain`, to resolve the custom domain.
+The updated `create-env` command is the following:
+
+```
+bosh -e <your-bosh-alias> deploy -d cf cf-deployment/cf-deployment.yml \
+    --vars-store deployment-vars.yml \
+    -o cf-deployment/operations/bosh-lite.yml \
+    -o cf-deployment/operations/experimental/use-bosh-dns.yml \
+    -o cf-deployment/iaas-support/softlayer/add-system-domain-dns-alias.yml \
+    -v system_domain=<your-domain>
+```  

--- a/iaas-support/softlayer/add-system-domain-dns-alias.yml
+++ b/iaas-support/softlayer/add-system-domain-dns-alias.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties/aliases/_.((system_domain))?/-
+  value: 10.244.0.34

--- a/scripts/test
+++ b/scripts/test
@@ -72,6 +72,14 @@ test_opsfile_interpolation() {
   done
 }
 
+test_iaas_opsfile_interpolation() {
+  test_iaas_ops &
+
+  for job in $(jobs -p); do
+    wait $job || exit_code=1
+  done
+}
+
 ensure_test_opsfiles_not_in_readme() {
   pushd ${home} > /dev/null
     local opsfiles=$(ls operations/test/*.yml)
@@ -144,6 +152,10 @@ main() {
   echo
   echo -e "${LIGHT_GREEN} ***** Begin interpolation operations tests ***** ${NOCOLOR}"
   test_opsfile_interpolation
+
+  echo
+  echo -e "${LIGHT_GREEN} ***** Begin interpolation iaas operations tests ***** ${NOCOLOR}"
+  test_iaas_opsfile_interpolation
 
   if [ "$RUN_SEMANTIC" == "true" ]; then
     echo

--- a/scripts/test-iaas-ops.sh
+++ b/scripts/test-iaas-ops.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+test_iaas_ops() {
+  # Padded for pretty output
+  suite_name="IaaS      "
+
+  pushd ${home} > /dev/null
+    pushd iaas-support/softlayer > /dev/null
+      check_interpolation "name: add-system-domain-dns-alias.yml" "${home}/operations/experimental/use-bosh-dns.yml -v system_domain=my.domain"
+    popd > /dev/null
+  popd > /dev/null
+  exit $exit_code
+}


### PR DESCRIPTION
In order to resolve a custom bosh-lite system domain - which is required
when deploying bosh-lite on Softlayer - this commit adds a additional
folder "softlayer" to "iaas-support". This includes the specific
ops and a README file with documentation on how to use the ops file and
why it is required.
Additionally, this commit adds interpolation tests for iaas-support ops
files (currently only the Softlayer specific ops file will be tested).

Signed-off-by: Norman Sutorius <norman.sutorius@de.ibm.com>