### PR TITLE
Add statsd-injector to the perm service instances

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1231,6 +1231,8 @@ instance_groups:
               cert: "((scheduler_api_tls.certificate))"
               key: "((scheduler_api_tls.private_key))"
               cn: "cloud-controller-ng.service.cf.internal"
+  - name: log-cache-scheduler
+    release: log-cache
 - name: doppler
   azs:
   - z1

--- a/operations/experimental/perm-service.yml
+++ b/operations/experimental/perm-service.yml
@@ -34,6 +34,15 @@
           tls:
             ca_certs:
             - ((uaa_ca.certificate))
+    - name: statsd_injector
+      release: statsd-injector
+      properties:
+        loggregator:
+          tls:
+            ca_cert: "((loggregator_ca.certificate))"
+            statsd_injector:
+              cert: "((loggregator_tls_statsdinjector.certificate))"
+              key: "((loggregator_tls_statsdinjector.private_key))"
 
 # Changes to other instance groups
 - type: replace

--- a/operations/experimental/secure-service-credentials.yml
+++ b/operations/experimental/secure-service-credentials.yml
@@ -2,9 +2,9 @@
   path: /releases/-
   value:
     name: credhub
-    sha1: 2390e855f092b0fb9c58f9cb88853ea938e87a3e
-    url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=1.9.5
-    version: 1.9.5
+    sha1: b07313930ec349a7dff3aaff210cc139e21d5d08
+    url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.0.0
+    version: 2.0.0
 - type: replace
   path: /instance_groups/-
   value:


### PR DESCRIPTION
What is this change about?
Describe the change and why it's needed.

With this change PERM will start sending server-side metrics.

Please provide contextual information.
https://www.pivotaltracker.com/story/show/157413837

Has a cf-deployment including this change passed our cf-acceptance-tests?
[ X ] YES
  NO
How should this change be described in cf-deployment release notes?
Something brief that conveys the change and is written with the Operator audience in mind.
See previous release notes for examples.

"Perm service now emits server-side metrics."

Does this PR introduce a breaking change?
Does this introduce changes that would require operators to take action in order to deploy without a failure?

NO

Examples of breaking changes:

changes the name of a job or instance group
moves a job to a different instance group
deletes a job or instance group
changes the name of a credential
Will this change increase the VM footprint of cf-deployment?
  YES --- does it really have to?
[ X ] NO
Does this PR make a change to an experimental or GA'd feature/component?
[ X ] experimental feature/component
  GA'd feature/component
What is the level of urgency for publishing this change?
  Urgent - unblocks current or future work
[ X ] Slightly Less than Urgent
Tag your pair, your PM, and/or team!
It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later.