### PR TITLE
Disable incoming udp for windows2012R2 metron agent

### DIFF
--- a/operations/windows-cell.yml
+++ b/operations/windows-cell.yml
@@ -81,6 +81,7 @@
               key: ((loggregator_tls_metron.private_key))
         metron_agent:
           deployment: ((system_domain))
+          disable_udp: true
         syslog_daemon_config:
           enable: false
       release: loggregator


### PR DESCRIPTION
Now that loggregator v2 is enabled by default we can remove the ability to talk to metron via UDP. This change is only required for windows2012R2 as there is no network isolation between apps and BOSH jobs.