### PR TITLE
Register nfs broker in push errand, not separate errand

### DIFF
--- a/operations/enable-nfs-volume-service.yml
+++ b/operations/enable-nfs-volume-service.yml
@@ -37,7 +37,7 @@
           domain: ((system_domain))
           organization: system
           password: ((nfs-broker-password))
-          register_broker: false
+          register_broker: true
           skip_cert_verify: true
           space: nfs-broker-space
           syslog_url: ""
@@ -45,32 +45,6 @@
       release: nfs-volume
     lifecycle: errand
     name: nfs-broker-push
-    networks:
-    - name: default
-    stemcell: default
-    vm_type: minimal
-- type: replace
-  path: /instance_groups/-
-  value:
-    azs:
-    - z1
-    instances: 1
-    jobs:
-    - name: broker-registrar
-      properties:
-        cf:
-          api_url: api.((system_domain))
-          password: ((cf_admin_password))
-          skip_ssl_validation: true
-          username: admin
-        servicebroker:
-          name: nfs-broker
-          password: ((nfs-broker-password))
-          url: http://nfs-broker.((system_domain))
-          username: nfs-broker
-      release: broker-registrar
-    lifecycle: errand
-    name: nfs-broker-registrar
     networks:
     - name: default
     stemcell: default
@@ -103,13 +77,6 @@
     sha1: 39cb877d1cf94dde8cf572cc547a2ad2b3af3140
     url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=1.5.0
     version: 1.5.0
-- type: replace
-  path: /releases/-
-  value:
-    name: broker-registrar
-    sha1: d44d9af8fd06ecf6d50004c9bfd5516a6e482201
-    url: https://bosh.io/d/github.com/cloudfoundry-community/broker-registrar-boshrelease?v=3.4.0
-    version: 3.4.0
 - type: replace
   path: /releases/name=mapfs?
   value:


### PR DESCRIPTION
[#159639152](https://www.pivotaltracker.com/story/show/159639152)

### What is this change about?

Register NFS service broker in the same errand that is pushing the service broker instead of using separate`broker-registrar` errand from `broker-registrar` release.

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/159639152

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO

It passed our PATS (persi acceptance tests).

### How should this change be described in cf-deployment release notes?

_Something brief that conveys the change and is written with the Operator audience in mind. 
See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

Updated Ops-files
`operations/enable-nfs-volume-service.yml` - registers NFS service broker by default in the `nfsbrokerpush` errand, removes extra `nfs-broker-registrar` errand.

### Does this PR introduce a breaking change? 

`nfs-broker-registrar` errand is now removed.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES
- [X] NO

It will actually decrease VM footprint.

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

@julian-hj @paulcwarren @davewalter 