### PR TITLE
Add key_properties nested hash to cf-deployment ops file

### DIFF
--- a/operations/experimental/secure-service-credentials.yml
+++ b/operations/experimental/secure-service-credentials.yml
@@ -52,7 +52,8 @@
           encryption:
             keys:
             - active: true
-              encryption_password: ((credhub_encryption_password))
+              key_properties:
+                encryption_password: ((credhub_encryption_password))
               provider_name: internal-provider
             providers:
             - name: internal-provider


### PR DESCRIPTION
[#158431599] key_properties and connection_properties hashes are necessary

### What is this change about?

Moved the credhub.encryption.keys.encryption_password to be credhub.encryption.keys.key_properties.encryption_password.
This change is needed because Credhub has made the key_properties nested hash necessary.



### Please provide contextual information.

https://www.pivotaltracker.com/story/show/158431599 

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO


### How should this change be described in cf-deployment release notes?

Credhub has made the key_properties nested hash necessary.

### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
@mdelillo 
