### PR TITLE
Add an opsfile to enable perm service

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -40,6 +40,7 @@ and the ops-files will be removed.
 | [`enable-instance-identity-credentials-windows.yml`](enable-instance-identity-credentials-windows.yml) | Deprecated and left intentionally blank for backward compatibility. | Identity credentials for `windows2012R2` cells are enabled in `windows-cell.yml` ops file by default. |
 | [`enable-instance-identity-credentials-windows2016.yml`](enable-instance-identity-credentials-windows2016.yml) | Enables identity credentials on the `rep_windows` for Windows 2016 cells. | Requires `operations/windows2016-cell.yml`|
 | [`enable-iptables-logger.yml`](enable-iptables-logger.yml) | Enables iptables logger. | |
+| [`enable-mysql-tls.yml`](enable-mysql-tls.yml) | Enables TLS on the database job | |
 | [`enable-nfs-broker-backup.yml`](enable-nfs-broker-backup.yml) | Deprecated, use equivalent file in `operations/backup-and-restore` | |
 | [`enable-oci-phase-1.yml`](enable-oci-phase-1.yml) | Configure Garden to create OCI compatible images. | |
 | [`enable-prefer-declarative-healthchecks.yml`](enable-prefer-declarative-healthchecks.yml) | Configure the Rep on the diego cells to prefer LRP CheckDefinition (a.k.a declarative healthchecks) over the old Monitor action | |
@@ -54,7 +55,7 @@ and the ops-files will be removed.
 | [`improve-diego-log-format-windows.yml`](improve-diego-log-format-windows.yml) | Enable human readable format for timestamp (rfc3339) and log level in Windows 2012 component logs. | Requires `windows-cell.yml` |
 | [`improve-diego-log-format-windows2016.yml`](improve-diego-log-format-windows2016.yml) | Enable human readable format for timestamp (rfc3339) and log level in Windows 2016 component logs. | Requires `windows2016-cell.yml` |
 | [`migrate-cf-mysql-to-pxc.yml`](migrate-cf-mysql-to-pxc.yml) | Migrates from an existing cf-mysql database to [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release). After the migration is complete, switch to the `use-pxc.yml` operations file. | |
-| [`perm-service.yml`](perm-service.yml) | Deploy CF with [Perm Service](https://github.com/cloudfoundry-incubator/perm) | Requires use-bosh-dns.yml |
+| [`perm-service.yml`](perm-service.yml) | Deploy CF with [Perm Service](https://github.com/cloudfoundry-incubator/perm) | Requires `use-bosh-dns.yml` and `enable-mysql-tls.yml` |
 | [`rootless-containers.yml`](rootless-containers.yml) | Enable rootless garden-runc containers. | Requires garden-runc 1.9.5 or later and grootfs 0.27.0 or later. |
 | [`secure-service-credentials.yml`](secure-service-credentials.yml) | Use CredHub for service credentials. | BOSH DNS is required if not using a credhub load balancer. You can add a credhub load balancer with `add-credhub-lb.yml`. |
 | [`secure-service-credentials-windows-cell.yml`](secure-service-credentials-windows-cell.yml) | Adds CredHub TLS CA as a trusted cert to the Windows Cell. | Requires `secure-service-credentials.yml`. |

--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -54,6 +54,7 @@ and the ops-files will be removed.
 | [`improve-diego-log-format-windows.yml`](improve-diego-log-format-windows.yml) | Enable human readable format for timestamp (rfc3339) and log level in Windows 2012 component logs. | Requires `windows-cell.yml` |
 | [`improve-diego-log-format-windows2016.yml`](improve-diego-log-format-windows2016.yml) | Enable human readable format for timestamp (rfc3339) and log level in Windows 2016 component logs. | Requires `windows2016-cell.yml` |
 | [`migrate-cf-mysql-to-pxc.yml`](migrate-cf-mysql-to-pxc.yml) | Migrates from an existing cf-mysql database to [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release). After the migration is complete, switch to the `use-pxc.yml` operations file. | |
+| [`perm-service.yml`](perm-service.yml) | Deploy CF with [Perm Service](https://github.com/cloudfoundry-incubator/perm) | Requires use-bosh-dns.yml |
 | [`rootless-containers.yml`](rootless-containers.yml) | Enable rootless garden-runc containers. | Requires garden-runc 1.9.5 or later and grootfs 0.27.0 or later. |
 | [`secure-service-credentials.yml`](secure-service-credentials.yml) | Use CredHub for service credentials. | BOSH DNS is required if not using a credhub load balancer. You can add a credhub load balancer with `add-credhub-lb.yml`. |
 | [`secure-service-credentials-windows-cell.yml`](secure-service-credentials-windows-cell.yml) | Adds CredHub TLS CA as a trusted cert to the Windows Cell. | Requires `secure-service-credentials.yml`. |

--- a/operations/experimental/enable-mysql-tls.yml
+++ b/operations/experimental/enable-mysql-tls.yml
@@ -1,0 +1,31 @@
+---
+- type: replace
+  path: /instance_groups/name=database?/jobs/name=mysql/properties/cf_mysql/mysql/tls?/ca_certificate
+  value: ((mysql_server_certificate.ca))
+
+- type: replace
+  path: /instance_groups/name=database?/jobs/name=mysql/properties/cf_mysql/mysql/tls?/server_certificate
+  value: ((mysql_server_certificate.certificate))
+
+- type: replace
+  path: /instance_groups/name=database?/jobs/name=mysql/properties/cf_mysql/mysql/tls?/server_key
+  value: ((mysql_server_certificate.private_key))
+
+
+- type: replace
+  path: /variables/-
+  value:
+    name: pxc_server_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: pxc_server_ca
+
+- type: replace
+  path: /variables/-
+  value:
+    name: mysql_server_certificate
+    type: certificate
+    options:
+      ca: pxc_server_ca
+      common_name: "sql-db.service.cf.internal"

--- a/operations/experimental/perm-service.yml
+++ b/operations/experimental/perm-service.yml
@@ -73,7 +73,7 @@
   path: /releases/-
   value:
     name: perm
-    version: ((perm_version))
+    version: 0.0.1
 
 # Changes to variables
 - type: replace

--- a/operations/experimental/perm-service.yml
+++ b/operations/experimental/perm-service.yml
@@ -61,7 +61,9 @@
   path: /releases/-
   value:
     name: perm
-    version: 0.0.1
+    version: 0.0.4
+    url: https://storage.googleapis.com/perm-releases/perm-release-0.0.4.tgz
+    sha1: e7f8a32765e7508aa3420849992d98d271e81e30
 
 # Changes to variables
 - type: replace

--- a/operations/experimental/perm-service.yml
+++ b/operations/experimental/perm-service.yml
@@ -27,7 +27,7 @@
           tls:
             required: true
             ca_certs:
-            - ((perm-mysql-tls.ca))
+            - ((mysql_server_certificate.ca))
 
 # Changes to other instance groups
 - type: replace
@@ -36,18 +36,6 @@
     name: perm
     password: ((perm-database_password))
     username: perm
-
-- type: replace
-  path: /instance_groups/name=database?/jobs/name=mysql/properties/cf_mysql/mysql/tls?/ca_certificate
-  value: ((perm-mysql-tls.ca))
-
-- type: replace
-  path: /instance_groups/name=database?/jobs/name=mysql/properties/cf_mysql/mysql/tls?/server_certificate
-  value: ((perm-mysql-tls.certificate))
-
-- type: replace
-  path: /instance_groups/name=database?/jobs/name=mysql/properties/cf_mysql/mysql/tls?/server_key
-  value: ((perm-mysql-tls.private_key))
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties?/perm
@@ -96,24 +84,6 @@
       extended_key_usage:
       - client_auth
       - server_auth
-
-- type: replace
-  path: /variables/-
-  value:
-    name: perm-mysql-tls-ca
-    type: certificate
-    options:
-      is_ca: true
-      common_name: perm_mysql_ca
-
-- type: replace
-  path: /variables/-
-  value:
-    name: perm-mysql-tls
-    type: certificate
-    options:
-      ca: perm-mysql-tls-ca
-      common_name: sql-db.service.cf.internal
 
 - type: replace
   path: /variables/-

--- a/operations/experimental/perm-service.yml
+++ b/operations/experimental/perm-service.yml
@@ -1,0 +1,203 @@
+# Perm Service
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: perm
+    instances: 1
+    azs: [z1]
+    vm_type: minimal
+    stemcell: default
+    networks:
+    - name: default
+    jobs:
+    - name: perm
+      release: perm
+      properties:
+        log_level: debug
+        tls: ((perm-tls))
+        sql:
+          db:
+            driver: mysql
+            username: perm
+            password: ((perm-database_password))
+            schema: perm
+            host: sql-db.service.cf.internal
+            port: 3306
+          tls:
+            required: true
+            ca_certs:
+            - ((perm-mysql-tls.ca))
+
+# Changes to other instance groups
+- type: replace
+  path: /instance_groups/name=database?/jobs/name=mysql/properties/cf_mysql/mysql/seeded_databases/-
+  value:
+    name: perm
+    password: ((perm-database_password))
+    username: perm
+
+- type: replace
+  path: /instance_groups/name=database?/jobs/name=mysql/properties/cf_mysql/mysql/tls?/ca_certificate
+  value: ((perm-mysql-tls.ca))
+
+- type: replace
+  path: /instance_groups/name=database?/jobs/name=mysql/properties/cf_mysql/mysql/tls?/server_certificate
+  value: ((perm-mysql-tls.certificate))
+
+- type: replace
+  path: /instance_groups/name=database?/jobs/name=mysql/properties/cf_mysql/mysql/tls?/server_key
+  value: ((perm-mysql-tls.private_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties?/perm
+  value:
+    ca_certs:
+    - ((perm-tls.ca))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/perm?/enabled
+  value: true
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/perm?/query_enabled
+  value: true
+
+- type: replace
+  path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties/aliases/perm.service.cf.internal?
+  value:
+    - "*.perm.default.cf.bosh"
+
+# Changes to releases
+- type: replace
+  path: /releases/-
+  value:
+    name: perm
+    version: ((perm_version))
+
+# Changes to variables
+- type: replace
+  path: /variables/-
+  value:
+    name: perm-tls-ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: perm_ca
+
+- type: replace
+  path: /variables/-
+  value:
+    name: perm-tls
+    type: certificate
+    options:
+      ca: perm-tls-ca
+      common_name: perm.service.cf.internal
+      extended_key_usage:
+      - client_auth
+      - server_auth
+
+- type: replace
+  path: /variables/-
+  value:
+    name: perm-mysql-tls-ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: perm_mysql_ca
+
+- type: replace
+  path: /variables/-
+  value:
+    name: perm-mysql-tls
+    type: certificate
+    options:
+      ca: perm-mysql-tls-ca
+      common_name: sql-db.service.cf.internal
+
+- type: replace
+  path: /variables/-
+  value:
+    name: perm-database_password
+    type: password
+
+
+# Perm Errands
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: perm-drop-database
+    instances: 1
+    azs: [z1]
+    lifecycle: errand
+    vm_type: minimal
+    stemcell: default
+    networks:
+    - name: default
+    jobs:
+    - name: perm-drop-db
+      release: perm
+      properties:
+        sql:
+          db:
+            driver: mysql
+            username: perm
+            password: ((perm-database_password))
+            schema: perm
+            host: sql-db.service.cf.internal
+            port: 3306
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: capi-perm-migrator
+    instances: 1
+    azs: [z1]
+    lifecycle: errand
+    vm_type: minimal
+    stemcell: default
+    networks:
+    - name: default
+    jobs:
+    - name: cc-to-perm-migrator
+      release: perm
+      properties:
+        uaa:
+          hostname: uaa.((system_domain))
+          port: 443
+          ca_certs:
+          - ((router_ssl.ca))
+
+        cloud_controller:
+          hostname: api.((system_domain))
+          port: 443
+          client_id: cloud-controller-monitor
+          client_secret: ((perm_uaa_clients_cloud_controller_monitor_secret))
+          client_scopes:
+          - cloud_controller.admin_read_only
+
+        perm:
+          ca_certs:
+          - ((perm-tls.ca))
+        sql:
+          db:
+            driver: mysql
+            username: perm
+            password: ((perm-database_password))
+            schema: perm
+            host: sql-db.service.cf.internal
+            port: 3306
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa?/clients/cloud-controller-monitor?
+  value:
+    authorities: cloud_controller.admin_read_only
+    authorized-grant-types: client_credentials
+    secret: ((perm_uaa_clients_cloud_controller_monitor_secret))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: perm_uaa_clients_cloud_controller_monitor_secret
+    type: password

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -73,6 +73,8 @@ test_experimental_ops() {
       check_interpolation "improve-diego-log-format.yml"
       check_interpolation "name: improve-diego-log-format-windows.yml" "${home}/operations/windows-cell.yml" "-o improve-diego-log-format-windows.yml"
       check_interpolation "name: improve-diego-log-format-windows2016.yml" "windows2016-cell.yml" "-o improve-diego-log-format-windows2016.yml"
+      check_interpolation "name: perm-service.yml" "use-bosh-dns.yml" "-o perm-service.yml"
+
     popd > /dev/null # operations/experimental
   popd > /dev/null
   exit $exit_code

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -73,7 +73,8 @@ test_experimental_ops() {
       check_interpolation "improve-diego-log-format.yml"
       check_interpolation "name: improve-diego-log-format-windows.yml" "${home}/operations/windows-cell.yml" "-o improve-diego-log-format-windows.yml"
       check_interpolation "name: improve-diego-log-format-windows2016.yml" "windows2016-cell.yml" "-o improve-diego-log-format-windows2016.yml"
-      check_interpolation "name: perm-service.yml" "use-bosh-dns.yml" "-o perm-service.yml"
+      check_interpolation "enable-mysql-tls.yml"
+      check_interpolation "name: perm-service.yml" "use-bosh-dns.yml" "-o enable-mysql-tls.yml" "-o perm-service.yml"
 
     popd > /dev/null # operations/experimental
   popd > /dev/null


### PR DESCRIPTION
**Please do not merge!**

This ops file extends a CF deployment with the experimental PERM service and its related errands.

We'd love some feedback on what you expect from an experimental ops file. For example, at the moment we template in a variable called `perm_version` to allow for continuous change in our pipeline. Would you prefer that this was hardcoded to a particular version for the time being?

Is there any other information you'd like (e.g. a README) as part of this pull request to let others know how to use this ops file?