### PR TITLE
remove log-cache group-reader job

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1335,10 +1335,6 @@ instance_groups:
     properties:
       gateway_addr: localhost:8081
     release: log-cache
-  - name: log-cache-group-reader
-    properties:
-      port: 8084
-    release: log-cache
   - consumes:
       reverse_log_proxy: {from: reverse_log_proxy}
     name: log-cache-nozzle

--- a/operations/disable-log-cache.yml
+++ b/operations/disable-log-cache.yml
@@ -4,8 +4,6 @@
 - type: remove
   path: /instance_groups/name=doppler/jobs/name=log-cache-gateway
 - type: remove
-  path: /instance_groups/name=doppler/jobs/name=log-cache-group-reader
-- type: remove
   path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder
 - type: remove
   path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy


### PR DESCRIPTION
Signed-off-by: Mark Gangl <mgangl@pivotal.io>

### WHAT is this change about?

We're removing the experimental group_reader feature, and so we're dropping it from cf-deployment.

### WHY is this change being made (What problem is being addressed)?

The feature was unstable and addressing a problem for which we have not established much customer support.

### Please provide contextual information.

Feel free to reach out to us in #cf-log-cache on the cloudfoundry slack. This should just remove one process from the set that runs on the doppler VM.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES 
- [ ] NO


### How should this change be described in cf-deployment release notes?

Log-cache is removing the experimental group_reader feature


### Does this PR introduce a breaking change? 

No - it precludes it. `log-cache` v1.4.5 will no longer contain this job, so it needs to be dropped from the manifest before that version bump.


### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [ ] GA'd feature/component


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@hdub2 @attack @toddboom @cloudfoundry/cf-log-cache 
