### PR TITLE
Bumped perm to version 0.0.7

### DIFF
--- a/operations/experimental/perm-service.yml
+++ b/operations/experimental/perm-service.yml
@@ -55,9 +55,9 @@
   path: /releases/-
   value:
     name: perm
-    version: 0.0.4
-    url: https://storage.googleapis.com/perm-releases/perm-release-0.0.4.tgz
-    sha1: e7f8a32765e7508aa3420849992d98d271e81e30
+    version: 0.0.7
+    url: https://storage.googleapis.com/perm-releases/perm-release-0.0.7.tgz
+    sha1: f1f7f0b36c1957aabc0dd478829418d04217a8d5
 
 # Changes to variables
 - type: replace


### PR DESCRIPTION
This version solves the incompatibility between perm-release and pxc-release 0.0.6.

NOTE:
- when redeploying this version of perm to an existing environment where perm deployment previously failed, one MUST first drop the "perm_migrations" table.