### PR TITLE
Include required mapfs job in enable nfs-volume-service.yml

### DIFF
--- a/operations/enable-nfs-volume-service.yml
+++ b/operations/enable-nfs-volume-service.yml
@@ -91,6 +91,11 @@
     properties: {}
     release: nfs-volume
 - type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=mapfs?
+  value:
+    name: mapfs
+    release: mapfs
+- type: replace
   path: /variables/-
   value:
     name: nfs-broker-password
@@ -114,3 +119,10 @@
     sha1: d44d9af8fd06ecf6d50004c9bfd5516a6e482201
     url: https://bosh.io/d/github.com/cloudfoundry-community/broker-registrar-boshrelease?v=3.4.0
     version: 3.4.0
+- type: replace
+  path: /releases/name=mapfs?
+  value:
+    name: mapfs
+    version: 1.0.1
+    url: https://bosh.io/d/github.com/cloudfoundry/mapfs-release?v=1.0.1
+    sha1: 9dcea268d327caff76690229ac09f57a0c83cf65


### PR DESCRIPTION
The mapfs package used to be part of nfs-volume-release, but we started to use it in other contexts, so we factored it out into its own release.  As a result, the nfs ops file needs to pull in mapfs-release and deploy mapfs as a separate (do-nothing) job.  This is similar to the pattern we have already established in cf-cli-release

### commits: 
- modify enable-nfs-volume-service to use the latest nfs release and include the required mapfs job from mapfs-release [#157857957]