### PR TITLE
Enable SpaceDeveloper self-service for network policies

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -945,6 +945,7 @@ instance_groups:
     properties:
       uaa_client_secret: ((uaa_clients_network_policy_secret))
       uaa_ca: ((uaa_ca.certificate))
+      enable_space_developer_self_service: true
       database:
         type: mysql
         username: network_policy


### PR DESCRIPTION
### What is this change about?

Required for users to set network policies; without this, container
networking isn't usable. Note: we could drop this property if
https://github.com/cloudfoundry/uaa-release/pull/96 is merged.

Chatted on slack about this with @staylor14 