### PR TITLE
Add UAA TLS

### DIFF
--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -155,6 +155,9 @@
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/address?
   value: sql-db.service.cf.internal
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/address?
+  value: sql-db.service.cf.internal
+- type: replace
   path: /instance_groups/name=api/jobs/name=routing-api/properties/routing_api/sqldb/ca_cert?
   value: ((pxc_server_ca.certificate))
 - type: replace
@@ -177,4 +180,10 @@
   value: ((pxc_server_ca.certificate))
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/require_ssl?
+  value: true
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa?/ca_certs/-
+  value: ((pxc_server_ca.certificate))
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/tls_enabled?
   value: true

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -130,6 +130,9 @@
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/address?
   value: sql-db.service.cf.internal
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/address?
+  value: sql-db.service.cf.internal
+- type: replace
   path: /instance_groups/name=api/jobs/name=routing-api/properties/routing_api/sqldb/ca_cert?
   value: ((pxc_server_ca.certificate))
 - type: replace
@@ -152,4 +155,10 @@
   value: ((pxc_server_ca.certificate))
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/require_ssl?
+  value: true
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa?/ca_certs/-
+  value: ((pxc_server_ca.certificate))
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaadb/tls_enabled?
   value: true


### PR DESCRIPTION
UAA v60 now supports accepting certs for TLS to the DB via a bosh property. This PR enables TLS from UAA to the mysql DB.

It also changes the mysql CA Cert to be referenced through the `mysql_server_certificate` variable's CA property. This is the same CA as the previous `pxc_server_ca` certificate property, but referenced in a way that enables easier CA rotation.