### PR TITLE
Add experimental ops file to use pxc-release for a mysql database

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -51,6 +51,7 @@ and the ops-files will be removed.
 | [`improve-diego-log-format.yml`](improve-diego-log-format.yml) | Enable human readable format for timestamp (rfc3339) and log level in linux component logs. | Incompatible with `bosh-lite.yml`, which enables this already. |
 | [`improve-diego-log-format-windows.yml`](improve-diego-log-format-windows.yml) | Enable human readable format for timestamp (rfc3339) and log level in Windows 2012 component logs. | Requires `windows-cell.yml` |
 | [`improve-diego-log-format-windows2016.yml`](improve-diego-log-format-windows2016.yml) | Enable human readable format for timestamp (rfc3339) and log level in Windows 2016 component logs. | Requires `windows2016-cell.yml` |
+| [`migrate-cf-mysql-to-pxc.yml`](migrate-cf-mysql-to-pxc.yml) | Migrates from an existing cf-mysql database to [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release). After the migration is complete, switch to the `use-pxc.yml` operations file. | |
 | [`rootless-containers.yml`](rootless-containers.yml) | Enable rootless garden-runc containers. | Requires garden-runc 1.9.5 or later and grootfs 0.27.0 or later. |
 | [`secure-service-credentials.yml`](secure-service-credentials.yml) | Use CredHub for service credentials. | BOSH DNS is required if not using a credhub load balancer. You can add a credhub load balancer with `add-credhub-lb.yml`. |
 | [`secure-service-credentials-windows-cell.yml`](secure-service-credentials-windows-cell.yml) | Adds CredHub TLS CA as a trusted cert to the Windows Cell. | Requires `secure-service-credentials.yml`. |

--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -66,6 +66,7 @@ and the ops-files will be removed.
 | [`use-bosh-dns-rename-network-and-deployment.yml`](use-bosh-dns-rename-network-and-deployment.yml) | Adds `bosh-dns` job to all instance groups running ubuntu-trusty via Bosh Addon, and renames network and deployment in domain aliases. | |
 | [`use-grootfs.yml`](use-grootfs.yml) | Groot is enabled by default. This file is blank to avoid breaking deployment scripts. | |
 | [`use-log-cache.yml`](use-log-cache.yml) | Adds the [Log Cache Release](https://github.com/cloudfoundry/log-cache-release) for logs and metrics. | |
+| [`use-pxc.yml`](use-pxc.yml) | Uses the [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release) instead of the [cf-mysql-release](https://github.com/cloudfoundry/cf-mysql-release/) as the internal mysql database. This ops-file is for clean-installs of cf or for redeploying cf already running pxc. It's not for migrating from cf-mysql-release. | | 
 | [`use-shed.yml`](use-shed.yml) | Enable deprecated garden-shed on diego cells. | |
 | [`use-silk-release.yml`](use-silk-release.yml) | Use [Silk Release](https://github.com/cloudfoundry/silk-release) as the container networking plugin. |  |
 | [`use-silk-release-external-db.yml`](use-silk-release-external-db.yml) | Use [Silk Release](https://github.com/cloudfoundry/silk-release) with an external database. | Requires `use-external-dbs.yml` and `use-silk-release.yml`. The required order is `use-external-dbs.yml`, `use-silk-release.yml`, and finally `use-silk-release-external-db.yml`|

--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -1,0 +1,113 @@
+---
+- type: replace
+  path: /releases/-
+  value:
+    name: pxc
+    version: 0.2.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.2.0
+    sha: 79c576f4682243f471000ab2901b863bb3cd4d30
+
+- type: replace
+  path: /releases/name=cf-mysql
+  value:
+    name: cf-mysql
+    url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.12.0
+    version: 36.12.0
+    sha1: 401cd27775423ee6b3a6e53e89010261c17e0c5c
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql_enabled?
+  value: false
+
+- type: replace
+  path: /instance_groups/name=database/instances
+  value: 1
+
+- type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
+    name: mysql-clustered
+    properties:
+      pxc_enabled: true
+      admin_password: "((cf_mysql_mysql_admin_password))"
+      binlog_enabled: false
+      cluster_health:
+        password: "((cf_mysql_mysql_cluster_health_password))"
+      galera_agent:
+        db_password: "((cf_mysql_mysql_galera_healthcheck_password))"
+        endpoint_username: galera_healthcheck
+        endpoint_password: "((cf_mysql_mysql_galera_healthcheck_endpoint_password))"
+      port: 13306
+      seeded_databases:
+      - name: cloud_controller
+        username: cloud_controller
+        password: "((cc_database_password))"
+      - name: diego
+        username: diego
+        password: "((diego_database_password))"
+      - name: network_connectivity
+        username: network_connectivity
+        password: "((network_connectivity_database_password))"
+      - name: network_policy
+        username: network_policy
+        password: "((network_policy_database_password))"
+      - name: routing-api
+        username: routing-api
+        password: "((routing_api_database_password))"
+      - name: uaa
+        username: uaa
+        password: "((uaa_database_password))"
+      - name: locket
+        username: locket
+        password: "((locket_database_password))"
+      tls:
+        galera: ((galera_server_certificate))
+        server: ((mysql_server_certificate))
+    release: pxc
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=proxy/release
+  value: pxc
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=proxy/properties
+  value:
+    api_password: "((cf_mysql_proxy_api_password))"
+    consul_enabled: true
+    consul_service_name: "sql-db"
+
+- type: replace
+  path: /variables/-
+  value:
+    name: pxc_galera_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: pxc_galera_ca
+
+- type: replace
+  path: /variables/-
+  value:
+    name: pxc_server_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: pxc_server_ca
+
+- type: replace
+  path: /variables/-
+  value:
+    name: galera_server_certificate
+    type: certificate
+    options:
+      ca: pxc_galera_ca
+      extended_key_usage: [ "server_auth", "client_auth" ]
+
+- type: replace
+  path: /variables/-
+  value:
+    name: mysql_server_certificate
+    type: certificate
+    options:
+      ca: pxc_server_ca
+      common_name: "sql-db.service.cf.internal"

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -1,10 +1,11 @@
+---
 - type: replace
   path: /releases/name=cf-mysql
   value:
     name: pxc
-    version: 0.1.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.1.0
-    sha: af9dc9f7218b1abff77f873e37cf465387ed9172
+    version: 0.2.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.2.0
+    sha: 79c576f4682243f471000ab2901b863bb3cd4d30
 
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql/name
@@ -64,7 +65,7 @@
     consul_service_name: "sql-db"
 
 - type: replace
-  path: /variables?/-
+  path: /variables/-
   value:
     name: pxc_galera_ca
     type: certificate
@@ -73,7 +74,7 @@
       common_name: pxc_galera_ca
 
 - type: replace
-  path: /variables?/-
+  path: /variables/-
   value:
     name: pxc_server_ca
     type: certificate
@@ -82,7 +83,7 @@
       common_name: pxc_server_ca
 
 - type: replace
-  path: /variables?/-
+  path: /variables/-
   value:
     name: galera_server_certificate
     type: certificate
@@ -91,7 +92,7 @@
       extended_key_usage: [ "server_auth", "client_auth" ]
 
 - type: replace
-  path: /variables?/-
+  path: /variables/-
   value:
     name: mysql_server_certificate
     type: certificate

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -1,0 +1,100 @@
+- type: replace
+  path: /releases/name=cf-mysql
+  value:
+    name: pxc
+    version: 0.1.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.1.0
+    sha: af9dc9f7218b1abff77f873e37cf465387ed9172
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=mysql/name
+  value: mysql-clustered
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=mysql-clustered/release
+  value: pxc
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=mysql-clustered?/properties
+  value:
+    admin_password: "((cf_mysql_mysql_admin_password))"
+    port: 33306
+    binlog_enabled: false
+    cluster_health:
+      password: "((cf_mysql_mysql_cluster_health_password))"
+    galera_agent:
+      db_password: "((cf_mysql_mysql_galera_healthcheck_password))"
+      endpoint_username: galera_healthcheck
+      endpoint_password: "((cf_mysql_mysql_galera_healthcheck_endpoint_password))"
+    seeded_databases:
+    - name: cloud_controller
+      username: cloud_controller
+      password: "((cc_database_password))"
+    - name: diego
+      username: diego
+      password: "((diego_database_password))"
+    - name: network_connectivity
+      username: network_connectivity
+      password: "((network_connectivity_database_password))"
+    - name: network_policy
+      username: network_policy
+      password: "((network_policy_database_password))"
+    - name: routing-api
+      username: routing-api
+      password: "((routing_api_database_password))"
+    - name: uaa
+      username: uaa
+      password: "((uaa_database_password))"
+    - name: locket
+      username: locket
+      password: "((locket_database_password))"
+    tls:
+      galera: ((galera_server_certificate))
+      server: ((mysql_server_certificate))
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=proxy/release
+  value: pxc
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=proxy/properties
+  value:
+    api_password: "((cf_mysql_proxy_api_password))"
+    consul_enabled: true
+    consul_service_name: "sql-db"
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: pxc_galera_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: pxc_galera_ca
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: pxc_server_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: pxc_server_ca
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: galera_server_certificate
+    type: certificate
+    options:
+      ca: pxc_galera_ca
+      extended_key_usage: [ "server_auth", "client_auth" ]
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: mysql_server_certificate
+    type: certificate
+    options:
+      ca: pxc_server_ca
+      common_name: "sql-db.service.cf.internal"

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -48,6 +48,7 @@ test_experimental_ops() {
       check_interpolation "use-bosh-dns-rename-network-and-deployment.yml" "-v network_name=new-network" "-v deployment_name=new-deployment"
       check_interpolation "use-shed.yml"
       check_interpolation "use-pxc.yml"
+      check_interpolation "migrate-cf-mysql-to-pxc.yml"
       check_interpolation "use-grootfs.yml"
       check_interpolation "enable-oci-phase-1.yml"
       check_interpolation "name: enable-routing-integrity.yml" "enable-routing-integrity.yml" "-o enable-instance-identity-credentials.yml"

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -47,6 +47,7 @@ test_experimental_ops() {
       check_interpolation "name: use-bosh-dns-for-containers-with-silk-release.yml" "use-bosh-dns.yml" "-o use-silk-release.yml" "-o use-bosh-dns-for-containers-with-silk-release.yml"
       check_interpolation "use-bosh-dns-rename-network-and-deployment.yml" "-v network_name=new-network" "-v deployment_name=new-deployment"
       check_interpolation "use-shed.yml"
+      check_interpolation "use-pxc.yml"
       check_interpolation "use-grootfs.yml"
       check_interpolation "enable-oci-phase-1.yml"
       check_interpolation "name: enable-routing-integrity.yml" "enable-routing-integrity.yml" "-o enable-instance-identity-credentials.yml"


### PR DESCRIPTION
* This is for a clean install case where cf-mysql-release was never
used. Ops files for upgrading from cf-mysql-release are coming soon.

[#156242645]

Signed-off-by: Joseph Palermo <jpalermo@pivotal.io>