### PR TITLE
pxc updates

### DIFF
--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -126,28 +126,10 @@
 - type: replace
   path: /variables/-
   value:
-    name: pxc_galera_ca
-    type: certificate
-    options:
-      is_ca: true
-      common_name: pxc_galera_ca
-
-- type: replace
-  path: /variables/-
-  value:
-    name: pxc_server_ca
-    type: certificate
-    options:
-      is_ca: true
-      common_name: pxc_server_ca
-
-- type: replace
-  path: /variables/-
-  value:
     name: galera_server_certificate
     type: certificate
     options:
-      ca: pxc_galera_ca
+      ca: service_cf_internal_ca
       common_name: galera_server_certificate
       extended_key_usage: [ "server_auth", "client_auth" ]
 
@@ -157,5 +139,5 @@
     name: mysql_server_certificate
     type: certificate
     options:
-      ca: pxc_server_ca
+      ca: service_cf_internal_ca
       common_name: sql-db.service.cf.internal

--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: pxc
-    sha1: bd784bb93ffeff62cdec6aeb62ba0fea4eba6f41
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.4.0
-    version: 0.4.0
+    sha1: 4dd970acd8fb059e73d9922adb9cc40206334882
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.6.0
+    version: 0.6.0
 
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql_enabled?

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -85,28 +85,13 @@
   value:
     name: bootstrap
     release: pxc
-- type: replace
-  path: /variables/-
-  value:
-    name: pxc_galera_ca
-    options:
-      common_name: pxc_galera_ca
-      is_ca: true
-    type: certificate
-- type: replace
-  path: /variables/-
-  value:
-    name: pxc_server_ca
-    options:
-      common_name: pxc_server_ca
-      is_ca: true
-    type: certificate
+
 - type: replace
   path: /variables/-
   value:
     name: galera_server_certificate
     options:
-      ca: pxc_galera_ca
+      ca: service_cf_internal_ca
       common_name: galera_server_certificate
       extended_key_usage:
       - server_auth
@@ -117,6 +102,6 @@
   value:
     name: mysql_server_certificate
     options:
-      ca: pxc_server_ca
+      ca: service_cf_internal_ca
       common_name: sql-db.service.cf.internal
     type: certificate

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -5,12 +5,15 @@
     sha1: 4dd970acd8fb059e73d9922adb9cc40206334882
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.6.0
     version: 0.6.0
+
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql/name
   value: mysql-clustered
+
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql-clustered/release
   value: pxc
+
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql-clustered?/properties
   value:
@@ -48,9 +51,11 @@
     tls:
       galera: ((galera_server_certificate))
       server: ((mysql_server_certificate))
+
 - type: replace
   path: /instance_groups/name=database/jobs/name=proxy/release
   value: pxc
+
 - type: replace
   path: /instance_groups/name=database/jobs/name=proxy/properties
   value:
@@ -58,6 +63,7 @@
     api_port: 8083
     consul_enabled: true
     consul_service_name: sql-db
+
 - type: replace
   path: /instance_groups/name=database/jobs/-
   value:
@@ -77,9 +83,11 @@
           uris:
           - proxy.((system_domain))
     release: routing
+
 - type: replace
   path: /instance_groups/name=database/jobs/name=proxy/properties/api_uri?
   value: proxy.((system_domain))
+
 - type: replace
   path: /instance_groups/name=database/jobs/-
   value:
@@ -97,6 +105,7 @@
       - server_auth
       - client_auth
     type: certificate
+
 - type: replace
   path: /variables/-
   value:


### PR DESCRIPTION
- Update pxc version in migration ops file.

- Change pxc certificates to use service_cf_internal_ca CA rather than creating their own.

Any existing deployments will be fine since the certificates won't get recreated. If there is a desire to update an existing deployment, it will need to delete the existing certificate so it is regenerated as well as scale down to a single database instance.