### PR TITLE
Add common SANs to loggregator-agent

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1452,6 +1452,11 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - metron
+    - agent
+    - localhost
+    - 127.0.0.1
 - name: loggregator_tls_doppler
   type: certificate
   options:


### PR DESCRIPTION
This allows clients of the agent to connect via:

- `localhost`
- `127.0.0.1`
- `agent`
- `metron`

This fixes an issue where the `rep` (via `go-loggregator`) is connecting to the agent and expecting a cert from the agent that has a CN or SAN of `metron`.