### PR TITLE
Bump bits-service to version 1.6.0

### DIFF
--- a/operations/experimental/bits-service.yml
+++ b/operations/experimental/bits-service.yml
@@ -94,6 +94,6 @@
   path: /releases/-
   value:
     name: bits-service
-    version: 1.4.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=1.4.0
-    sha1: caa55a888046c2898063fabf0bb19c650ff9a618
+    version: 1.5.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=1.5.0
+    sha1: c9e53e2cdfb0efcf180ade8a1669584657e67293

--- a/operations/experimental/bits-service.yml
+++ b/operations/experimental/bits-service.yml
@@ -94,6 +94,6 @@
   path: /releases/-
   value:
     name: bits-service
-    version: 1.5.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=1.5.0
-    sha1: c9e53e2cdfb0efcf180ade8a1669584657e67293
+    version: 1.6.0
+    url: https://github.com/cloudfoundry-incubator/bits-service-release/releases/download/1.6.0/bits-service-1.6.0.tgz
+    sha1: b763c2aac41f2563a991e9b34a1472e3a0b65270


### PR DESCRIPTION
This release includes a more complete set of metrics emitted to statsd.