### PR TITLE
Fix disable-log-cache.yml to remove schedulers log-cache-expvar-forwarder job

### DIFF
--- a/operations/disable-log-cache.yml
+++ b/operations/disable-log-cache.yml
@@ -16,6 +16,8 @@
 - type: remove
   path: /instance_groups/name=scheduler/jobs/name=log-cache-scheduler
 - type: remove
+  path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder
+- type: remove
   path: /variables/name=logs_provider
 - type: remove
   path: /variables/name=log_cache


### PR DESCRIPTION
### What is this change about?

Fix for https://github.com/cloudfoundry/cf-deployment/issues/602

### Please provide contextual information.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO

### How should this change be described in cf-deployment release notes?

`operations/disable-log-cache.yml` - Removes log-cache-expvar-forwarder job from the scheduler instance group.

### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

Given it fixes a deployment error when using this ops file.

### Tag your pair, your PM, and/or team!
