### PR TITLE
Change log-cache common name to doppler

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1900,14 +1900,14 @@ variables:
 - name: logs_provider
   options:
     ca: loggregator_ca
-    common_name: log-cache
+    common_name: doppler
     extended_key_usage:
     - client_auth
     - server_auth
   type: certificate
 - name: log_cache_ca
   options:
-    common_name: log-cache
+    common_name: doppler
     is_ca: true
   type: certificate
 - name: log_cache
@@ -1917,7 +1917,7 @@ variables:
     - log-cache
     - logcache
     ca: log_cache_ca
-    common_name: log-cache
+    common_name: doppler
     extended_key_usage:
     - client_auth
     - server_auth
@@ -1925,7 +1925,7 @@ variables:
 - name: log_cache_tls_cc_auth_proxy
   options:
     ca: service_cf_internal_ca
-    common_name: log-cache
+    common_name: doppler
     extended_key_usage:
     - client_auth
   type: certificate


### PR DESCRIPTION
Signed-off-by: Hunter Williams <huwilliams@pivotal.io>

### What is this change about?

Since log cache will be colocated with doppler, it should be using the doppler common name in generated certs.

### Please provide contextual information.

https://cloudfoundry.slack.com/archives/CBFB7NP9B/p1533253042000020

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO

### How should this change be described in cf-deployment release notes?

Change log-cache common name to doppler in generated certificates

### Does this PR introduce a breaking change? 

No.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

/cc @hdub2 