### PR TITLE
Override default deployment name in uaa dns alias.

### DIFF
--- a/operations/use-bosh-dns-rename-network-and-deployment.yml
+++ b/operations/use-bosh-dns-rename-network-and-deployment.yml
@@ -233,7 +233,7 @@
           tps.service.cf.internal:
           - '*.scheduler.((network_name)).((deployment_name)).bosh'
           uaa.service.cf.internal:
-          - '*.uaa.((network_name)).cf.bosh'
+          - '*.uaa.((network_name)).((deployment_name)).bosh'
         api:
           client:
             tls:


### PR DESCRIPTION
### What is this change about?

Looks like we missed the deployment name override for the uaa bosh dns alias.

cc @LinuxBozo