### PR TITLE
Update pxc database ports to match cf-mysql port

### DIFF
--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -33,7 +33,7 @@
       db_password: ((cf_mysql_mysql_galera_healthcheck_password))
       endpoint_password: ((cf_mysql_mysql_galera_healthcheck_endpoint_password))
       endpoint_username: galera_healthcheck
-    port: 33306
+    port: 13306
     seeded_databases:
     - name: cloud_controller
       password: ((cc_database_password))


### PR DESCRIPTION
We noticed that the `use-pxc.yml` file was using a different port than `cf-deployment.yml` and the `migrate-cf-mysql-to-pxc.yml` ops file.