### PR TITLE
Make the client id match its definition (dash/underscore)

### DIFF
--- a/operations/experimental/perm-service.yml
+++ b/operations/experimental/perm-service.yml
@@ -138,7 +138,7 @@
           hostname: uaa.((system_domain))
           port: 443
           ca_certs:
-          - ((router_ssl.ca))
+          - ((router_ca.certificate))
 
         cloud_controller:
           hostname: api.((system_domain))

--- a/operations/experimental/perm-service.yml
+++ b/operations/experimental/perm-service.yml
@@ -143,7 +143,7 @@
         cloud_controller:
           hostname: api.((system_domain))
           port: 443
-          client_id: cloud-controller-monitor
+          client_id: cloud_controller_monitor
           client_secret: ((perm_uaa_clients_cloud_controller_monitor_secret))
           client_scopes:
           - cloud_controller.admin_read_only


### PR DESCRIPTION
This bug prevents migrator from working because dashed-client-id does not match underscored_client_id in the other section of the manifest.

[#157952485]