### PR TITLE
Change to the nfs ldap ops file in cf-deployment to disallow uid, gid for security purposes. 

### DIFF
--- a/operations/enable-nfs-ldap.yml
+++ b/operations/enable-nfs-ldap.yml
@@ -9,6 +9,7 @@
       ldap_port: ((nfs-ldap-port))
       ldap_proto: ((nfs-ldap-proto))
       ldap_user_fqdn: ((nfs-ldap-fqdn))
+      allowed-in-source: ""
 - type: replace
   path: /instance_groups/name=nfs-broker-push/jobs/name=nfsbrokerpush/properties/nfsbrokerpush/ldap_enabled?
   value: true


### PR DESCRIPTION
[#158704386](https://www.pivotaltracker.com/story/show/158704386)

Signed-off-by: Maria Shaldibina <mshaldibina@pivotal.io>

### What is this change about?

Change to the nfs ldap ops file in cf-deployment to disallow uid, gid for security purposes. 

### Please provide contextual information.

[158704386](https://www.pivotaltracker.com/story/show/158704386)



### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

NFS with LDAP is not being tested in cf-acceptance-tests in releng pipeline. It is tested in PATS acceptance tests in our pipeline though.


### How should this change be described in cf-deployment release notes?

_Something brief that conveys the change and is written with the Operator audience in mind. 
In order to be properly secured by ldap, nfsv3driver should disallow setting uid and gid in service bindings. That way, nobody can register a rogue broker that specifies a uid directly, and nfsv3driver will only use uids that have been resolved by ldap.



### Does this PR introduce a breaking change? 

No this isn't a breaking change.  This is tightening security.


### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@julian-hj @mariash
