### PR TITLE
mysql proxy job uses regular consul service discovery

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -173,6 +173,11 @@ instance_groups:
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
+    properties:
+      consul:
+        agent:
+          services:
+            sql-db: {}
   - name: mysql
     release: cf-mysql
     properties:
@@ -215,8 +220,6 @@ instance_groups:
       cf_mysql:
         proxy:
           api_password: "((cf_mysql_proxy_api_password))"
-          consul_enabled: true
-          consul_service_name: "sql-db"
 - name: diego-api
   migrated_from:
   - name: diego-bbs

--- a/operations/experimental/disable-consul.yml
+++ b/operations/experimental/disable-consul.yml
@@ -12,10 +12,6 @@
 - type: remove
   path: /instance_groups/name=database?/jobs/name=consul_agent
 - type: remove
-  path: /instance_groups/name=database?/jobs/name=proxy/properties/cf_mysql/proxy/consul_enabled
-- type: remove
-  path: /instance_groups/name=database?/jobs/name=proxy/properties/cf_mysql/proxy/consul_service_name
-- type: remove
   path: /instance_groups/name=diego-api/jobs/name=consul_agent
 - type: remove
   path: /instance_groups/name=uaa/jobs/name=consul_agent

--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -78,8 +78,6 @@
   value:
     api_password: ((cf_mysql_proxy_api_password))
     api_port: 8083
-    consul_enabled: true
-    consul_service_name: sql-db
 - type: replace
   path: /instance_groups/name=database/jobs/-
   value:

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -56,8 +56,6 @@
   value:
     api_password: ((cf_mysql_proxy_api_password))
     api_port: 8083
-    consul_enabled: true
-    consul_service_name: sql-db
 - type: replace
   path: /instance_groups/name=database/jobs/-
   value:


### PR DESCRIPTION
### What is this change about?

We are removing outdated consul code from the mysql proxy job. This PR changes cf-deployment to use regular consul service discovery for consul instead of the special code inside the proxy.


### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES 
- [ ] NO



### How should this change be described in cf-deployment release notes?

Update database proxy job to use consul service discovery in a way more consistent with other jobs.

### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [X] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

