### PR TITLE
Ops file for configuring CC to use Log Cache instead of Traffic Controller for app container metrics

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -55,6 +55,7 @@ and the ops-files will be removed.
 | [`use-compiled-releases-xenial-stemcell.yml`](use-compiled-releases-xenial-stemcell.yml) | Use releases compiled for Xenial stemcell, as opposed to Trusty | Requires `use-xenial-stemcell.yml` |
 | [`use-garden-containerd.yml`](use-garden-containerd.yml) | Configure Garden to create containers via containerd. | |
 | [`use-grootfs.yml`](use-grootfs.yml) | Groot is enabled by default. This file is blank to avoid breaking deployment scripts. | |
+| [`use-logcache-for-cloud-controller-app-stats.yml`](use-logcache-for-cloud-controller-app-stats.yml) | Configure Cloud Controller to use Log Cache instead of Traffic Controller for app container metrics. | |
 | [`use-pxc.yml`](use-pxc.yml) | Uses the [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release) instead of the [cf-mysql-release](https://github.com/cloudfoundry/cf-mysql-release/) as the internal mysql database. This ops-file is for clean-installs of cf or for redeploying cf already running pxc. It's not for migrating from cf-mysql-release. | |
 | [`use-shed.yml`](use-shed.yml) | Enable deprecated garden-shed on diego cells. | |
 | [`use-xenial-stemcell.yml`](use-xenial-stemcell.yml) | Use Ubuntu Xenial as the default stemcell. | |

--- a/operations/experimental/use-logcache-for-cloud-controller-app-stats.yml
+++ b/operations/experimental/use-logcache-for-cloud-controller-app-stats.yml
@@ -1,0 +1,23 @@
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/logcache_tls?/private_key
+  value: "((cc_logcache_tls.private_key))"
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/logcache_tls?/certificate
+  value: "((cc_logcache_tls.certificate))"
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/temporary_use_logcache?
+  value: true
+
+- type: replace
+  path: /variables/name=cc_logcache_tls?
+  value:
+    name: cc_logcache_tls
+    type: certificate
+    options:
+      ca: log_cache_ca
+      common_name: "api.((system_domain))"
+      alternative_names:
+      - "api.((system_domain))"
+      - cloud-controller-ng.service.cf.internal

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -54,6 +54,7 @@ test_experimental_ops() {
       check_interpolation "name: use-compiled-releases-xenial-stemcell.yml" "use-xenial-stemcell.yml" "-o use-compiled-releases-xenial-stemcell.yml"
       check_interpolation "use-garden-containerd.yml"
       check_interpolation "use-grootfs.yml"
+      check_interpolation "use-logcache-for-cloud-controller-app-stats.yml"
       check_interpolation "use-pxc.yml"
       check_interpolation "use-shed.yml"
       check_interpolation "use-xenial-stemcell.yml"


### PR DESCRIPTION
### What is this change about?

Cloud Controller typically uses Traffic Controller to get container metrics (cpu/disk/memory utilization) for running apps. Loggregator has introduced a new component, Log Cache, that they would like us to use instead. 

This ops file configures CC to use Log Cache instead of Traffic Controller, so we can start kicking the tyres on Log Cache for container metrics.

### Please provide contextual information.

Here is the story in the CAPI backlog: https://www.pivotaltracker.com/story/show/159042437

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO

We haven't run CATS against it yet, but we're working on it. 😄 

### How should this change be described in cf-deployment release notes?

Adds a new experimental ops-file for using Log Cache to provide container metrics on the CC API.

### Does this PR introduce a breaking change? 

Nope.



### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@Gerg @zrob @ericpromislow 
