### PR TITLE
Support to stemcell version 1018

### DIFF
--- a/iaas-support/alicloud/stemcells.yml
+++ b/iaas-support/alicloud/stemcells.yml
@@ -1,12 +1,5 @@
 ---
 # Light Stemcells
-- type: remove
-  path: /stemcells/alias=default/os?
-
-- type: replace
-  path: /stemcells/alias=default/name?
-  value: bosh-alicloud-kvm-ubuntu-trusty-go_agent
-
 - type: replace
   path: /stemcells/alias=default/version?
-  value: 1016
+  value: 1018


### PR DESCRIPTION
This PR change stemcell version to 1018 and it can support bosh blobstore with alibaba cloud oss.