### PR TITLE
Fix Diego component logging configuration

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -945,6 +945,9 @@ instance_groups:
     properties:
       bpm:
         enabled: true
+      logging:
+        format:
+          timestamp: "rfc3339"
       loggregator: *diego_loggregator_client_properties
   - name: routing-api
     release: routing
@@ -971,9 +974,6 @@ instance_groups:
       uaa:
         ca_cert: "((uaa_ca.certificate))"
         tls_port: 8443
-      logging:
-        format:
-          timestamp: "rfc3339"
   - name: policy-server
     release: cf-networking
     properties:

--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -36,22 +36,25 @@
     name: ssh_proxy
     release: diego
     properties:
-      loggregator: &diego_loggregator_client_properties
-        use_v2_api: true
-        ca_cert: "((loggregator_ca.certificate))"
-        cert: "((loggregator_tls_agent.certificate))"
-        key: "((loggregator_tls_agent.private_key))"
       diego:
-        ssl:
-          skip_cert_verify: true
         ssh_proxy:
-          enable_cf_auth: true
-          host_key: "((diego_ssh_proxy_host_key.private_key))"
-          uaa_secret: "((uaa_clients_ssh-proxy_secret))"
           bbs: &5
             ca_cert: "((service_cf_internal_ca.certificate))"
             client_cert: "((diego_bbs_client.certificate))"
             client_key: "((diego_bbs_client.private_key))"
+          enable_cf_auth: true
+          host_key: "((diego_ssh_proxy_host_key.private_key))"
+          uaa_secret: "((uaa_clients_ssh-proxy_secret))"
+        ssl:
+          skip_cert_verify: true
+      logging:
+        format:
+          timestamp: "rfc3339"
+      loggregator: &diego_loggregator_client_properties
+        ca_cert: "((loggregator_ca.certificate))"
+        cert: "((loggregator_tls_agent.certificate))"
+        key: "((loggregator_tls_agent.private_key))"
+        use_v2_api: true
 
 # ----- Scale Down ------
 - type: replace
@@ -104,39 +107,6 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_app_memory?
   value: 256
-
-# ----- Improve diego log format ------
-- type: replace
-  path: /instance_groups/name=scheduler/jobs/name=auctioneer/properties?/logging/format/timestamp
-  value: "rfc3339"
-
-- type: replace
-  path: /instance_groups/name=diego-api/jobs/name=bbs/properties?/logging/format/timestamp
-  value: "rfc3339"
-
-- type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties?/logging/format/timestamp
-  value: "rfc3339"
-
-- type: replace
-  path: /instance_groups/name=api/jobs/name=file_server/properties?/logging/format/timestamp
-  value: "rfc3339"
-
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=garden/properties?/logging/format/timestamp
-  value: "rfc3339"
-
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties?/logging/format/timestamp
-  value: "rfc3339"
-
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties?/logging/format/timestamp
-  value: "rfc3339"
-
-- type: replace
-  path: /instance_groups/name=router/jobs/name=ssh_proxy/properties?/logging/format/timestamp
-  value: "rfc3339"
 
 # ----- Disable kernel parameter tuning ------
 - type: replace


### PR DESCRIPTION
### WHAT is this change about?

Fix errors and clean up redundancies after completion of [#159833429](https://www.pivotaltracker.com/story/show/159833429).

### WHY is this change being made (What problem is being addressed)?

Ensure consistently human-readable log format for Diego components by default and remove unnecessary operations from cf-deployment repo.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO (not applicable)



### How should this change be described in cf-deployment release notes?

Fix minor omissions in updating Diego log timestamps from unix epoch to the human readable rfc3339 format.


### Does this PR introduce a breaking change? 

No.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

@cloudfoundry/cf-diego 