### PR TITLE
Add cc.database_encryption properties to Cloud Controller jobs

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -655,6 +655,10 @@ instance_groups:
         - name: binary_buildpack
           package: binary-buildpack
         db_encryption_key: "((cc_db_encryption_key))"
+        database_encryption: &cc-database-encryption
+          current_key_label: "encryption_key_0"
+          keys:
+            encryption_key_0: "((cc_db_encryption_key))"
         bulk_api_password: "((cc_bulk_api_password))"
         internal_api_password: "((cc_internal_api_password))"
         staging_upload_user: staging_user
@@ -807,6 +811,7 @@ instance_groups:
     properties:
       cc:
         db_encryption_key: "((cc_db_encryption_key))"
+        database_encryption: *cc-database-encryption
         internal_api_password: "((cc_internal_api_password))"
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"
@@ -953,6 +958,7 @@ instance_groups:
     properties:
       cc:
         db_encryption_key: "((cc_db_encryption_key))"
+        database_encryption: *cc-database-encryption
         internal_api_password: "((cc_internal_api_password))"
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"


### PR DESCRIPTION
### What is this change about?

- This change adds the new cc.database_encryption key properties in
addition to the legacy cc.db_encryption_key property to enable rotation
of these keys in the future
- The upcoming version of capi-release will ship with a BOSH errand that lets operators rotate all keys in their ccdb
- Currently it is required that the legacy `cc.db_encryption_key`
property also remain present until operators have updated all encrypted
values that were encrypted with this key

To better demonstrate this, the following database query shows some of the apps in a ccdb after this change. All five apps were pushed before deploying with these changes. After the deployment, I updated the app `static-1` and it's sensitive content was re-encrypted with the labeled key. All untouched apps are still encrypted with the legacy `cc.db_encryption_key` which is denoted by not having a value in the `encryption_key_label` column. The upcoming key rotation bosh errand will allow operators to update all encrypted values, but this is the state of things if it hasn't been run.

```
mysql> select name, encrypted_environment_variables, encryption_key_label from apps limit 5;
+----------+---------------------------------+----------------------+
| name     | encrypted_environment_variables | encryption_key_label |
+----------+---------------------------------+----------------------+
| static-0 | DbDUcFTzsuwHcrXBqjNuLQ==        |                      |
| static-1 | w5/gvZjcc8gFE0VRGsEarA==        | encryption_key_0     |
| static-2 | zoIuE6iOdwN51qHecxJ+qw==        |                      |
| static-3 | ijo6HvjoG2F3fCaLHSu96g==        |                      |
| static-4 | 1lsQrL6etrEqGbcJCjtoxg==        |                      |
+----------+---------------------------------+----------------------+
5 rows in set (0.04 sec)
```

[CAPI Tracker Story #158735162](https://www.pivotaltracker.com/story/show/158735162)

### Additional Discussions/Context

- Some comments on the [CAPI Story](https://www.pivotaltracker.com/story/show/158735162)
- Some discussion occurred in [this Slack conversation](https://cloudfoundry.slack.com/archives/C0FAEKGUQ/p1531501873000096)
- This is the ops-file we've been using in our pipelines: https://github.com/cloudfoundry/capi-ci/blob/29ad053a8739745a389afbbe7e333174eb12f829/cf-deployment-operations/add-database-encryption-keys.yml

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES 
- [ ] NO

~Yes, and no, we have a CI environment that has been running fine with these changes when applied via an ops-file. I'm currently running CATS against a bosh-lite that was deployed with these exact changes directly in the manifest.~

Yes, we've had this running in our CI (changes were applied via an ops-file) and I had a passing CATS run against a bosh-lite that was deployed using this branch.

### How should this change be described in cf-deployment release notes?

This change will add the current database encryption key (`cc.db_encryption_key`) as a labeled key in `cc.database_encryption.keys` and set it as the `cc.database_encryption.current_key_label`. This will **not** automatically update existing encrypted values so it is important that the legacy `cc.db_encryption_key` property be maintained until operators have rotated everything to use the new key. It's important to note this.

Additionally if operators are tweaking these values with their own ops-files, they will want to account for this change.

### Does this PR introduce a breaking change? 

It does not introduce a breaking change, but _eventually_ in the future when we will want to remove the legacy `cc.db_encryption_key` property that will be a breaking change.

We have the following stories logged for that work:

- [Pre-start verifies encryption configuration #159024434](https://www.pivotaltracker.com/story/show/159024434)
- [CF deployment uses cc.database_encryption instead of db_encryption_key #159024379](https://www.pivotaltracker.com/story/show/159024379)

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!

Anyone on CAPI should be able to provide additional context, but here's some tagged folks for good measure. 😄 
@selzoc @zrob @Gerg 

Thanks!