### PR TITLE
Allow garden to use containerd

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -76,6 +76,7 @@ and the ops-files will be removed.
 | [`enable-iptables-logger-with-networking-2.yml`](enable-iptables-logger-with-networking-2.yml) | Enable iptables logger when using cf-networking 2.x. | Requires `use-cf-networking-2.yml` |
 | [`use-external-dbs-with-networking-2.yml`](use-external-dbs-with-networking-2.yml) | Updates policy-server and silk-controller to use external dbs when using cf-networking 2.x. | Requires `use-external-dbs.yml` and `use-cf-networking-2.yml` |
 | [`use-postgres-with-networking-2.yml`](use-postgres-with-networking-2.yml) | Updates policy-server and silk-controller to use postgres db when using cf-networking 2.x. | Requires `use-postgres.yml` and `use-cf-networking-2.yml` |
+| [`use-garden-containerd.yml`](use-garden-containerd.yml) | Configure Garden to create containers via containerd. | |
 | [`use-grootfs.yml`](use-grootfs.yml) | Groot is enabled by default. This file is blank to avoid breaking deployment scripts. | |
 | [`use-log-cache.yml`](use-log-cache.yml) | Adds the [Log Cache Release](https://github.com/cloudfoundry/log-cache-release) for logs and metrics. | |
 | [`use-pxc.yml`](use-pxc.yml) | Uses the [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release) instead of the [cf-mysql-release](https://github.com/cloudfoundry/cf-mysql-release/) as the internal mysql database. This ops-file is for clean-installs of cf or for redeploying cf already running pxc. It's not for migrating from cf-mysql-release. | | 

--- a/operations/experimental/use-garden-containerd.yml
+++ b/operations/experimental/use-garden-containerd.yml
@@ -1,0 +1,9 @@
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/-
+  value:
+   name: containerd
+   release: garden-runc
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/experimental_containerd_mode?
+  value: true

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -55,6 +55,7 @@ test_experimental_ops() {
       check_interpolation "migrate-cf-mysql-to-pxc.yml"
       check_interpolation "use-grootfs.yml"
       check_interpolation "enable-oci-phase-1.yml"
+      check_interpolation "use-garden-containerd.yml"
       check_interpolation "name: enable-routing-integrity.yml" "enable-routing-integrity.yml" "-o enable-instance-identity-credentials.yml"
       check_interpolation "name: enable-service-discovery.yml" "use-bosh-dns-for-containers.yml" "-o enable-service-discovery.yml"
       check_interpolation "use-cf-networking-2.yml"


### PR DESCRIPTION
Allows garden to use its experimental containerd mode. When enabled, Garden will create containers via containerd.