### PR TITLE
Rename bits-service URLs from bits-service.* to bits.*

### DIFF
--- a/operations/experimental/bits-service.yml
+++ b/operations/experimental/bits-service.yml
@@ -12,8 +12,8 @@
           client_key: ((cc_tls.private_key))
         droplets: null
         packages: null
-        private_endpoint: https://bits-service.service.cf.internal
-        public_endpoint: https://bits-service.((system_domain))
+        private_endpoint: https://bits.service.cf.internal
+        public_endpoint: https://bits.((system_domain))
         secret: ((bits_service_secret))
         signing_users:
         - password: ((bits_service_signing_password))
@@ -24,20 +24,20 @@
   value:
     name: bits-service
     registration_interval: 20s
-    server_cert_domain_san: https://bits-service.((system_domain))
+    server_cert_domain_san: https://bits.((system_domain))
     tags:
       component: bits-service
     tls_port: 443
     uris:
-    - bits-service.((system_domain))
+    - bits.((system_domain))
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/bits_service?
   value:
     ca_cert: ((service_cf_internal_ca.certificate))
     enabled: true
     password: ((bits_service_signing_password))
-    private_endpoint: https://bits-service.service.cf.internal
-    public_endpoint: https://bits-service.((system_domain))
+    private_endpoint: https://bits.service.cf.internal
+    public_endpoint: https://bits.((system_domain))
     username: admin
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/bits_service?
@@ -45,8 +45,8 @@
     ca_cert: ((service_cf_internal_ca.certificate))
     enabled: true
     password: ((bits_service_signing_password))
-    private_endpoint: https://bits-service.service.cf.internal
-    public_endpoint: https://bits-service.((system_domain))
+    private_endpoint: https://bits.service.cf.internal
+    public_endpoint: https://bits.((system_domain))
     username: admin
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/bits_service?
@@ -54,8 +54,8 @@
     ca_cert: ((service_cf_internal_ca.certificate))
     enabled: true
     password: ((bits_service_signing_password))
-    private_endpoint: https://bits-service.service.cf.internal
-    public_endpoint: https://bits-service.((system_domain))
+    private_endpoint: https://bits.service.cf.internal
+    public_endpoint: https://bits.((system_domain))
     username: admin
 - type: replace
   path: /variables/-
@@ -73,11 +73,11 @@
     name: bits_service_ssl
     options:
       alternative_names:
-      - bits-service.service.cf.internal
+      - bits.service.cf.internal
       - ((system_domain))
       - '*.((system_domain))'
       ca: service_cf_internal_ca
-      common_name: bits-service.service.cf.internal
+      common_name: bits.service.cf.internal
     type: certificate
 - type: replace
   path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/tls?

--- a/operations/experimental/bits-service.yml
+++ b/operations/experimental/bits-service.yml
@@ -74,6 +74,7 @@
     options:
       alternative_names:
       - bits.service.cf.internal
+      - bits-service.service.cf.internal
       - ((system_domain))
       - '*.((system_domain))'
       ca: service_cf_internal_ca

--- a/operations/experimental/enable-bits-service-consul.yml
+++ b/operations/experimental/enable-bits-service-consul.yml
@@ -1,4 +1,4 @@
 ---
 - type: replace
-  path: /instance_groups/name=api/jobs/name=consul_agent/properties/consul/agent/services/bits-service?
+  path: /instance_groups/name=api/jobs/name=consul_agent/properties/consul/agent/services/bits?
   value: {}

--- a/operations/experimental/enable-bits-service-consul.yml
+++ b/operations/experimental/enable-bits-service-consul.yml
@@ -1,4 +1,9 @@
 ---
 - type: replace
   path: /instance_groups/name=api/jobs/name=consul_agent/properties/consul/agent/services/bits?
-  value: {}
+  value:
+    name: bits
+    check:
+      name: dns_health_check
+      script: /var/vcap/jobs/bits-service/bin/dns_health_check
+      interval: 3s

--- a/operations/experimental/use-bosh-dns-rename-network-and-deployment.yml
+++ b/operations/experimental/use-bosh-dns-rename-network-and-deployment.yml
@@ -17,7 +17,7 @@
           - '*.scheduler.((network_name)).((deployment_name)).bosh'
           bbs.service.cf.internal:
           - 'q-s4.diego-api.((network_name)).((deployment_name)).bosh'
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.api.((network_name)).((deployment_name)).bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.((network_name)).((deployment_name)).bosh'
@@ -84,7 +84,7 @@
           - '*.scheduler.((network_name)).((deployment_name)).bosh'
           bbs.service.cf.internal:
           - 'q-s4.diego-api.((network_name)).((deployment_name)).bosh'
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.api.((network_name)).((deployment_name)).bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.((network_name)).((deployment_name)).bosh'
@@ -151,7 +151,7 @@
           - '*.scheduler.((network_name)).((deployment_name)).bosh'
           bbs.service.cf.internal:
           - 'q-s4.diego-api.((network_name)).((deployment_name)).bosh'
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.api.((network_name)).((deployment_name)).bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.((network_name)).((deployment_name)).bosh'

--- a/operations/experimental/use-bosh-dns.yml
+++ b/operations/experimental/use-bosh-dns.yml
@@ -17,7 +17,7 @@
           - '*.scheduler.default.cf.bosh'
           bbs.service.cf.internal:
           - 'q-s4.diego-api.default.cf.bosh'
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.api.default.cf.bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.default.cf.bosh'
@@ -84,7 +84,7 @@
           - '*.scheduler.default.cf.bosh'
           bbs.service.cf.internal:
           - 'q-s4.diego-api.default.cf.bosh'
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.api.default.cf.bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.default.cf.bosh'
@@ -151,7 +151,7 @@
           - '*.scheduler.default.cf.bosh'
           bbs.service.cf.internal:
           - 'q-s4.diego-api.default.cf.bosh'
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.api.default.cf.bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.default.cf.bosh'


### PR DESCRIPTION
`bits-service` as a name for URLs doesn't make a lot of sense, as we're dealing with `bits` and that's what the URL should describe. Also, `bits-service.service.cf.internal` always looked repetitive and silly. Therefore changing it.

This change requires an update in certificates. We decided now is still a better time to make such an invasive change than when it is out of experimental and potentially deployed in many production environments.