### PR TITLE
Remove log-cache-scheduler

### DIFF
--- a/operations/disable-log-cache.yml
+++ b/operations/disable-log-cache.yml
@@ -14,6 +14,8 @@
 - type: remove
   path: /instance_groups/name=doppler/jobs/name=route_registrar
 - type: remove
+  path: /instance_groups/name=scheduler/jobs/name=log-cache-scheduler
+- type: remove
   path: /variables/name=logs_provider
 - type: remove
   path: /variables/name=log_cache


### PR DESCRIPTION
Remove log-cache-scheduler from the scheduler if disable-log-cache ops file is used

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO (we don't run the full cf-acceptance-tests. We deployed it on 4 different iaases, ran our tests and everything was fine)

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
