### PR TITLE
Operator to enable 2FA/MFA on default UAA zone

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -30,6 +30,7 @@ and the ops-files will be removed.
 | [`enable-bits-service-consul.yml`](enable-bits-service-consul.yml) | Registers the bits-service [bits-service](https://github.com/cloudfoundry-incubator/bits-service) job via consul | Requires `bits-service.yml` from the same directory. |
 | [`enable-bpm.yml`](enable-bpm.yml) | Enables the [BOSH Process Manager](https://github.com/cloudfoundry-incubator/bpm-release) for several BOSH jobs. | |
 | [`enable-iptables-logger.yml`](enable-iptables-logger.yml) | Enables iptables logger. | |
+| [`enable-mfa-google-auth-default-zone.yml`](enable-mfa-google-auth-default-zone.yml) | Enables mult-factor authentication (MFA) using Google Authenticator/Authy | |
 | [`enable-mysql-tls.yml`](enable-mysql-tls.yml) | Enables TLS on the database job | |
 | [`enable-oci-phase-1.yml`](enable-oci-phase-1.yml) | Configure Garden to create OCI compatible images. | |
 | [`enable-routing-integrity.yml`](enable-routing-integrity.yml) | Enables container proxy on the Diego Cell `rep` and configures gorouter to opt into TLS-enabled connections to the backend. | |

--- a/operations/experimental/enable-mfa-google-auth-default-zone.yml
+++ b/operations/experimental/enable-mfa-google-auth-default-zone.yml
@@ -1,0 +1,11 @@
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login?/mfa
+  value:
+    providers:
+      2fa:
+        type: google-authenticator
+        config:
+          providerDescription: Add google authenticator/authy to the default zone
+          issuer: uaa
+    providerName: 2fa
+    enabled: true

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -55,6 +55,7 @@ test_experimental_ops() {
       check_interpolation "enable-mysql-tls.yml"
       check_interpolation "name: perm-service.yml" "use-bosh-dns.yml" "-o enable-mysql-tls.yml" "-o perm-service.yml -v perm_uaa_clients_cc_perm_secret=perm_secret -v perm_uaa_clients_perm_monitor_secret=perm_monitor_secret"
       check_interpolation "name: perm-service-with-pxc-release.yml" "use-bosh-dns.yml" "-o perm-service.yml" "-o use-pxc.yml" "-o perm-service-with-pxc-release.yml -v perm_uaa_clients_cc_perm_secret=perm_secret -v perm_uaa_clients_perm_monitor_secret=perm_monitor_secret"
+      check_interpolation "enable-mfa-google-auth-default-zone.yml"
     popd > /dev/null # operations/experimental
   popd > /dev/null
   exit $exit_code


### PR DESCRIPTION
New MFA support for UAA looks fantastic. This PR enables it for all CF users (prompted on their next login attempt via `cf` CLI or https://uaa.xxx visit.

```
MFA Code ( Register at https://uaa.cf-ohio.starkandwayne.com )>
```

Similar PR submitted to https://github.com/cloudfoundry/uaa-release/pull/90

/cc @sreetummidi - do these PRs look right to you? Anything missing? (this is what I'm applying to my dev/test CF)