### PR TITLE
 Rename URLs from bits-service.* to bits.*

### DIFF
--- a/operations/experimental/bits-service.yml
+++ b/operations/experimental/bits-service.yml
@@ -24,12 +24,12 @@
           routes:
           - name: bits-service
             registration_interval: 20s
-            server_cert_domain_san: https://bits-service.((system_domain))
+            server_cert_domain_san: https://bits.((system_domain))
             tags:
               component: bits-service
             tls_port: 443
             uris:
-            - bits-service.((system_domain))
+            - bits.((system_domain))
       release: routing
     - name: statsd_injector
       properties:
@@ -51,8 +51,8 @@
             client_key: ((cc_tls.private_key))
           droplets: null
           packages: null
-          private_endpoint: https://bits-service.service.cf.internal
-          public_endpoint: https://bits-service.((system_domain))
+          private_endpoint: https://bits.service.cf.internal
+          public_endpoint: https://bits.((system_domain))
           secret: ((bits_service_secret))
           signing_users:
           - password: ((bits_service_signing_password))
@@ -74,8 +74,8 @@
     ca_cert: ((service_cf_internal_ca.certificate))
     enabled: true
     password: ((bits_service_signing_password))
-    private_endpoint: https://bits-service.service.cf.internal
-    public_endpoint: https://bits-service.((system_domain))
+    private_endpoint: https://bits.service.cf.internal
+    public_endpoint: https://bits.((system_domain))
     username: admin
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/bits_service?
@@ -83,8 +83,8 @@
     ca_cert: ((service_cf_internal_ca.certificate))
     enabled: true
     password: ((bits_service_signing_password))
-    private_endpoint: https://bits-service.service.cf.internal
-    public_endpoint: https://bits-service.((system_domain))
+    private_endpoint: https://bits.service.cf.internal
+    public_endpoint: https://bits.((system_domain))
     username: admin
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/bits_service?
@@ -92,8 +92,8 @@
     ca_cert: ((service_cf_internal_ca.certificate))
     enabled: true
     password: ((bits_service_signing_password))
-    private_endpoint: https://bits-service.service.cf.internal
-    public_endpoint: https://bits-service.((system_domain))
+    private_endpoint: https://bits.service.cf.internal
+    public_endpoint: https://bits.((system_domain))
     username: admin
 - type: replace
   path: /variables/-

--- a/operations/experimental/enable-bits-service-consul.yml
+++ b/operations/experimental/enable-bits-service-consul.yml
@@ -1,4 +1,9 @@
 ---
 - type: replace
-  path: /instance_groups/name=bits/jobs/name=consul_agent/properties/consul/agent/services/bits-service?
-  value: {}
+  path: /instance_groups/name=bits/jobs/name=consul_agent/properties/consul/agent/services/bits?
+  value:
+    name: bits
+    check:
+      name: dns_health_check
+      script: /var/vcap/jobs/bits-service/bin/dns_health_check
+      interval: 3s

--- a/operations/experimental/use-bosh-dns-rename-network-and-deployment.yml
+++ b/operations/experimental/use-bosh-dns-rename-network-and-deployment.yml
@@ -17,7 +17,7 @@
           - '*.scheduler.((network_name)).((deployment_name)).bosh'
           bbs.service.cf.internal:
           - q-s4.diego-api.((network_name)).((deployment_name)).bosh
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.bits.((network_name)).((deployment_name)).bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.((network_name)).((deployment_name)).bosh'
@@ -84,7 +84,7 @@
           - '*.scheduler.((network_name)).((deployment_name)).bosh'
           bbs.service.cf.internal:
           - q-s4.diego-api.((network_name)).((deployment_name)).bosh
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.bits.((network_name)).((deployment_name)).bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.((network_name)).((deployment_name)).bosh'
@@ -151,7 +151,7 @@
           - '*.scheduler.((network_name)).((deployment_name)).bosh'
           bbs.service.cf.internal:
           - q-s4.diego-api.((network_name)).((deployment_name)).bosh
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.bits.((network_name)).((deployment_name)).bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.((network_name)).((deployment_name)).bosh'

--- a/operations/experimental/use-bosh-dns.yml
+++ b/operations/experimental/use-bosh-dns.yml
@@ -17,7 +17,7 @@
           - '*.scheduler.default.cf.bosh'
           bbs.service.cf.internal:
           - q-s4.diego-api.default.cf.bosh
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.bits.default.cf.bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.default.cf.bosh'
@@ -84,7 +84,7 @@
           - '*.scheduler.default.cf.bosh'
           bbs.service.cf.internal:
           - q-s4.diego-api.default.cf.bosh
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.bits.default.cf.bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.default.cf.bosh'
@@ -151,7 +151,7 @@
           - '*.scheduler.default.cf.bosh'
           bbs.service.cf.internal:
           - q-s4.diego-api.default.cf.bosh
-          bits-service.service.cf.internal:
+          bits.service.cf.internal:
           - '*.bits.default.cf.bosh'
           blobstore.service.cf.internal:
           - '*.blobstore.default.cf.bosh'


### PR DESCRIPTION
As discussed with @dsabeti  in https://github.com/cloudfoundry/cf-deployment/pull/475 and specifically in https://github.com/cloudfoundry/cf-deployment/pull/475#issuecomment-386092041, now that certificates allow both `bits.*` and `bits-service.*`, and operators should have re-created these certs as noted in [release notes 1.31.0](https://github.com/cloudfoundry/cf-deployment/releases/tag/v1.31.0), we can actually change the URLs.

@dsabeti I hope this is how you intended this to go. Otherwise, please advise.