### PR TITLE
added a perm monitor client to UAA

### DIFF
--- a/operations/experimental/perm-service.yml
+++ b/operations/experimental/perm-service.yml
@@ -175,6 +175,13 @@
     secret: ((perm_uaa_clients_cc_perm_secret))
 
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/perm_monitor?
+  value:
+    authorities: perm.admin
+    authorized-grant-types: client_credentials
+    secret: ((perm_uaa_clients_perm_monitor_secret))
+
+- type: replace
   path: /variables/-
   value:
     name: perm_uaa_clients_cloud_controller_monitor_secret


### PR DESCRIPTION
In the future, we want to use these client creds to allow perm monitor to access the perm resource server.