### PR TITLE
Drop unused locket database link.

### DIFF
--- a/operations/use-external-dbs.yml
+++ b/operations/use-external-dbs.yml
@@ -220,6 +220,3 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=policy-server/consumes?
   value: {database: nil}
-- type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/consumes?
-  value: {database: nil}


### PR DESCRIPTION
Under the latest version of bosh, setting a link that isn't specified in the job spec raises an error, like this: `Job 'locket' in instance group 'diego-api' specifies consumers in the manifest but the job does not define any consumers in the release spec`. This patch drops the unused database link from the locket job in the external database operations file.