### PR TITLE
Add perm.admin scope to the CF CLI admin user

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -413,7 +413,7 @@ instance_groups:
             authorized-grant-types: password,refresh_token
             override: true
             refresh-token-validity: 2592000
-            scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor
+            scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor,perm.admin
             secret: ''
           cloud_controller_username_lookup:
             authorities: scim.userids

--- a/operations/experimental/perm-service.yml
+++ b/operations/experimental/perm-service.yml
@@ -31,6 +31,11 @@
 
 # Changes to other instance groups
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/scim/users/name=admin/groups/-
+  value:
+   perm.admin
+
+- type: replace
   path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql/mysql/seeded_databases/-
   value:
     name: perm


### PR DESCRIPTION
This is a resubmit of #495 but this time against the `develop` branch.

Bosh interpolate doesn't provide a great way to append to a string, so we'd like to ask to merge this scope in the mainline `cf-deployment.yml`

When https://github.com/cloudfoundry/uaa-release/pull/89 is merged and the new uaa release makes it into `cf-deployment`, we'll consider putting this into an opsfile.

[#157527204]

Signed-off-by: Nick Wei <nwei@pivotal.io>