### PR TITLE
Add cf networking components to pxc opsfiles

### DIFF
--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -178,3 +178,15 @@
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/require_ssl?
   value: true
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/ca_cert?
+  value: ((pxc_server_ca.certificate))
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/require_ssl?
+  value: true
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/ca_cert?
+  value: ((pxc_server_ca.certificate))
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/require_ssl?
+  value: true

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -153,3 +153,15 @@
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/require_ssl?
   value: true
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/ca_cert?
+  value: ((pxc_server_ca.certificate))
+- type: replace
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/database/require_ssl?
+  value: true
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/ca_cert?
+  value: ((pxc_server_ca.certificate))
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/require_ssl?
+  value: true


### PR DESCRIPTION
This PR updates the PXC opsfiles to update policy-server and silk-controller to use TLS connections with PXC.

/cc @tylerschultz 