### PR TITLE
please upgrade datadog nozzle version away from cf-attic

### DIFF
--- a/operations/test/add-datadog-firehose-nozzle.yml
+++ b/operations/test/add-datadog-firehose-nozzle.yml
@@ -50,6 +50,6 @@
   path: /releases/-
   value:
     name: datadog-firehose-nozzle
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/datadog-firehose-nozzle-release?v=59
-    version: 59
-    sha1: 6ebe59075bde3be44c6a788fdd02a07b7d950aee
+    url: https://bosh.io/d/github.com/DataDog/datadog-firehose-nozzle-release?v=68
+    version: 68
+    sha1: 88f4d0d66a6e792c486ed26237b15b0ec4c95150


### PR DESCRIPTION
### What is this change about?

_Describe the change and why it's needed._
Datadog now manages this release. 


### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._



### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO



### How should this change be described in cf-deployment release notes?

_Something brief that conveys the change and is written with the Operator audience in mind. 
See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._



### Does this PR introduce a breaking change? 
Unaware
_Does this introduce changes that would require operators to take action in order to deploy without a failure?_

Examples of breaking changes:
- changes the name of a job or instance group
- deletes a job or instance group
- moves a job to a different instance group
- changes the name of a credential



### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
