### PR TITLE
Remove redundant UAA port from Diego SSH-proxy job

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -993,7 +993,6 @@ instance_groups:
           uaa_secret: "((uaa_clients_ssh-proxy_secret))"
           uaa:
             ca_cert: "((uaa_ca.certificate))"
-            port: 8443
           bbs: *diego_bbs_client_properties
       loggregator: *diego_loggregator_client_properties
   - name: scheduler

--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -48,8 +48,6 @@
           enable_cf_auth: true
           host_key: "((diego_ssh_proxy_host_key.private_key))"
           uaa_secret: "((uaa_clients_ssh-proxy_secret))"
-          uaa:
-            port: 8443
           bbs: &5
             ca_cert: "((service_cf_internal_ca.certificate))"
             client_cert: "((diego_bbs_client.certificate))"


### PR DESCRIPTION
Starting with [Diego v2.5.0](https://github.com/cloudfoundry/diego-release/releases/tag/v2.5.0), the default value for this property is 8443, so this manifest property is now redundant.

[#155735780]