### PR TITLE
Bump pxc release to 0.6.0 in migration ops file

### DIFF
--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: pxc
-    sha1: bd784bb93ffeff62cdec6aeb62ba0fea4eba6f41
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.4.0
-    version: 0.4.0
+    sha1: 4dd970acd8fb059e73d9922adb9cc40206334882
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.6.0
+    version: 0.6.0
 
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql_enabled?


### PR DESCRIPTION
The use-pxc ops file gets bumped by Rel Int CI, the migrate ops file does not.

Signed-off-by: Nitya Dhanushkodi <ndhanushkodi@pivotal.io>