### PR TITLE
collocate cf-cli release with nfsbrokerpush errand

### DIFF
--- a/operations/enable-nfs-volume-service.yml
+++ b/operations/enable-nfs-volume-service.yml
@@ -43,6 +43,8 @@
           syslog_url: ""
           username: nfs-broker
       release: nfs-volume
+    - name: cf-cli-6-linux
+      release: cf-cli
     lifecycle: errand
     name: nfs-broker-push
     networks:
@@ -117,3 +119,10 @@
     sha1: 9dcea268d327caff76690229ac09f57a0c83cf65
     url: https://bosh.io/d/github.com/cloudfoundry/mapfs-release?v=1.0.1
     version: 1.0.1
+- type: replace
+  path: /releases/name=cf-cli?
+  value:
+    name: cf-cli
+    url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.5.0
+    sha1: 6749a07026e335f7744f013c9707911fb72170b5
+    version: 1.5.0


### PR DESCRIPTION
[#159187003](https://www.pivotaltracker.com/story/show/159187003)

Signed-off-by: Maria Shaldibina <mshaldibina@pivotal.io>

### What is this change about?

Instead of using vendored cf-cli collocate cf-cli release with nfsbrokerpush errand.


### Please provide contextual information.

As per discussion in rel-eng channel this it the first step after which rel-eng is going to move cf-cli release to separate ops file so other errands can use it as well.
https://cloudfoundry.slack.com/archives/C0FAEKGUQ/p1533755991000145

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO

This change passed our pipeline PATS.

### How should this change be described in cf-deployment release notes?

nfsbrokerpush is now collocating cf-cli release instead of vendoring it

### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

@davewalter, @julian-hj, @paulcwarren