### PR TITLE
Add use-garden-containerd.yml warning

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -31,7 +31,7 @@ and the ops-files will be removed.
 | [`disable-consul-windows1803.yml`](disable-consul-windows1803.yml) | Removes `consul` job from `windows2016-cell` instance group and prevents the Windows 2016 cell rep from registering itself as a service with Consul | Requires `windows2016-cell.yml` or `windows1803-cell.yml` |
 | [`enable-bits-service-consul.yml`](enable-bits-service-consul.yml) | Registers the bits-service [bits-service](https://github.com/cloudfoundry-incubator/bits-service) job via consul | Requires `bits-service.yml` from the same directory. |
 | [`enable-bpm.yml`](enable-bpm.yml) | **DEPRECATED**. BPM for these components is enabled in `cf-deployment.yml`. Enables the [BOSH Process Manager](https://github.com/cloudfoundry-incubator/bpm-release) for several BOSH jobs. | |
-| [`enable-bpm-garden.yml`](enable-bpm-garden.yml) | Enables the [BOSH Process Manager](https://github.com/cloudfoundry-incubator/bpm-release) for Garden. | |
+| [`enable-bpm-garden.yml`](enable-bpm-garden.yml) | Enables the [BOSH Process Manager](https://github.com/cloudfoundry-incubator/bpm-release) for Garden. This ops file cannot be deployed in conjunction with `use-garden-containerd.yml` | |
 | [`enable-iptables-logger.yml`](enable-iptables-logger.yml) | Enables iptables logger. | |
 | [`enable-mysql-tls.yml`](enable-mysql-tls.yml) | Enables TLS on the database job, and secures all client database connections. | |
 | [`enable-oci-phase-1.yml`](enable-oci-phase-1.yml) | Configure Garden to create OCI compatible images. | |
@@ -47,7 +47,7 @@ and the ops-files will be removed.
 | [`migrate-cf-mysql-to-pxc.yml`](migrate-cf-mysql-to-pxc.yml) | Migrates from an existing cf-mysql database to [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release). After the migration is complete, switch to the `use-pxc.yml` operations file. | |
 | [`perm-service.yml`](perm-service.yml) | Deploy CF with [Perm Service](https://github.com/cloudfoundry-incubator/perm) | Requires `enable-mysql-tls.yml`. See the [deployment section of perm-release's README file](https://github.com/cloudfoundry-incubator/perm-release/blob/master/README.md#deploying-perm-with-cf-deployment) for more information|
 | [`perm-service-with-pxc-release.yml`](perm-service-with-pxc-release.yml) | Use [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release) as data store for Perm Service. | Requires `perm-service.yml` and `use-pxc.yml`. |
-| [`rootless-containers.yml`](rootless-containers.yml) | Enable rootless garden-runc containers. | Requires garden-runc 1.9.5 or later and grootfs 0.27.0 or later. |
+| [`rootless-containers.yml`](rootless-containers.yml) | Enable rootless garden-runc containers. | Requires garden-runc 1.9.5 or later and grootfs 0.27.0 or later. This ops file cannot be deployed in conjunction with `use-garden-containerd.yml` |
 | [`secure-service-credentials.yml`](secure-service-credentials.yml) | Use CredHub for service credentials. | BOSH DNS is required if not using a credhub load balancer. You can add a credhub load balancer with `add-credhub-lb.yml`. |
 | [`secure-service-credentials-windows-cell.yml`](secure-service-credentials-windows-cell.yml) | Adds CredHub TLS CA as a trusted cert to the Windows Cell. | Requires `secure-service-credentials.yml`. |
 | [`secure-service-credentials-windows2016-cell.yml`](secure-service-credentials-windows2016-cell.yml) | Adds CredHub TLS CA as a trusted cert to the Windows 2016 Cell. | Requires `secure-service-credentials.yml`, `windows2016-cell.yml` and `enable-instance-identity-credentials-windows2016.yml`. |
@@ -58,7 +58,7 @@ and the ops-files will be removed.
 | [`skip-consul-cell-registrations.yml`](skip-consul-cell-registrations.yml) | Configure the BBS to only use Locket to find registered Diego cells | |
 | [`skip-consul-locks.yml`](skip-consul-locks.yml) | Prevent several components from also attempting to claim a lock in Consul | |
 | [`use-compiled-releases-xenial-stemcell.yml`](use-compiled-releases-xenial-stemcell.yml) | Use releases compiled for Xenial stemcell, as opposed to Trusty | Requires `use-xenial-stemcell.yml` |
-| [`use-garden-containerd.yml`](use-garden-containerd.yml) | Configure Garden to create containers via containerd. | |
+| [`use-garden-containerd.yml`](use-garden-containerd.yml) | Configure Garden to create containers via containerd. This ops file cannot be deployed in conjunction with either `rootless-containers.yml` or `enable-bpm-garden.yml`. | |
 | [`use-grootfs.yml`](use-grootfs.yml) | Groot is enabled by default. This file is blank to avoid breaking deployment scripts. | |
 | [`use-logcache-for-cloud-controller-app-stats.yml`](use-logcache-for-cloud-controller-app-stats.yml) | Configure Cloud Controller to use Log Cache instead of Traffic Controller for app container metrics. | |
 | [`use-pxc.yml`](use-pxc.yml) | Uses the [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release) instead of the [cf-mysql-release](https://github.com/cloudfoundry/cf-mysql-release/) as the internal mysql database. This ops-file is for clean-installs of cf or for redeploying cf already running pxc. It's not for migrating from cf-mysql-release. | |

--- a/operations/experimental/enable-bpm-garden.yml
+++ b/operations/experimental/enable-bpm-garden.yml
@@ -1,4 +1,5 @@
 ---
+# enable-bpm-garden.yml cannot be deployed with use-garden-containerd.yml
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/bpm?/enabled
   value: true

--- a/operations/experimental/rootless-containers.yml
+++ b/operations/experimental/rootless-containers.yml
@@ -1,5 +1,6 @@
 ---
 # Requires grootfs 0.27.0 or later, and garden-runc 1.9.5 or later.
+# rootless-containers.yml cannot be deployed with use-garden-containerd.yml
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/experimental_rootless_mode?

--- a/operations/experimental/use-garden-containerd.yml
+++ b/operations/experimental/use-garden-containerd.yml
@@ -1,4 +1,5 @@
 ---
+# use-garden-containerd.yml cannot be deployed with either rootless-containerd.yml or enable-bpm-garden.yml
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/-
   value:


### PR DESCRIPTION
### What is this change about?

This change warns operators that`operations/experimental/use-garden-containerd.yml` cannot yet be deployed with either `operations/experimental/enable-bpm-garden.yml` or `operations/experimental/rootless-containerd.yml`.
The warnings appear in several places to be extra safe :)

### Please provide contextual information.

Conversation in slack starting [here](https://cloudfoundry.slack.com/archives/C033RE5D6/p1535051737000100).
Associated [garden chore](https://www.pivotaltracker.com/story/show/160014652).

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

This change affects documentation only.


### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!
Garden
