### PR TITLE
Increase the route registrar's cc timeout on bosh-lite

### DIFF
--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -102,6 +102,11 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_app_memory?
   value: 256
 
+# ----- Increase route registrar's CC timeout, in case of load ------
+- type: replace
+  path: /instance_groups/name=api/jobs/name=route_registrar/properties/route_registrar/routes/name=api/health_check/timeout?
+  value: 10s
+
 # ----- Improve diego log format ------
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=auctioneer/properties?/logging/format/timestamp


### PR DESCRIPTION
### What is this change about?

We have observed in some CI systems that the route registrar will
deregister the single instance of a cloud controller if that cloud
controller is under load and cannot respond to a healthcheck in time.

So, this commit will increase the amount of time that a registrar will
allow for the cloud controller to respond.


### Please provide contextual information.

[#158990935](https://www.pivotaltracker.com/story/show/158990935)

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [] NO

### How should this change be described in cf-deployment release notes?

Updated `operations/bosh-lite.yml`

- Lengthened the route registrar's default cloud controller healthcheck timeout from 3 seconds to 10 seconds. We have observed that some bosh-lites under load will deregister their cloud controller.

### Does this PR introduce a breaking change? 

No.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._

/cc @mkenyon @selzoc @tcdowney @zrob 