### PR TITLE
Move bits-service into a separate VM

### DIFF
--- a/operations/experimental/bits-service-local.yml
+++ b/operations/experimental/bits-service-local.yml
@@ -1,23 +1,23 @@
 ---
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/app_stash
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/app_stash
   value:
     directory_key: cc-resources
     fog_connection: &fog-connection
       provider: "local"
       local_root: "/var/vcap/store/bits-service/"
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/buildpacks
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/buildpacks
   value:
     directory_key: cc-buildpacks
     fog_connection: *fog-connection
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/droplets
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/droplets
   value:
     directory_key: cc-droplets
     fog_connection: *fog-connection
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/packages
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/packages
   value:
     directory_key: cc-packages
     fog_connection: *fog-connection

--- a/operations/experimental/bits-service-s3.yml
+++ b/operations/experimental/bits-service-s3.yml
@@ -1,6 +1,6 @@
 ---
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/app_stash
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/app_stash
   value:
     directory_key: "((resource_directory_key))"
     fog_connection: &aws-config
@@ -9,17 +9,17 @@
       aws_secret_access_key: "((blobstore_secret_access_key))"
       region: "((aws_region))"
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/buildpacks
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/buildpacks
   value:
     directory_key: "((buildpack_directory_key))"
     fog_connection: *aws-config
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/droplets
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/droplets
   value:
     directory_key: "((droplet_directory_key))"
     fog_connection: *aws-config
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/packages
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/packages
   value:
     directory_key: "((app_package_directory_key))"
     fog_connection: *aws-config

--- a/operations/experimental/bits-service-webdav.yml
+++ b/operations/experimental/bits-service-webdav.yml
@@ -1,6 +1,6 @@
 ---
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/app_stash
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/app_stash
   value:
     blobstore_type: webdav
     directory_key: cc-resources
@@ -11,19 +11,19 @@
       public_endpoint: https://blobstore.((system_domain))
       username: blobstore-user
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/buildpacks
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/buildpacks
   value:
     blobstore_type: webdav
     directory_key: cc-buildpacks
     webdav_config: *webdav-config
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/droplets
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/droplets
   value:
     blobstore_type: webdav
     directory_key: cc-droplets
     webdav_config: *webdav-config
 - type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/packages
+  path: /instance_groups/name=bits/jobs/name=bits-service/properties/bits-service/packages
   value:
     blobstore_type: webdav
     directory_key: cc-packages

--- a/operations/experimental/bits-service.yml
+++ b/operations/experimental/bits-service.yml
@@ -1,35 +1,72 @@
 - type: replace
-  path: /instance_groups/name=api/jobs/-
+  path: /instance_groups/name=api:before
   value:
-    name: bits-service
-    properties:
-      bits-service:
-        app_stash: null
-        buildpacks: null
-        cc_updates:
-          ca_cert: ((service_cf_internal_ca.certificate))
-          client_cert: ((cc_tls.certificate))
-          client_key: ((cc_tls.private_key))
-        droplets: null
-        packages: null
-        private_endpoint: https://bits-service.service.cf.internal
-        public_endpoint: https://bits-service.((system_domain))
-        secret: ((bits_service_secret))
-        signing_users:
-        - password: ((bits_service_signing_password))
-          username: admin
-    release: bits-service
-- type: replace
-  path: /instance_groups/name=api/jobs/name=route_registrar/properties/route_registrar/routes/-
-  value:
-    name: bits-service
-    registration_interval: 20s
-    server_cert_domain_san: https://bits-service.((system_domain))
-    tags:
-      component: bits-service
-    tls_port: 443
-    uris:
-    - bits-service.((system_domain))
+    name: bits
+    azs:
+    - z1
+    - z2
+    instances: 2
+    vm_type: small
+    vm_extensions:
+    - 50GB_ephemeral_disk
+    stemcell: default
+    networks:
+    - name: default
+    jobs:
+    - name: consul_agent
+      release: consul
+      consumes:
+        consul_common: {from: consul_common_link}
+        consul_server: nil
+        consul_client: {from: consul_client_link}
+      properties:
+        consul:
+          agent:
+            services: {}
+    - name: route_registrar
+      release: routing
+      properties:
+        route_registrar:
+          routes:
+          - name: bits-service
+            registration_interval: 20s
+            server_cert_domain_san: https://bits-service.((system_domain))
+            tags:
+              component: bits-service
+            tls_port: 443
+            uris:
+            - bits-service.((system_domain))
+    - name: statsd_injector
+      release: statsd-injector
+      properties:
+        loggregator:
+          tls:
+            ca_cert: "((loggregator_ca.certificate))"
+            statsd_injector:
+              cert: "((loggregator_tls_statsdinjector.certificate))"
+              key: "((loggregator_tls_statsdinjector.private_key))"
+    - name: bits-service
+      properties:
+        bits-service:
+          app_stash: null
+          buildpacks: null
+          cc_updates:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            client_cert: ((cc_tls.certificate))
+            client_key: ((cc_tls.private_key))
+          droplets: null
+          packages: null
+          private_endpoint: https://bits-service.service.cf.internal
+          public_endpoint: https://bits-service.((system_domain))
+          secret: ((bits_service_secret))
+          signing_users:
+          - password: ((bits_service_signing_password))
+            username: admin
+          tls:
+            cert: ((bits_service_ssl.certificate))
+            key: ((bits_service_ssl.private_key))
+      release: bits-service
+
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/bits_service?
   value:
@@ -79,11 +116,6 @@
       ca: service_cf_internal_ca
       common_name: bits-service.service.cf.internal
     type: certificate
-- type: replace
-  path: /instance_groups/name=api/jobs/name=bits-service/properties/bits-service/tls?
-  value:
-    cert: ((bits_service_ssl.certificate))
-    key: ((bits_service_ssl.private_key))
 - type: replace
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router/backends?/enable_tls
   value: true

--- a/operations/experimental/enable-bits-service-consul.yml
+++ b/operations/experimental/enable-bits-service-consul.yml
@@ -1,4 +1,4 @@
 ---
 - type: replace
-  path: /instance_groups/name=api/jobs/name=consul_agent/properties/consul/agent/services/bits-service?
+  path: /instance_groups/name=bits/jobs/name=consul_agent/properties/consul/agent/services/bits-service?
   value: {}

--- a/operations/experimental/use-bosh-dns-rename-network-and-deployment.yml
+++ b/operations/experimental/use-bosh-dns-rename-network-and-deployment.yml
@@ -18,7 +18,7 @@
           bbs.service.cf.internal:
           - 'q-s4.diego-api.((network_name)).((deployment_name)).bosh'
           bits-service.service.cf.internal:
-          - '*.api.((network_name)).((deployment_name)).bosh'
+          - '*.bits.((network_name)).((deployment_name)).bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.((network_name)).((deployment_name)).bosh'
           - '*.singleton-blobstore.((network_name)).((deployment_name)).bosh'
@@ -85,7 +85,7 @@
           bbs.service.cf.internal:
           - 'q-s4.diego-api.((network_name)).((deployment_name)).bosh'
           bits-service.service.cf.internal:
-          - '*.api.((network_name)).((deployment_name)).bosh'
+          - '*.bits.((network_name)).((deployment_name)).bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.((network_name)).((deployment_name)).bosh'
           - '*.singleton-blobstore.((network_name)).((deployment_name)).bosh'
@@ -152,7 +152,7 @@
           bbs.service.cf.internal:
           - 'q-s4.diego-api.((network_name)).((deployment_name)).bosh'
           bits-service.service.cf.internal:
-          - '*.api.((network_name)).((deployment_name)).bosh'
+          - '*.bits.((network_name)).((deployment_name)).bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.((network_name)).((deployment_name)).bosh'
           - '*.singleton-blobstore.((network_name)).((deployment_name)).bosh'

--- a/operations/experimental/use-bosh-dns.yml
+++ b/operations/experimental/use-bosh-dns.yml
@@ -18,7 +18,7 @@
           bbs.service.cf.internal:
           - 'q-s4.diego-api.default.cf.bosh'
           bits-service.service.cf.internal:
-          - '*.api.default.cf.bosh'
+          - '*.bits.default.cf.bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.default.cf.bosh'
           - '*.singleton-blobstore.default.cf.bosh'
@@ -85,7 +85,7 @@
           bbs.service.cf.internal:
           - 'q-s4.diego-api.default.cf.bosh'
           bits-service.service.cf.internal:
-          - '*.api.default.cf.bosh'
+          - '*.bits.default.cf.bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.default.cf.bosh'
           - '*.singleton-blobstore.default.cf.bosh'
@@ -152,7 +152,7 @@
           bbs.service.cf.internal:
           - 'q-s4.diego-api.default.cf.bosh'
           bits-service.service.cf.internal:
-          - '*.api.default.cf.bosh'
+          - '*.bits.default.cf.bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.default.cf.bosh'
           - '*.singleton-blobstore.default.cf.bosh'


### PR DESCRIPTION
As discussed with @dsabeti and @staylor14, we're trying to move the Bits-Service to a separate VM to see if memory constraints or similar cause the slow push times. Once we found the root cause, we will try to co-locate the Bits-Service again on `api`.