### PR TITLE
Add UAA certificate to application container trusted certs

### DIFF
--- a/operations/experimental/secure-service-credentials.yml
+++ b/operations/experimental/secure-service-credentials.yml
@@ -78,6 +78,7 @@
   value: |
     ((application_ca.certificate))
     ((credhub_ca.certificate))
+    ((uaa_ca.certificate))
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/credhub_api?/ca_cert
   value: ((credhub_ca.certificate))


### PR DESCRIPTION
Applications that are authenticating with CredHub via UAA client credentials need to talk to the UAA in order to get their tokens.

Signed-off-by: Ben Moss <bmoss@pivotal.io>