### PR TITLE
Be explicit about which credhub to consume

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -776,6 +776,9 @@ instance_groups:
               name: policy-server
   - name: cloud_controller_ng
     release: capi
+    consumes:
+      credhub:
+        from: cf-credhub
     provides:
       cloud_controller: {as: cloud_controller, shared: true}
     properties:
@@ -1025,6 +1028,9 @@ instance_groups:
       consul_client: {from: consul_client_link}
   - name: cloud_controller_worker
     release: capi
+    consumes:
+      credhub:
+        from: cf-credhub
     properties:
       bpm:
         enabled: true
@@ -1187,6 +1193,9 @@ instance_groups:
           timestamp: "rfc3339"
   - name: cloud_controller_clock
     release: capi
+    consumes:
+      credhub:
+        from: cf-credhub
     properties:
       bpm:
         enabled: true
@@ -1684,6 +1693,9 @@ instance_groups:
             credhub: {}
     release: consul
   - name: credhub
+    provides:
+      credhub:
+        as: cf-credhub
     properties:
       credhub:
         authentication:


### PR DESCRIPTION
### WHAT is this change about?

Make the bosh links explicit for credhub so that this won't fail if another instance of credhub is deployed.

### WHY is this change being made (What problem is being addressed)?

For various reasons we already have a credhub running in our CF deployments. v4.0.0 broke on deployment as it was unable to resolve the bosh link for the new CF credhub since multiple link providers for type credhub existed.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

Unsure. We've deployed the changes as described in this PR via an operator file in our environment.

### How should this change be described in cf-deployment release notes?

As I understand it, this should not impact operators.

### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

No

### Does this PR make a change to an experimental or GA'd feature/component?

GA - I think?

### What is the level of urgency for publishing this change?

Not urgent - we're working around via an operator file.
