### PR TITLE
Experimentally enable BPM in Garden

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1641,9 +1641,9 @@ releases:
   version: "7.0"
   sha1: 5b633a277044f78f333b68da54f804b2384d889d
 - name: cflinuxfs2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.223.0
-  version: 1.223.0
-  sha1: 4a676366e2823898c6c182f8af1b49809da81206
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.224.0
+  version: 1.224.0
+  sha1: c36e6c10010d4bc6dc36adc360f21e5f7d786317
 - name: consul
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/consul-release?v=195
   version: "195"

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -173,6 +173,14 @@ instance_groups:
       consul_common: {from: consul_common_link}
       consul_server: nil
       consul_client: {from: consul_client_link}
+    properties:
+      consul:
+        agent:
+          services:
+            sql-db:
+              check:
+                http: "http://localhost:1936"
+                interval: 3s
   - name: mysql
     release: cf-mysql
     properties:
@@ -215,8 +223,6 @@ instance_groups:
       cf_mysql:
         proxy:
           api_password: "((cf_mysql_proxy_api_password))"
-          consul_enabled: true
-          consul_service_name: "sql-db"
 - name: diego-api
   migrated_from:
   - name: diego-bbs

--- a/iaas-support/bosh-lite/README.md
+++ b/iaas-support/bosh-lite/README.md
@@ -35,36 +35,30 @@ bbl up
 The path to the plan patch should be something like
 `~/workspace/bosh-bootloader/plan-patches/bosh-lite-gcp/`
 
-## 2. Targeting and Logging in
+## 2. Targeting
 
 There a several ways to target a bosh director.
-This doc will use `alias-env` and `-e`,
-but you can set environment variables if you prefer.
+This doc will use environment variables.
 
-First, create an alias for your director:
 ```
-bosh -e $(bbl director-address) --ca-cert <(bbl director-ca-cert) alias-env MY_ENV
-```
-
-Then, log in:
-```
-bosh -e MY_ENV login --client $(bbl director-username) --client-secret $(bbl director-password)
+eval "$(bbl print-env)"
 ```
 
 
 ## 3. Upload a stemcell
+
+With your bosh director targeted:
 ```
 bosh \
--e MY_ENV \
 upload-stemcell \
 https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent
 ```
 
 ## 4. Deploy CF
 
+With your bosh director targeted:
 ```
 bosh \
--e MY_ENV \
 -d cf \
 deploy \
 cf-deployment/cf-deployment.yml \

--- a/iaas-support/bosh-lite/README.md
+++ b/iaas-support/bosh-lite/README.md
@@ -49,9 +49,11 @@ eval "$(bbl print-env)"
 
 With your bosh director targeted:
 ```
+STEMCELL_VERSION=$(bosh interpolate cf-deployment/cf-deployment.yml --path /stemcells/alias=default/version)
+
 bosh \
-upload-stemcell \
-https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent
+  upload-stemcell \
+  https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent?v=${STEMCELL_VERSION}
 ```
 
 ## 4. Deploy CF

--- a/operations/experimental/disable-consul.yml
+++ b/operations/experimental/disable-consul.yml
@@ -12,10 +12,6 @@
 - type: remove
   path: /instance_groups/name=database?/jobs/name=consul_agent
 - type: remove
-  path: /instance_groups/name=database?/jobs/name=proxy/properties/cf_mysql/proxy/consul_enabled
-- type: remove
-  path: /instance_groups/name=database?/jobs/name=proxy/properties/cf_mysql/proxy/consul_service_name
-- type: remove
   path: /instance_groups/name=diego-api/jobs/name=consul_agent
 - type: remove
   path: /instance_groups/name=uaa/jobs/name=consul_agent

--- a/operations/experimental/enable-bpm.yml
+++ b/operations/experimental/enable-bpm.yml
@@ -2,24 +2,61 @@
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/bpm?/enabled?
   value: true
 - type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego?/executor?/garden?/address?
+  value: /var/vcap/data/garden/sockets/garden.sock
+
+- type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=locket/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=auctioneer/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=api/jobs/name=file_server/properties?/bpm?/enabled?
   value: true
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/listen_address?
+  value: /var/vcap/data/garden/sockets/garden.sock
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/bpm?/enabled?
+  value: true
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/network_plugin?
+  value: /var/vcap/packages/netplugin-shim/bin/garden-plugin
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/network_plugin_extra_args?
+  value:
+    - "--socket"
+    - "/var/vcap/data/garden/sockets/network-shim.sock"
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=netplugin-server?
+  value:
+    name: netplugin-server
+    release: garden-runc
+    properties:
+      netplugin-server:
+        plugin_path: "/var/vcap/packages/runc-cni/bin/garden-external-networker"
+        plugin_extra_args:
+          - "--configFile"
+          - "/var/vcap/jobs/garden-cni/config/adapter.json"

--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -78,8 +78,6 @@
   value:
     api_password: ((cf_mysql_proxy_api_password))
     api_port: 8083
-    consul_enabled: true
-    consul_service_name: sql-db
 - type: replace
   path: /instance_groups/name=database/jobs/-
   value:

--- a/operations/experimental/secure-service-credentials.yml
+++ b/operations/experimental/secure-service-credentials.yml
@@ -52,7 +52,8 @@
           encryption:
             keys:
             - active: true
-              encryption_password: ((credhub_encryption_password))
+              key_properties:
+                encryption_password: ((credhub_encryption_password))
               provider_name: internal-provider
             providers:
             - name: internal-provider

--- a/operations/experimental/use-compiled-releases-xenial-stemcell.yml
+++ b/operations/experimental/use-compiled-releases-xenial-stemcell.yml
@@ -81,13 +81,13 @@
   value: bfd4a57a373a8489751ae6304b937a847e5863ae
 - path: /releases/name=cflinuxfs2/url
   type: replace
-  value: https://storage.googleapis.com/cf-deployment-compiled-releases/cflinuxfs2-1.223.0-ubuntu-xenial-87-20180703-135432-760424297.tgz
+  value: https://storage.googleapis.com/cf-deployment-compiled-releases/cflinuxfs2-1.224.0-ubuntu-xenial-87-20180709-233413-92491057.tgz
 - path: /releases/name=cflinuxfs2/version
   type: replace
-  value: 1.223.0
+  value: 1.224.0
 - path: /releases/name=cflinuxfs2/sha1
   type: replace
-  value: 40df2fecca7adc8e3129a28f6050437ce6bc3643
+  value: 31dfb62751f4587b9836d465eff63177c66556d7
 - path: /releases/name=garden-runc/url
   type: replace
   value: https://storage.googleapis.com/cf-deployment-compiled-releases/garden-runc-1.15.1-ubuntu-xenial-87-20180703-005028-278477298.tgz

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -56,8 +56,6 @@
   value:
     api_password: ((cf_mysql_proxy_api_password))
     api_port: 8083
-    consul_enabled: true
-    consul_service_name: sql-db
 - type: replace
   path: /instance_groups/name=database/jobs/-
   value:

--- a/operations/use-bosh-dns-rename-network-and-deployment.yml
+++ b/operations/use-bosh-dns-rename-network-and-deployment.yml
@@ -233,7 +233,7 @@
           tps.service.cf.internal:
           - '*.scheduler.((network_name)).((deployment_name)).bosh'
           uaa.service.cf.internal:
-          - '*.uaa.((network_name)).cf.bosh'
+          - '*.uaa.((network_name)).((deployment_name)).bosh'
         api:
           client:
             tls:

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -81,13 +81,13 @@
   value: 40f0e84644713d569c58d2d8216eea5f07e1461b
 - path: /releases/name=cflinuxfs2/url
   type: replace
-  value: https://storage.googleapis.com/cf-deployment-compiled-releases/cflinuxfs2-1.223.0-ubuntu-trusty-3586.25-20180703-134835-013586745.tgz
+  value: https://storage.googleapis.com/cf-deployment-compiled-releases/cflinuxfs2-1.224.0-ubuntu-trusty-3586.25-20180709-232715-601707381.tgz
 - path: /releases/name=cflinuxfs2/version
   type: replace
-  value: 1.223.0
+  value: 1.224.0
 - path: /releases/name=cflinuxfs2/sha1
   type: replace
-  value: a7635d37694cad02a796e571f1819d3910cf4fda
+  value: c29f0e8bde0f20e9f495a25141aecb45dde77789
 - path: /releases/name=garden-runc/url
   type: replace
   value: https://storage.googleapis.com/cf-deployment-compiled-releases/garden-runc-1.15.1-ubuntu-trusty-3586.25-20180703-000305-593320306.tgz


### PR DESCRIPTION
### What is this change about?

For additional security benefits (running rootless), run the garden job in a container using BPM.

### Please provide contextual information.

In order to run Garden in BPM containers Garden needs specific network
settings:
* Diego talks to Garden via a socket
* Garden talks to a networking server that runs outside the Garden
container over a dedicated socket
* The networking server invokes the external networker

Story in Garden team's backlog: https://www.pivotaltracker.com/story/show/158594265
Related PR in cf-networking release: https://github.com/cloudfoundry/cf-networking-release/pull/45

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?

* Experimentally run Garden in BPM

### Does this PR introduce a breaking change? 
No 

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@danail-branekov @julz @BooleanCat 
