### PR TITLE
Make database in blobstore optional in rename-network

### DIFF
--- a/operations/rename-network.yml
+++ b/operations/rename-network.yml
@@ -19,7 +19,7 @@
   value: ((network_name))
 
 - type: replace
-  path: /instance_groups/name=database/networks/name=default/name
+  path: /instance_groups/name=database?/networks/name=default/name
   value: ((network_name))
 
 - type: replace
@@ -31,7 +31,7 @@
   value: ((network_name))
 
 - type: replace
-  path: /instance_groups/name=singleton-blobstore/networks/name=default/name
+  path: /instance_groups/name=singleton-blobstore?/networks/name=default/name
   value: ((network_name))
 
 - type: replace


### PR DESCRIPTION
Database and blobstore can be changed to external by other ops-files (and it's one of our cases). So I think it's better to have corresponding instance_groups optional in `rename-network.yml` ops-file to avoid  
`Expected to find exactly one matching array item for path` errors and too strict ops-files order.