### PR TITLE
Correct vsphere cloud config cloud_properties section

### DIFF
--- a/iaas-support/vsphere/cloud-config-vars.yml
+++ b/iaas-support/vsphere/cloud-config-vars.yml
@@ -1,5 +1,6 @@
 z1_cluster: 
 z1_resource_pool: 
+z1_datacenter_name: 
 z1_network_name: 
 z1_network_gateway: 
 z1_network_dns_array: []
@@ -8,6 +9,7 @@ z1_network_reserved_array: []
 
 z2_cluster: 
 z2_resource_pool: 
+z2_datacenter_name: 
 z2_network_name: 
 z2_network_gateway: 
 z2_network_dns_array: []
@@ -16,6 +18,7 @@ z2_network_reserved_array: []
 
 z3_cluster: 
 z3_resource_pool: 
+z3_datacenter_name: 
 z3_network_name: 
 z3_network_gateway: 
 z3_network_dns_array: []

--- a/iaas-support/vsphere/cloud-config.yml
+++ b/iaas-support/vsphere/cloud-config.yml
@@ -5,19 +5,22 @@ azs:
     datacenters:
     - clusters:
       - ((z1_cluster)):
-          resource-pool: ((z1_resource_pool))
+          resource_pool: ((z1_resource_pool))
+      name: ((z1_datacenter_name))
 - name: z2
   cloud_properties:
     datacenters:
     - clusters:
       - ((z2_cluster)):
-          resource-pool: ((z2_resource_pool))
+          resource_pool: ((z2_resource_pool))
+      name: ((z2_datacenter_name))
 - name: z3
   cloud_properties:
     datacenters:
     - clusters:
       - ((z3_cluster)):
-          resource-pool: ((z3_resource_pool))
+          resource_pool: ((z3_resource_pool))
+      name: ((z3_datacenter_name))
 
 networks:
 - name: default


### PR DESCRIPTION
As per: http://bosh.io/docs/vsphere-cpi.html#azs

- changed `resource-pool` to `resource_pool`
- added the required datacenter name field