### PR TITLE
Configure ssh_proxy on BOSH-Lite to skip consul

### DIFF
--- a/operations/experimental/disable-consul-bosh-lite.yml
+++ b/operations/experimental/disable-consul-bosh-lite.yml
@@ -1,3 +1,6 @@
-
 - type: remove
   path: /instance_groups/name=consul
+
+- type: replace
+  path: /instance_groups/name=router/jobs/name=ssh_proxy/properties/enable_consul_service_registration?
+  value: false


### PR DESCRIPTION
This change alters the disable-consul/BOSH-Lite "cross-term" operations file to configure the ssh_proxy job not to register as a Consul service. This configuration is present in the disable-consul operations file but is lost when the bosh-lite operations file adds a separate copy of the ssh_proxy job to the router and removes it from the scheduler. When Consul is actually removed from the CF deployment, the ssh-proxy then logs frequently about its failure to register.