### PR TITLE
Tweak the timeout parameters for CC route-registration health check

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -709,7 +709,7 @@ instance_groups:
       route_registrar:
         routes:
         - name: api
-          registration_interval: 20s
+          registration_interval: 10s
           port: 9022
           tags:
             component: CloudController
@@ -718,7 +718,7 @@ instance_groups:
           health_check:
             name: api-health-check
             script_path: "/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check"
-            timeout: 3s
+            timeout: 6s
         - name: policy-server
           port: 4002
           registration_interval: 20s


### PR DESCRIPTION
### What is this change about?

This change is similar to the one that was made for UAA in cb89aa1b. There have been cases where a Cloud Controller API is running and handling requests successfully, but is under load so the health check requests get backed up in the request queue.

This means that **currently** if a health check request gets backed up and it takes longer than 3 seconds for CC to handle it, the route registrar will take it our of the routing rotation and make the CC vm unavailable until the next `registration_interval`.

We're wanting to both decrease that interval and increase the `timeout` to reduce the chance and impact of health check failures.

We increased the timeout value from 3s to 6s because recent changes
to the health check script in capi-release
(https://github.com/cloudfoundry/capi-release/commit/73ec2075cc0da2caa08c06319162275e37544fec)
have added internal retries to the script itself and 6 seconds will give it a chance to retry several times under the default configuration.

### Please provide contextual information.

[CAPI Story #158990935](https://www.pivotaltracker.com/story/show/158990935)

For additional information about how this manifests in capi-release,
see: https://github.com/cloudfoundry/capi-release/issues/87

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO

We're in the process of running CATS, will update when they succeed. 😸 

### How should this change be described in cf-deployment release notes?

We _believe_ this change should make the Route Registrat's health checking of CC more robust for both production environments and R&D team CI environments. We would just call out that the values here have changed, but that they are still configurable by operators if their circumstances require them to be changed.

### Does this PR introduce a breaking change? 

Nope!

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

@ericpromislow @zrob 

Thanks!
Tim Downey && @ericpromislow 