### PR TITLE
Update pxc to v0.3.0

### DIFF
--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -90,6 +90,12 @@
     consul_service_name: "sql-db"
 
 - type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
+    name: bootstrap
+    release: pxc
+
+- type: replace
   path: /variables/-
   value:
     name: pxc_galera_ca

--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: pxc
-    version: 0.2.0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.2.0
-    sha: 79c576f4682243f471000ab2901b863bb3cd4d30
+    sha1: e4509d2b76f05aa6fcd83fe2710a5997ff7add92
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.3.0
+    version: 0.3.0
 
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql_enabled?
@@ -16,9 +16,25 @@
   value: 1
 
 - type: replace
+  path: /instance_groups/name=database/jobs/name=mysql/consumes?/mysql
+  value:
+    from: mysql-legacy
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=mysql/provides?/mysql
+  value:
+    as: mysql-legacy
+
+- type: replace
   path: /instance_groups/name=database/jobs/-
   value:
     name: mysql-clustered
+    provides:
+      mysql:
+        as: mysql-clustered
+    consumes:
+      mysql:
+        from: mysql-clustered
     properties:
       pxc_enabled: true
       admin_password: "((cf_mysql_mysql_admin_password))"
@@ -60,6 +76,11 @@
 - type: replace
   path: /instance_groups/name=database/jobs/name=proxy/release
   value: pxc
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=proxy/consumes?/mysql
+  value:
+    from: mysql-clustered
 
 - type: replace
   path: /instance_groups/name=database/jobs/name=proxy/properties

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -2,7 +2,7 @@
   path: /releases/name=cf-mysql
   value:
     name: pxc
-    sha: 79c576f4682243f471000ab2901b863bb3cd4d30
+    sha1: e4509d2b76f05aa6fcd83fe2710a5997ff7add92
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.3.0
     version: 0.3.0
 - type: replace

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -5,12 +5,15 @@
     sha1: e4509d2b76f05aa6fcd83fe2710a5997ff7add92
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.3.0
     version: 0.3.0
+
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql/name
   value: mysql-clustered
+
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql-clustered/release
   value: pxc
+
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql-clustered?/properties
   value:
@@ -48,15 +51,24 @@
     tls:
       galera: ((galera_server_certificate))
       server: ((mysql_server_certificate))
+
 - type: replace
   path: /instance_groups/name=database/jobs/name=proxy/release
   value: pxc
+
 - type: replace
   path: /instance_groups/name=database/jobs/name=proxy/properties
   value:
     api_password: ((cf_mysql_proxy_api_password))
     consul_enabled: true
     consul_service_name: sql-db
+
+- type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
+    name: bootstrap
+    release: pxc
+
 - type: replace
   path: /variables/-
   value:
@@ -65,6 +77,7 @@
       common_name: pxc_galera_ca
       is_ca: true
     type: certificate
+
 - type: replace
   path: /variables/-
   value:
@@ -73,6 +86,7 @@
       common_name: pxc_server_ca
       is_ca: true
     type: certificate
+
 - type: replace
   path: /variables/-
   value:
@@ -83,6 +97,7 @@
       - server_auth
       - client_auth
     type: certificate
+
 - type: replace
   path: /variables/-
   value:


### PR DESCRIPTION
We realized that changing the link types in pxc to `mysql-clustered` caused those consuming those links to remap them using `provides` and `consumes` statements. This is undesirable in the long term so we've revered them back to types of `mysql`. This does mean we must remap the links during the migration do to the now ambiguous two links of type `mysql`. These changes are included in this PR.