### PR TITLE
Allow bits-service.* and bits.* for Bits-Service certificate

### DIFF
--- a/operations/experimental/bits-service.yml
+++ b/operations/experimental/bits-service.yml
@@ -73,11 +73,12 @@
     name: bits_service_ssl
     options:
       alternative_names:
+      - bits.service.cf.internal
       - bits-service.service.cf.internal
       - ((system_domain))
       - '*.((system_domain))'
       ca: service_cf_internal_ca
-      common_name: bits-service.service.cf.internal
+      common_name: bits.service.cf.internal
     type: certificate
 - type: replace
   path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/tls?


### PR DESCRIPTION
This is the first step for the migration from bits-service.* URLs to bits.* and requires a recreation of the certificate.

For more context, see: https://github.com/cloudfoundry/cf-deployment/pull/475