### PR TITLE
Experimentally enable BPM for Garden

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -29,6 +29,7 @@ and the ops-files will be removed.
 | [`disable-consul-windows2016.yml`](disable-consul-windows2016.yml) | Removes `consul` job from `windows2016-cell` instance group and prevents the Windows 2016 cell rep from registering itself as a service with Consul | Requires `windows2016-cell.yml` |
 | [`enable-bits-service-consul.yml`](enable-bits-service-consul.yml) | Registers the bits-service [bits-service](https://github.com/cloudfoundry-incubator/bits-service) job via consul | Requires `bits-service.yml` from the same directory. |
 | [`enable-bpm.yml`](enable-bpm.yml) | **DEPRECATED**. BPM for these components is enabled in `cf-deployment.yml`. Enables the [BOSH Process Manager](https://github.com/cloudfoundry-incubator/bpm-release) for several BOSH jobs. | |
+| [`enable-bpm-garden.yml`](enable-bpm-garden.yml) | Enables the [BOSH Process Manager](https://github.com/cloudfoundry-incubator/bpm-release) for Garden. | |
 | [`enable-iptables-logger.yml`](enable-iptables-logger.yml) | Enables iptables logger. | |
 | [`enable-mysql-tls.yml`](enable-mysql-tls.yml) | Enables TLS on the database job, and secures all client database connections. | |
 | [`enable-oci-phase-1.yml`](enable-oci-phase-1.yml) | Configure Garden to create OCI compatible images. | |

--- a/operations/experimental/enable-bpm-garden.yml
+++ b/operations/experimental/enable-bpm-garden.yml
@@ -1,0 +1,40 @@
+---
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/bpm?/enabled?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego?/executor?/garden?/address?
+  value: /var/vcap/data/garden/sockets/garden.sock
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/listen_address?
+  value: /var/vcap/data/garden/sockets/garden.sock
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/network_plugin?
+  value: /var/vcap/packages/netplugin-shim/bin/garden-plugin
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/network_plugin_extra_args?
+  value:
+    - "--socket"
+    - "/var/vcap/data/netplugin-server/sockets/network-shim.sock"
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden?/additional_bpm_volumes?
+  value:
+    - "/var/vcap/data/rep/shared_data"
+    - "/var/vcap/data/netplugin-server/sockets"
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=netplugin-server?
+  value:
+    name: netplugin-server
+    release: garden-runc
+    properties:
+      netplugin-server:
+        plugin_path: "/var/vcap/packages/runc-cni/bin/garden-external-networker"
+        plugin_extra_args:
+          - "--configFile"
+          - "/var/vcap/jobs/garden-cni/config/adapter.json"

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -53,6 +53,7 @@ test_experimental_ops() {
 
       check_interpolation "name: use-compiled-releases-xenial-stemcell.yml" "use-xenial-stemcell.yml" "-o use-compiled-releases-xenial-stemcell.yml"
       check_interpolation "use-garden-containerd.yml"
+      check_interpolation "enable-bpm-garden.yml"
       check_interpolation "use-grootfs.yml"
       check_interpolation "use-pxc.yml"
       check_interpolation "use-shed.yml"


### PR DESCRIPTION
### Re-PR of [557](https://github.com/cloudfoundry/cf-deployment/pull/557)
Garden-runc-release 1.16.0 has now been released.

Note: this feature then requires cf-networking-release 2.8.0+ and GRR 1.16.0+

### What is this change about?

For additional security benefits (running rootless), run the garden job in a container using BPM.

### Please provide contextual information.
In order to run Garden in BPM containers Garden needs specific network
settings:

- Diego talks to Garden via a socket
- Garden talks to a networking server that runs outside the Garden container over a dedicated socket
- The networking server invokes the external networker
Story in Garden team's backlog: [https://www.pivotaltracker.com/story/show/158594265](https://www.pivotaltracker.com/story/show/158594265)
Related PR in cf-networking release: [cloudfoundry/cf-networking-release#45](https://github.com/cloudfoundry/cf-networking-release/pull/45)

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?
- Experimentally run Garden in BPM

### Does this PR introduce a breaking change? 
No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!
@julz @BooleanCat 