### PR TITLE
operations: Custom S3 provider for blobstore

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -23,6 +23,8 @@ This is the README for Ops-files. To learn more about `cf-deployment`, go to the
 | **Openstack** | | |
 | [`openstack.yml`](openstack.yml) | Used for deploying Cloud Foundry on OpenStack with BOSH | See [OpenStack](../iaas-support/openstack/README.md) documentation. |
 | [`use-swift-blobstore.yml`](use-swift-blobstore.yml) | Replaces local WebDAV blobstore with OpenStack swift blobstore. Used for deploying Cloud Foundry on OpenStack with BOSH | Introduces [new variables](example-vars-files/vars-use-swift-blobstore.yml) for OpenStack credentials and directory names. If you plan using the [Swift ops file](use-swift-blobstore.yml) to enable Swift as blobstore for the Cloud Controller, you should also run the [Swift extension](https://github.com/cloudfoundry-incubator/cf-openstack-validator/tree/master/extensions/object_storage). |
+| **S3-compatible** | | |
+| [`use-s3-custom-blobstore.yml`](use-s3-custom-blobstore.yml) | Replaces local WebDAV blobstore with external s3 blobstore. | Introduces [new variables](example-vars-files/vars-use-s3-custom-blobstore.yml) for s3 credentials, bucket names, etc. |
 
 
 ## Feature-based Ops-files

--- a/operations/example-vars-files/vars-use-s3-custom-blobstore.yml
+++ b/operations/example-vars-files/vars-use-s3-custom-blobstore.yml
@@ -1,0 +1,10 @@
+aws_region: us-east-1
+blobstore_access_key_id: example-access-key-id
+blobstore_secret_access_key: example-secret-access-key
+app_package_directory_key: example-app-package-directory-key
+buildpack_directory_key: example-buildpack-directory-key
+droplet_directory_key: example-droplet-directory-key
+resource_directory_key: example-resource-directory-key
+s3_host: 10.10.10.10
+s3_endpoint: http://10.10.10.10:9000
+s3_path_style: true

--- a/operations/use-s3-custom-blobstore.yml
+++ b/operations/use-s3-custom-blobstore.yml
@@ -1,0 +1,194 @@
+---
+- type: remove
+  path: /instance_groups/name=singleton-blobstore
+
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool
+
+- type: remove
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks
+- type: remove
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets
+- type: remove
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages
+- type: remove
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool
+
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/fog_connection?
+  value: &blobstore-properties
+    provider: AWS
+    aws_access_key_id: ((blobstore_access_key_id))
+    aws_secret_access_key: ((blobstore_secret_access_key))
+    region: ((aws_region))
+    host: ((s3_host))
+    endpoint: ((s3_endpoint))
+    path_style: ((s3_path_style))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/webdav_config?
+  value: &webdav_config
+    public_endpoint: blobstore.((system_domain))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/webdav_config?
+  value: *webdav_config
+
+# replace s3 bucket names
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/buildpack_directory_key?
+  value: ((buildpack_directory_key))
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/droplet_directory_key?
+  value: ((droplet_directory_key))
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/app_package_directory_key?
+  value: ((app_package_directory_key))
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/resource_directory_key?
+  value: ((resource_directory_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/buildpack_directory_key?
+  value: ((buildpack_directory_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/droplet_directory_key?
+  value: ((droplet_directory_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/app_package_directory_key?
+  value: ((app_package_directory_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/resource_directory_key?
+  value: ((resource_directory_key))
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/buildpack_directory_key?
+  value: ((buildpack_directory_key))
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/droplet_directory_key?
+  value: ((droplet_directory_key))
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/app_package_directory_key?
+  value: ((app_package_directory_key))
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/resource_directory_key?
+  value: ((resource_directory_key))
+
+# remove unnecessary variables for internal blobstore
+
+- type: remove
+  path: /variables/name=blobstore_admin_users_password
+
+- type: remove
+  path: /variables/name=blobstore_secure_link_secret
+
+- type: remove
+  path: /variables/name=blobstore_tls

--- a/scripts/test-standard-ops.sh
+++ b/scripts/test-standard-ops.sh
@@ -54,6 +54,7 @@ test_standard_ops() {
       fi
       check_interpolation "use-postgres.yml"
       check_interpolation "use-s3-blobstore.yml" "-l example-vars-files/vars-use-s3-blobstore.yml"
+      check_interpolation "use-s3-custom-blobstore.yml" "-l example-vars-files/vars-use-s3-custom-blobstore.yml"
       check_interpolation "use-gcs-blobstore.yml" "-l example-vars-files/vars-use-gcs-blobstore.yml"
       check_interpolation "name: use-gcs-blobstore-service-account.yml" "use-gcs-blobstore.yml -o use-gcs-blobstore-service-account.yml -l example-vars-files/vars-use-gcs-blobstore-service-account.yml"
       check_interpolation "use-swift-blobstore.yml" "-l example-vars-files/vars-use-swift-blobstore.yml"


### PR DESCRIPTION
Can be used with non-AWS S3 providers such as minio. Based on operations/use-s3-blobstore.yml.