### PR TITLE
Add experimental use-cpu-weight ops file

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -55,6 +55,7 @@ and the ops-files will be removed.
 | [`use-compiled-releases-xenial-stemcell.yml`](use-compiled-releases-xenial-stemcell.yml) | Use releases compiled for Xenial stemcell, as opposed to Trusty | Requires `use-xenial-stemcell.yml` |
 | [`use-garden-containerd.yml`](use-garden-containerd.yml) | Configure Garden to create containers via containerd. | |
 | [`use-grootfs.yml`](use-grootfs.yml) | Groot is enabled by default. This file is blank to avoid breaking deployment scripts. | |
+| [`set-cpu-weight.yml`](set-cpu-weight.yml) | CPU shares for each garden container are proportional to its memory limits. | |
 | [`use-pxc.yml`](use-pxc.yml) | Uses the [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release) instead of the [cf-mysql-release](https://github.com/cloudfoundry/cf-mysql-release/) as the internal mysql database. This ops-file is for clean-installs of cf or for redeploying cf already running pxc. It's not for migrating from cf-mysql-release. | |
 | [`use-shed.yml`](use-shed.yml) | Enable deprecated garden-shed on diego cells. | |
 | [`use-xenial-stemcell.yml`](use-xenial-stemcell.yml) | Use Ubuntu Xenial as the default stemcell. | |

--- a/operations/experimental/set-cpu-weight.yml
+++ b/operations/experimental/set-cpu-weight.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/containers/set_cpu_weight?
+  value: true

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -57,6 +57,7 @@ test_experimental_ops() {
       check_interpolation "use-pxc.yml"
       check_interpolation "use-shed.yml"
       check_interpolation "use-xenial-stemcell.yml"
+      check_interpolation "set-cpu-weight.yml"
 
       check_interpolation "windows1803-cell.yml"
       check_interpolation "name: windows-component-syslog-ca.yml" "windows-enable-component-syslog.yml" "-o windows-component-syslog-ca.yml" "-l ${home}/operations/addons/example-vars-files/vars-enable-component-syslog.yml"


### PR DESCRIPTION
**Note** Please merge after cf-deployment is using Diego 2.16.0.

This ops file instructs diego to create garden containers whose CPU
shares are directly proportional to container memory.

Co-authored-by: Ed King <eking@pivotal.io>

### What is this change about?

This ops-file instructs diego to ignore cloud controller's CPU share calculation and make CPU shares for Garden containers directly proportional to the container's memory limit.

### Please provide contextual information.

This is part of Garden's work to make CPU allocation and metrics better. [See doc here.](https://docs.google.com/document/d/16TvBsZSInjy7zoboSQWRJo30lmxr07tvd40_GzpfD3I/edit?usp=sharing)

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO

### How should this change be described in cf-deployment release notes?

App developers and operators shouldn't notice any difference after deploying with this feature enabled.

This may have undesirable side effects for staging containers, but our hypothesis is that nothing will change.

### Does this PR introduce a breaking change? 

No.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [X] GA'd feature/component

We're experimentally changing a GA'd feature.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

@teddyking @julz