### PR TITLE
switch sha to sha1

### DIFF
--- a/operations/experimental/use-log-cache.yml
+++ b/operations/experimental/use-log-cache.yml
@@ -2,7 +2,7 @@
   path: /releases/-
   value:
     name: log-cache
-    sha: 87134510c23ce5facca665ac025f41a19340f5e9
+    sha1: 2fee0f51c4093091d33eb117202f7476f1a4ebcf
     url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=1.3.0
     version: 1.3.0
 - type: replace


### PR DESCRIPTION
Potential fix for https://github.com/cloudfoundry/cf-deployment/issues/520

SHA1 is from https://bosh.io/releases/github.com/cloudfoundry/log-cache-release?all=1