### PR TITLE
**BREAKING**: Improve syslog vars

### DIFF
--- a/operations/addons/enable-component-syslog.yml
+++ b/operations/addons/enable-component-syslog.yml
@@ -18,7 +18,7 @@
           port: ((syslog_port))
           transport: tcp
           tls_enabled: true
-          permitted_peer: ((permitted_peer))
+          permitted_peer: ((syslog_permitted_peer))
       release: syslog
     name: syslog_forwarder
 - type: replace

--- a/operations/addons/example-vars-files/vars-enable-component-syslog.yml
+++ b/operations/addons/example-vars-files/vars-enable-component-syslog.yml
@@ -2,8 +2,8 @@
 syslog_address: logN.papertrailapp.com
 syslog_port: 5473
 syslog_fallback_servers: []
+syslog_permitted_peer: '*.papertrailapp.com'
 syslog_custom_rule: ''
-permitted_peer: '*.papertrailapp.com'
 # Note: single quotes work well for a simple single-line rule.
 # However, the yaml `|` multi-line syntax works better
 # for multiple rules, or rules with multiple lines.


### PR DESCRIPTION
### What is this change about?
Consistency in variable names, and some other little cleanup.

Please note that, unfortunately, this is a breaking change. I recommend you go to 3.0 for just this, but hey, not my call.

### Please provide contextual information.
When merging the branch to switch to TLS for syslog, the relint team discovered that permitted peer was necessary to work with Papertrail, and added a variable for it.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO

Cats don't test syslog, though, so.

### How should this change be described in cf-deployment release notes?
- **BREAKING** we've corrected the `permitted_peer` variable used in the `enable-component-syslog.md` ops-file to `syslog_permitted_peer` for consistency with other variable names. You will need to manually move your variables to the new names in your credhub/vars-store.

### Does this PR introduce a breaking change? 
**Yes.**

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
It's just me!

### Add Unsolicited Feedback
I don't like this form, it took longer to fill out than to make the change.
