### PR TITLE
Add ops-file for enabling TLS between Gorouter and CC

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -32,6 +32,7 @@ and the ops-files will be removed.
 | [`enable-iptables-logger.yml`](enable-iptables-logger.yml) | Enables iptables logger. | |
 | [`enable-mysql-tls.yml`](enable-mysql-tls.yml) | Enables TLS on the database job | |
 | [`enable-oci-phase-1.yml`](enable-oci-phase-1.yml) | Configure Garden to create OCI compatible images. | |
+| [`enable-router-cc-tls.yml`](enable-router-cc-tls.yml) | Enables the usage of TLS to secure the connection between the gorouters and Cloud Controller. It should be applied after if used in conjunction with the `enable-routing-integrity.yml` ops-file.| |
 | [`enable-routing-integrity.yml`](enable-routing-integrity.yml) | Enables container proxy on the Diego Cell `rep` and configures gorouter to opt into TLS-enabled connections to the backend. | |
 | [`enable-tls-cloud-controller-postgres.yml`](enable-tls-cloud-controller-postgres.yml) | Enables the usage of TLS to secure the connection between Cloud Controller and its Postgres database | Requires capi-release >= 1.41.0 and `use-postgres.yml` |
 | [`enable-traffic-to-internal-networks.yml`](enable-traffic-to-internal-networks.yml) | Allows traffic from app containers to internal networks. Required to allow applications to communicate with the running CredHub in non-assisted mode. | |

--- a/operations/experimental/enable-router-cc-tls.yml
+++ b/operations/experimental/enable-router-cc-tls.yml
@@ -1,0 +1,41 @@
+- type: replace
+  path: /instance_groups/name=api/jobs/name=route_registrar/properties/route_registrar/routes/name=api?/tls_port
+  value: 9024
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/public_tls?/private_key
+  value: "((cc_public_tls.private_key))"
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/public_tls?/certificate
+  value: "((cc_public_tls.certificate))"
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/public_tls?/ca_cert
+  value: "((cc_public_tls.ca))"
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=route_registrar/properties/route_registrar/routes/name=api?/server_cert_domain_san
+  value: "api.((system_domain))"
+
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs?
+  value: |
+    ((application_ca.certificate))
+    ((service_cf_internal_ca.certificate))
+
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/backends?/enable_tls
+  value: true
+
+- type: replace
+  path: /variables/name=cc_public_tls?
+  value:
+    name: cc_public_tls
+    type: certificate
+    options:
+      ca: service_cf_internal_ca
+      common_name: "api.((system_domain))"
+      alternative_names:
+      - "api.((system_domain))"
+      - cloud-controller-ng.service.cf.internal

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -37,6 +37,8 @@ test_experimental_ops() {
       check_interpolation "enable-oci-phase-1.yml"
       check_interpolation "use-garden-containerd.yml"
       check_interpolation "enable-routing-integrity.yml"
+      check_interpolation "enable-router-cc-tls.yml"
+      check_interpolation "name: enable-routing-integrity.yml and enable-router-cc-tls.yml" "enable-routing-integrity.yml" "-o enable-router-cc-tls.yml"
       check_interpolation "fast-deploy-with-downtime-and-danger.yml"
       check_interpolation "name: enable-tls-cloud-controller-postgres" "${home}/operations/use-postgres.yml" "-o enable-tls-cloud-controller-postgres.yml"
       check_interpolation "use-xenial-stemcell.yml"


### PR DESCRIPTION
### What is this change about?

This PR includes a version of the ops-file that the CAPI team uses to enable and test TLS between the Gorouters and Cloud Controller.

We concatenated the `((application_ca.certificate))` CA certificate
  that the "Routing Integrity" functionality requires with the
  `((service_cf_internal_ca.certificate))` CA certificate that CC's TLS
  certs are signed by to make this ops-file compatible with the
  `enable-routing-integrity.yml` ops-file.

### Please provide contextual information.

CAPI has a separate story for this work because we were hoping to get the ball rolling since we're very interested in getting this functionality into cf-deployment by default:
[CAPI Story #159254762](https://www.pivotaltracker.com/story/show/159254762)

We understand that this will be done in [#158981742](https://www.pivotaltracker.com/story/show/158981742) but hope that this PR will provide additional context and make that one easier.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [ ] NO

I have not run CATS, but I have pushed several apps and observed that both API traffic and app traffic is encrypted.

You can test this yourselves by deploying an environment like this:
```
bosh deploy ~/workspace/cf-deployment/cf-deployment.yml \
  -v system_domain=$BOSH_LITE_DOMAIN \
  -o ~/workspace/capi-ci/cf-deployment-operations/skip-cert-verify.yml \
  -o ~/workspace/cf-deployment/operations/bosh-lite.yml \
  -o ~/workspace/cf-deployment/operations/use-compiled-releases.yml \
  -o ~/workspace/capi-ci/cf-deployment-operations/use-latest-capi.yml \
  -o ~/workspace/cf-deployment/operations/experimental/enable-routing-integrity.yml \
  -o ~/workspace/cf-deployment/operations/experimental/enable-router-cc-tls.yml
```

Then do the following:
1. Note the IP addresses of the `router` and `diego-cell` instance groups
2. `bosh ssh`ed on to `api/0` and `router/0` in two separate tabs
3. `sudo su -` in both sessions and run `apt install ngrep -y` to install `ngrep`
4. In the `api/0` session run `ngrep -d any host <router-ip>`
5. In the `router/0` session run `ngrep -d any host <diego-cell-ip>`
6. Push an app `cf push static-app`
7. In the api session you should see encrypted traffic to the `api` vm on port `9024`. Looks something like this:

```
##
T 10.244.0.34:39458 -> 10.244.0.135:9024 [AP]
  .............9:..c..D...]..Db..
```

This shows that the Gorouter to CC connection is over TLS. If you want to verify that routing-integrity is still working. Just hit the route for the app you pushed and observe something like in the `router/0` ssh session:

```
##
T 10.244.0.34:33082 -> 10.244.0.140:61006 [AP]
  ...................`!."P.....G.
```

### How should this change be described in cf-deployment release notes?

Enables communication over TLS for API traffic between Gorouter and Cloud Controller


### Does this PR introduce a breaking change? 

This does not introduce a breaking change. We implemented the functionality in CC to cover rolling-deploy scenarios and the non-TLS nginx server will continue to handle regular `http` traffic.



### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._

@zrob @Gerg @elenasharma 