### PR TITLE
add statsd injector to the perm service

### DIFF
--- a/operations/experimental/perm-service.yml
+++ b/operations/experimental/perm-service.yml
@@ -34,6 +34,15 @@
           tls:
             ca_certs:
             - ((uaa_ca.certificate))
+    - name: statsd_injector
+      release: statsd-injector
+      properties:
+        loggregator:
+          tls:
+            ca_cert: "((loggregator_ca.certificate))"
+            statsd_injector:
+              cert: "((loggregator_tls_statsdinjector.certificate))"
+              key: "((loggregator_tls_statsdinjector.private_key))"
 
 # Changes to other instance groups
 - type: replace


### PR DESCRIPTION
NOTE: this PR is a followup to 2 other PRs that have been closed: #578 #562

What is this change about?
Describe the change and why it's needed.

With this change PERM will start sending server-side metrics.

Please provide contextual information.
https://www.pivotaltracker.com/story/show/157413837

Has a cf-deployment including this change passed our cf-acceptance-tests?
[ X ] YES
NO
How should this change be described in cf-deployment release notes?
Something brief that conveys the change and is written with the Operator audience in mind.
See previous release notes for examples.

"Perm service now emits server-side metrics."

Does this PR introduce a breaking change?
Does this introduce changes that would require operators to take action in order to deploy without a failure?

NO

Examples of breaking changes:

changes the name of a job or instance group
moves a job to a different instance group
deletes a job or instance group
changes the name of a credential
Will this change increase the VM footprint of cf-deployment?
YES --- does it really have to?
[ X ] NO
Does this PR make a change to an experimental or GA'd feature/component?
[ X ] experimental feature/component
GA'd feature/component
What is the level of urgency for publishing this change?
Urgent - unblocks current or future work
[ X ] Slightly Less than Urgent
Tag your pair, your PM, and/or team!
It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later.