### PR TITLE
Add perm.admin scope to the CF CLI admin user

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -413,7 +413,7 @@ instance_groups:
             authorized-grant-types: password,refresh_token
             override: true
             refresh-token-validity: 2592000
-            scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor
+            scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor,perm.admin
             secret: ''
           cloud_controller_username_lookup:
             authorities: scim.userids

--- a/operations/enable-nfs-volume-service.yml
+++ b/operations/enable-nfs-volume-service.yml
@@ -104,9 +104,9 @@
   path: /releases/-
   value:
     name: nfs-volume
-    sha1: 933eb1dc038c8264d82fe3cc227dd844d61845d7
-    url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=1.3.0
-    version: 1.3.0
+    sha1: de807ffa3fc84949bb92edac6a4152245826d6da
+    url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=1.2.0
+    version: 1.2.0
 - type: replace
   path: /releases/-
   value:


### PR DESCRIPTION
Hi,

We want to add `perm.admin` scope in 2 places in the `cf-deployment.yml`, one under `uaa/scim/users/name=admin` and the other to the comma-separated list of scopes under CF CLI admin user.

We can accomplish the former with an opsfile. If we use an opsfile for the latter, we'll have to keep it in sync with `cf-deployment.yml`'s value. 

One way around that is to append the scope in the mainline `cf-deployment.yml` file which this PR illustrates.

Are you okay with us doing it that way, or should we hardcode the long list of existing scopes into the opsfile?
