### PR TITLE
Add a bosh errand to rotate cc encryption keys

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1244,23 +1244,7 @@ instance_groups:
   jobs:
   - name: rotate_cc_database_key
     release: capi
-    properties:
-     cc:
-       db_encryption_key: ((cc_db_encryption_key))
-       mutual_tls:
-         ca_cert: "((service_cf_internal_ca.certificate))"
-         private_key: "((cc_tls.private_key))"
-         public_cert: "((cc_tls.certificate))"
-     ccdb:
-       databases:
-       - name: cloud_controller
-         tag: cc
-       db_scheme: mysql
-       port: 3306
-       roles:
-       - name: cloud_controller
-         password: ((cc_database_password))
-         tag: admin
+    properties: {}
 
 variables:
 - name: blobstore_admin_users_password

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1233,6 +1233,34 @@ instance_groups:
           uris:
           - doppler.((system_domain))
           - "*.doppler.((system_domain))"
+- name: rotate-cc-database-key
+  instances: 1
+  azs: [z1]
+  lifecycle: errand
+  vm_type: minimal
+  stemcell: default
+  networks:
+  - name: default
+  jobs:
+  - name: rotate_cc_database_key
+    release: capi
+    properties:
+     cc:
+       db_encryption_key: ((cc_db_encryption_key))
+       mutual_tls:
+         ca_cert: "((service_cf_internal_ca.certificate))"
+         private_key: "((cc_tls.private_key))"
+         public_cert: "((cc_tls.certificate))"
+     ccdb:
+       databases:
+       - name: cloud_controller
+         tag: cc
+       db_scheme: mysql
+       port: 3306
+       roles:
+       - name: cloud_controller
+         password: ((cc_database_password))
+         tag: admin
 
 variables:
 - name: blobstore_admin_users_password


### PR DESCRIPTION
# Important: this PR depends on the release of capi-release 1.62

### What is this change about?

The cloud controller now supports rotating its database keys by running
`bosh run-errand rotate-cc-database-key`. The CC team believes this 
should be a core feature in CF. This PR defines the errand only.

### Please provide contextual information.

Tracker stories
- [Define the errand](https://www.pivotaltracker.com/story/show/158675271)
- [Key rotation support](https://www.pivotaltracker.com/story/show/157206210)

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO

### How should this change be described in cf-deployment release notes?

We are working on a [story to write the docs for this feature](https://www.pivotaltracker.com/story/show/158734896). The release notes should link to the detailed docs.

### Does this PR introduce a breaking change? 

No.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@ericpromislow @dwfrank @zrob 