### PR TITLE
Experimentally enable BPM for Garden

### DIFF
--- a/operations/experimental/enable-bpm.yml
+++ b/operations/experimental/enable-bpm.yml
@@ -2,24 +2,61 @@
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/bpm?/enabled?
   value: true
 - type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego?/executor?/garden?/address?
+  value: /var/vcap/data/garden/sockets/garden.sock
+
+- type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=locket/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=auctioneer/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/bpm?/enabled?
   value: true
+
 - type: replace
   path: /instance_groups/name=api/jobs/name=file_server/properties?/bpm?/enabled?
   value: true
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/listen_address?
+  value: /var/vcap/data/garden/sockets/garden.sock
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/bpm?/enabled?
+  value: true
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/network_plugin?
+  value: /var/vcap/packages/netplugin-shim/bin/garden-plugin
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/network_plugin_extra_args?
+  value:
+    - "--socket"
+    - "/var/vcap/data/netplugin-server/sockets/network-shim.sock"
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=netplugin-server?
+  value:
+    name: netplugin-server
+    release: garden-runc
+    properties:
+      netplugin-server:
+        plugin_path: "/var/vcap/packages/runc-cni/bin/garden-external-networker"
+        plugin_extra_args:
+          - "--configFile"
+          - "/var/vcap/jobs/garden-cni/config/adapter.json"


### PR DESCRIPTION
### What is this change about?

For additional security benefits (running rootless), run the garden job in a container using BPM.

### Please provide contextual information.

In order to run Garden in BPM containers Garden needs specific network
settings:
* Diego talks to Garden via a socket
* Garden talks to a networking server that runs outside the Garden
container over a dedicated socket
* The networking server invokes the external networker

Story in Garden team's backlog: https://www.pivotaltracker.com/story/show/158594265
Related PR in cf-networking release: https://github.com/cloudfoundry/cf-networking-release/pull/45

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?

* Experimentally run Garden in BPM

### Does this PR introduce a breaking change? 
No 

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@danail-branekov @julz @BooleanCat 
