### PR TITLE
Upgrade pxc to 0.11.0

### DIFF
--- a/operations/experimental/migrate-cf-mysql-to-pxc.yml
+++ b/operations/experimental/migrate-cf-mysql-to-pxc.yml
@@ -2,9 +2,9 @@
   path: /releases/-
   value:
     name: pxc
-    sha1: 44822031ded0e4c48133df92775964dcebe99204
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.10.0
-    version: 0.10.0
+    sha1: ec71552ab435506abb287efce9356baa5dc12c67
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.11.0
+    version: 0.11.0
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql_enabled?
   value: false
@@ -28,13 +28,11 @@
     name: pxc-mysql
     properties:
       admin_password: ((cf_mysql_mysql_admin_password))
-      binlog_enabled: false
-      cluster_health:
-        password: ((cf_mysql_mysql_cluster_health_password))
-      galera_agent:
-        db_password: ((cf_mysql_mysql_galera_healthcheck_password))
-        endpoint_password: ((cf_mysql_mysql_galera_healthcheck_endpoint_password))
-        endpoint_username: galera_healthcheck
+      engine_config:
+        binlog:
+          enabled: false
+        galera:
+          enabled: true
       port: 13306
       pxc_enabled: true
       seeded_databases:
@@ -66,6 +64,35 @@
       mysql:
         as: pxc-mysql
     release: pxc
+- type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
+    name: galera-agent
+    consumes:
+      mysql:
+        from: pxc-mysql
+    properties:
+      endpoint_password: ((cf_mysql_mysql_galera_healthcheck_endpoint_password))
+      db_password: ((cf_mysql_mysql_galera_healthcheck_password))
+    release: pxc
+- type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
+    name: gra-log-purger
+    consumes:
+      mysql:
+        from: pxc-mysql
+    release: pxc
+- type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
+    name: cluster-health-logger
+    consumes:
+      mysql:
+        from: pxc-mysql
+    release: pxc
+    properties:
+      db_password: ((cf_mysql_mysql_cluster_health_password))
 - type: replace
   path: /instance_groups/name=database/jobs/name=proxy/release
   value: pxc
@@ -103,9 +130,6 @@
 - type: replace
   path: /instance_groups/name=database/jobs/-
   value:
-    consumes:
-      mysql:
-        from: pxc-mysql
     name: bootstrap
     release: pxc
 - type: replace

--- a/operations/experimental/use-pxc.yml
+++ b/operations/experimental/use-pxc.yml
@@ -2,9 +2,9 @@
   path: /releases/name=cf-mysql
   value:
     name: pxc
-    sha1: 44822031ded0e4c48133df92775964dcebe99204
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.10.0
-    version: 0.10.0
+    sha1: ec71552ab435506abb287efce9356baa5dc12c67
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.11.0
+    version: 0.11.0
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql/name
   value: pxc-mysql
@@ -15,13 +15,11 @@
   path: /instance_groups/name=database/jobs/name=pxc-mysql?/properties
   value:
     admin_password: ((cf_mysql_mysql_admin_password))
-    binlog_enabled: false
-    cluster_health:
-      password: ((cf_mysql_mysql_cluster_health_password))
-    galera_agent:
-      db_password: ((cf_mysql_mysql_galera_healthcheck_password))
-      endpoint_password: ((cf_mysql_mysql_galera_healthcheck_endpoint_password))
-      endpoint_username: galera_healthcheck
+    engine_config:
+      binlog:
+        enabled: false
+      galera:
+        enabled: true
     port: 13306
     seeded_databases:
     - name: cloud_controller
@@ -48,6 +46,26 @@
     tls:
       galera: ((galera_server_certificate))
       server: ((mysql_server_certificate))
+- type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
+    name: galera-agent
+    properties:
+      endpoint_password: ((cf_mysql_mysql_galera_healthcheck_endpoint_password))
+      db_password: ((cf_mysql_mysql_galera_healthcheck_password))
+    release: pxc
+- type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
+    name: gra-log-purger
+    release: pxc
+- type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
+    name: cluster-health-logger
+    release: pxc
+    properties:
+      db_password: ((cf_mysql_mysql_cluster_health_password))
 - type: replace
   path: /instance_groups/name=database/jobs/name=proxy/release
   value: pxc


### PR DESCRIPTION
### What is this change about?

Upgrade pxc release to 0.11.0. This includes a large set of job and property refactorings.

This will probably be the final release before we ship pxc 1.0.0

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES 
- [ ] NO


### How should this change be described in cf-deployment release notes?

pxc release upgraded from 0.10.0 to 0.11.0. Custom ops files that configure database properties will need to update their paths to match the new jobs and property names.

### Does this PR introduce a breaking change? 

There are a good number of job and property changes. However, no action is required if the Operator is using manifests and ops files straight from cf-deployment. If they have custom ops files that change database properties, they may need to be updated.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

