### PR TITLE
Revert log-cache to 1.3.0

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2144,9 +2144,9 @@ releases:
   version: "2.0"
   sha1: df91c31c15da68c7b2905645b20b93a930627d46
 - name: log-cache
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=1.4.1
-  version: 1.4.1
-  sha1: 8330eee7454c27790869aacdf5b58d497c3007b0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=1.3.0
+  version: 1.3.0
+  sha1: 2fee0f51c4093091d33eb117202f7476f1a4ebcf
 - name: bosh-dns-aliases
   url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
   version: 0.0.3


### PR DESCRIPTION
### What is this change about?

It looks like cf-d 3.0.0 was released with log-cache 1.3.0, but 3.1.0 appears to have automatically grabbed the latest version (1.4.1), which has some known issues. This commit will roll back to the known-good version. We'll remove the packages for both 1.4.0 and 1.4.1 to prevent automatic upgrades until 1.4.2 is released.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?

Reverts log-cache to 1.3.0 due to memory management issues under high load.

### Does this PR introduce a breaking change? 

No.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

/cc @hdub2 @colins