### PR TITLE
Use loggregator v2 api on windows2016

### DIFF
--- a/operations/experimental/windows2016-cell.yml
+++ b/operations/experimental/windows2016-cell.yml
@@ -59,6 +59,11 @@
             preloaded_rootfses:
             - windows2016:oci:///C:/var/vcap/packages/windows2016fs
             require_tls: true
+        loggregator:
+          ca_cert: ((loggregator_ca.certificate))
+          cert: ((loggregator_tls_metron.certificate))
+          key: ((loggregator_tls_metron.private_key))
+          use_v2_api: true
         syslog_daemon_config:
           enable: false
         tls:


### PR DESCRIPTION
Required with Diego v2.1.0 (https://www.pivotaltracker.com/story/show/154748808)