### PR TITLE
Add the log-cache-scheduler job to the scheduler instance_group

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1231,6 +1231,8 @@ instance_groups:
               cert: "((scheduler_api_tls.certificate))"
               key: "((scheduler_api_tls.private_key))"
               cn: "cloud-controller-ng.service.cf.internal"
+  - name: log-cache-scheduler
+    release: log-cache
 - name: doppler
   azs:
   - z1


### PR DESCRIPTION
Signed-off-by: Hunter Williams <huwilliams@pivotal.io>

### What is this change about?

This adds the missing log-cache-scheduler job back to the scheduler instance_group. This is needed for log cache to function correctly and was inadvertently missed in the original pull request.

### Please provide contextual information.

Conversation with Gary Liu in Slack here:
https://pivotal.slack.com/archives/CBF2AU6A0/p1532984626000150

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?

Add the log-cache-scheduler job to the scheduler instance_grou

### Does this PR introduce a breaking change? 

No.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
/cc @hdub2 @syslxg 