### PR TITLE
add ops file for bosh-lite compatibility

### DIFF
--- a/operations/test/add-persistent-isolation-segment-diego-cell-bosh-lite.yml
+++ b/operations/test/add-persistent-isolation-segment-diego-cell-bosh-lite.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=isolated-diego-cell/jobs/name=rep/properties?/set_kernel_parameters
+  value: false

--- a/scripts/test-test-ops.sh
+++ b/scripts/test-test-ops.sh
@@ -8,6 +8,7 @@ test_test_ops() {
     pushd operations/test > /dev/null
       check_interpolation "add-datadog-firehose-nozzle.yml" "-v datadog_api_key=XYZ" "-v datadog_metric_prefix=foo.bar" "-v traffic_controller_external_port=8443"
       check_interpolation "add-persistent-isolation-segment-diego-cell.yml"
+      check_interpolation "add-persistent-isolation-segment-diego-cell-bosh-lite.yml"
       check_interpolation "add-persistent-isolation-segment-router.yml"
       check_interpolation "alter-ssh-proxy-redirect-uri.yml"
       check_interpolation "name: disable_windows_consul_agent_nameserver_overwriting.yml" "${home}/operations/windows-cell.yml" "-o disable_windows_consul_agent_nameserver_overwriting.yml"

--- a/scripts/test-test-ops.sh
+++ b/scripts/test-test-ops.sh
@@ -8,7 +8,7 @@ test_test_ops() {
     pushd operations/test > /dev/null
       check_interpolation "add-datadog-firehose-nozzle.yml" "-v datadog_api_key=XYZ" "-v datadog_metric_prefix=foo.bar" "-v traffic_controller_external_port=8443"
       check_interpolation "add-persistent-isolation-segment-diego-cell.yml"
-      check_interpolation "add-persistent-isolation-segment-diego-cell-bosh-lite.yml"
+      check_interpolation "name: add-persistent-isolation-segment-diego-cell-bosh-lite.yml" "add-persistent-isolation-segment-diego-cell.yml" "-o add-persistent-isolation-segment-diego-cell-bosh-lite.yml"
       check_interpolation "add-persistent-isolation-segment-router.yml"
       check_interpolation "alter-ssh-proxy-redirect-uri.yml"
       check_interpolation "name: disable_windows_consul_agent_nameserver_overwriting.yml" "${home}/operations/windows-cell.yml" "-o disable_windows_consul_agent_nameserver_overwriting.yml"


### PR DESCRIPTION
### What is this change about?

This change makes the `add-persistent-isolation-segment-diego-cell.yml` compatible with bosh-lite environments.

### Please provide contextual information.

Diego's rep job was recently modified to use a `set-kernel-parameters` property to control whether or not it will try and manipulate certain kernel parameters. By default, that property is true. However, it does not work on bosh-lite and will prevent deploys from succeeding.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [ ] NO



### How should this change be described in cf-deployment release notes?

Adds a new ops file that can be used along with `add-persistent-isolation-segment-diego-cell.yml` to deploy an isolated diego cell on bosh-lite.

### Does this PR introduce a breaking change? 

In fact, it fixes a breaking change (for bosh-lite, admittedly)

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO


### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

Neither?

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

