### PR TITLE
pxc proxy dashboard and credhub fix

### DIFF
--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -92,8 +92,37 @@
 - type: replace
   path: /instance_groups/name=database/jobs/-
   value:
+    release: routing
+    name: route_registrar
+    consumes:
+      nats: {from: nats, deployment: cf}
+    properties:
+      route_registrar:
+        routes:
+        - name: cf-mysql-proxy
+          port: 8080
+          registration_interval: 10s
+          uris:
+          - &proxy_base_uri proxy.((system_domain))
+          prepend_instance_index: true
+        - name: cf-mysql-proxy-aggregator
+          port: 8082
+          registration_interval: 10s
+          uris:
+          - *proxy_base_uri
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=proxy/properties/api_uri?
+  value: *proxy_base_uri
+
+- type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
     name: bootstrap
     release: pxc
+    consumes:
+      mysql:
+        from: mysql-clustered
 
 - type: replace
   path: /variables/-
@@ -120,6 +149,7 @@
     type: certificate
     options:
       ca: pxc_galera_ca
+      common_name: galera_server_certificate
       extended_key_usage: [ "server_auth", "client_auth" ]
 
 - type: replace
@@ -129,4 +159,4 @@
     type: certificate
     options:
       ca: pxc_server_ca
-      common_name: "sql-db.service.cf.internal"
+      common_name: sql-db.service.cf.internal

--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: pxc
-    sha1: e4509d2b76f05aa6fcd83fe2710a5997ff7add92
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.3.0
-    version: 0.3.0
+    sha1: bd784bb93ffeff62cdec6aeb62ba0fea4eba6f41
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.4.0
+    version: 0.4.0
 
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql_enabled?

--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -88,6 +88,7 @@
     api_password: "((cf_mysql_proxy_api_password))"
     consul_enabled: true
     consul_service_name: "sql-db"
+    api_port: 8083
 
 - type: replace
   path: /instance_groups/name=database/jobs/-
@@ -100,7 +101,7 @@
       route_registrar:
         routes:
         - name: cf-mysql-proxy
-          port: 8080
+          port: 8083
           registration_interval: 10s
           uris:
           - &proxy_base_uri proxy.((system_domain))

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -57,6 +57,8 @@
     api_password: ((cf_mysql_proxy_api_password))
     consul_enabled: true
     consul_service_name: sql-db
+    api_port: 8083
+
 - type: replace
   path: /instance_groups/name=database/jobs/-
   value:
@@ -68,7 +70,7 @@
       route_registrar:
         routes:
         - name: cf-mysql-proxy
-          port: 8080
+          port: 8083
           registration_interval: 10s
           uris:
           - &proxy_base_uri proxy.((system_domain))

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -60,6 +60,32 @@
 - type: replace
   path: /instance_groups/name=database/jobs/-
   value:
+    release: routing
+    name: route_registrar
+    consumes:
+      nats: {from: nats, deployment: cf}
+    properties:
+      route_registrar:
+        routes:
+        - name: cf-mysql-proxy
+          port: 8080
+          registration_interval: 10s
+          uris:
+          - &proxy_base_uri proxy.((system_domain))
+          prepend_instance_index: true
+        - name: cf-mysql-proxy-aggregator
+          port: 8082
+          registration_interval: 10s
+          uris:
+          - *proxy_base_uri
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=proxy/properties/api_uri?
+  value: *proxy_base_uri
+
+- type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
     name: bootstrap
     release: pxc
 - type: replace
@@ -84,6 +110,7 @@
     name: galera_server_certificate
     options:
       ca: pxc_galera_ca
+      common_name: galera_server_certificate
       extended_key_usage:
       - server_auth
       - client_auth


### PR DESCRIPTION
This makes the proxy dashboard available at `proxy.SYSTEM_DOMAIN` so operators can see the number of connections to the database.

There are also two fixes included:
- The `common_name` was not specified for the internal galera server certificate, which is needed when generated by credhub. 
- The `bootstrap` errand job needs the `mysql` link to be specified when performing the migration since there are two jobs that supply it.
