### PR TITLE
Add ops-files to add credhub support to NFS volume services

### DIFF
--- a/operations/example-vars-files/vars-migrate-nfsbroker-mysql-to-credhub.yml
+++ b/operations/example-vars-files/vars-migrate-nfsbroker-mysql-to-credhub.yml
@@ -1,0 +1,3 @@
+---
+nfs-broker-database-password: password
+nfs-broker-credhub-uaa-client-secret: secret

--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -34,6 +34,7 @@ and the ops-files will be removed.
 | [`enable-bpm-garden.yml`](enable-bpm-garden.yml) | Enables the [BOSH Process Manager](https://github.com/cloudfoundry-incubator/bpm-release) for Garden. This ops file cannot be deployed in conjunction with `use-garden-containerd.yml` | |
 | [`enable-iptables-logger.yml`](enable-iptables-logger.yml) | Enables iptables logger. | |
 | [`enable-mysql-tls.yml`](enable-mysql-tls.yml) | Enables TLS on the database job, and secures all client database connections. | |
+| [`enable-nfs-volume-service-credhub.yml`](enable-nfs-volume-service-credhub.yml) | Enables credhub integration for NFS volume services | Requires `enable-nfs-volume-service.yml` |
 | [`enable-oci-phase-1.yml`](enable-oci-phase-1.yml) | Configure Garden to create OCI compatible images. | |
 | [`enable-routing-integrity.yml`](enable-routing-integrity.yml) | Enables container proxy on the Diego Cell `rep` and configures gorouter to opt into TLS-enabled connections to the backend. | |
 | [`enable-smb-volume-service.yml`](enable-smb-volume-service.yml) | Enables volume support and deploys an SMB broker and volume driver | As of cf-deployment v2, you must use the `azurefilebrokerpush` errand to cf push the smb broker after `bosh deploy` completes. |
@@ -43,6 +44,7 @@ and the ops-files will be removed.
 | [`fast-deploy-with-downtime-and-danger.yml`](fast-deploy-with-downtime-and-danger.yml) | Risky, but fast. Disable canaries, increase the max number of vms bosh will update simultaneously, and remove `serial: true` from most instance groups to enable faster, but probably downtimeful, deploys. | |
 | ['infrastructure-metrics.yml`](infrastructure-metrics.yml) | Add the Prometheus node exporter and Loggregator Prom Scraper to addons. This puts infrastructure metrics into Loggregator's metric stream. | |
 | [`migrate-cf-mysql-to-pxc.yml`](migrate-cf-mysql-to-pxc.yml) | Migrates from an existing cf-mysql database to [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release). After the migration is complete, switch to the `use-pxc.yml` operations file. | |
+| [`migrate-nfsbroker-mysql-to-credhub.yml`](migrate-nfsbroker-mysql-to-credhub.yml) | Migrates existing NFS volume services state storage from MySQL to Credhub | Requires `enable-nfs-volume-service.yml` |
 | [`perm-service.yml`](perm-service.yml) | Deploy CF with [Perm Service](https://github.com/cloudfoundry-incubator/perm) | Requires `enable-mysql-tls.yml`. See the [deployment section of perm-release's README file](https://github.com/cloudfoundry-incubator/perm-release/blob/master/README.md#deploying-perm-with-cf-deployment) for more information|
 | [`perm-service-with-pxc-release.yml`](perm-service-with-pxc-release.yml) | Use [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release) as data store for Perm Service. | Requires `perm-service.yml` and `use-pxc.yml`. |
 | [`rootless-containers.yml`](rootless-containers.yml) | Enable rootless garden-runc containers. | Requires garden-runc 1.9.5 or later and grootfs 0.27.0 or later. This ops file cannot be deployed in conjunction with `use-garden-containerd.yml` |

--- a/operations/experimental/enable-nfs-volume-service-credhub.yml
+++ b/operations/experimental/enable-nfs-volume-service-credhub.yml
@@ -1,0 +1,120 @@
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/volume_services_enabled?
+  value: true
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/volume_services_enabled?
+  value: true
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/volume_services_enabled?
+  value: true
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/nfs-broker-credhub-client?
+  value:
+    authorities: credhub.read,credhub.write
+    authorized-grant-types: client_credentials
+    secret: ((nfs-broker-credhub-uaa-client-secret))
+- type: replace
+  path: /instance_groups/-
+  value:
+    azs: [z1]
+    lifecycle: errand
+    instances: 1
+    jobs:
+    - name: nfsbrokerpush
+      properties:
+        nfsbrokerpush:
+          app_name: nfs-broker-credhub
+          domain: ((system_domain))
+          app_domain: ((system_domain))
+          register_broker: true
+          create_sql_security_group: false
+          create_credhub_security_group: true
+          cf:
+            admin_password: ((cf_admin_password))
+            admin_user: admin
+          organization: system
+          space: nfs-broker-space
+          password: ((nfs-broker-credhub-password))
+          username: nfs-broker
+          broker_name: nfs-credhub-broker
+          syslog_url: ""
+          skip_cert_verify: true
+          credhub:
+            url: https://credhub.service.cf.internal:8844
+            uaa_client_id: nfs-broker-credhub-client
+            uaa_client_secret: ((nfs-broker-credhub-uaa-client-secret))
+          services:
+          - id: "2b1ae04-6a97-4d6f-8979-fbe0bb3331c1"
+            name: "nfs-credhub"
+            description: "Existing NFSv3 volumes with CredHub as a store"
+            bindable: true
+            plan_updatable: false
+            tags: ["nfs"]
+            requires: ["volume_mount"]
+            plans:
+            - id: "6316d9ca-9d05-44c2-b652-b83d60cf2f93"
+              name: "Existing"
+              description: "A preexisting filesystem"
+          - id: "d8ab29a9-81d0-4e45-afcd-fb9ed858ccf4"
+            name: "nfs-credhub-experimental"
+            description: "Experimental support for NFSv3 and v4 with CredHub as a store"
+            bindable: true
+            plan_updatable: false
+            tags: ["nfs", "experimental"]
+            requires: ["volume_mount"]
+            plans:
+            - id: "2e315570-802f-44fd-886c-1a2d6676da9d"
+              name: "Existing"
+              description: "A preexisting filesystem"
+      release: nfs-volume
+    - name: cf-cli-6-linux
+      release: cf-cli
+    name: nfs-broker-credhub-push
+    networks:
+    - name: default
+    stemcell: default
+    vm_type: minimal
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver?
+  value:
+    name: nfsv3driver
+    properties: {}
+    release: nfs-volume
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=mapfs?
+  value:
+    name: mapfs
+    release: mapfs
+
+- type: replace
+  path: /variables/-
+  value:
+    name: nfs-broker-credhub-password
+    type: password
+- type: replace
+  path: /variables/-
+  value:
+    name: nfs-broker-credhub-uaa-client-secret
+    type: password
+
+- type: replace
+  path: /releases/name=nfs-volume?
+  value:
+    name: nfs-volume
+    sha1: de807ffa3fc84949bb92edac6a4152245826d6da
+    url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=1.2.0
+    version: 1.2.0
+- type: replace
+  path: /releases/name=mapfs?
+  value:
+    name: "mapfs"
+    version: "1.0.1"
+    url: "https://bosh.io/d/github.com/cloudfoundry/mapfs-release?v=1.0.1"
+    sha1: "9dcea268d327caff76690229ac09f57a0c83cf65"
+- type: replace
+  path: /releases/name=cf-cli?
+  value:
+    name: cf-cli
+    url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.5.0
+    sha1: 6749a07026e335f7744f013c9707911fb72170b5
+    version: 1.5.0

--- a/operations/experimental/migrate-nfsbroker-mysql-to-credhub.yml
+++ b/operations/experimental/migrate-nfsbroker-mysql-to-credhub.yml
@@ -1,0 +1,37 @@
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: migrate-mysql-to-credhub
+    networks:
+    - name: default
+    stemcell: default
+    vm_type: minimal
+    azs: [z1]
+    lifecycle: errand
+    instances: 1
+    jobs:
+    - name: migrate_mysql_to_credhub
+      release: nfs-volume
+      properties:
+        app_name: nfs-broker
+        domain: ((system_domain))
+        cf:
+          admin_password: ((cf_admin_password))
+          admin_user: admin
+        organization: system
+        space: nfs-broker-space
+        skip_cert_verify: true
+        db:
+          driver: mysql
+          name: nfs-broker
+          password: ((nfs-broker-database-password))
+          port: 3306
+          username: nfs-broker
+        credhub:
+          url: https://credhub.service.cf.internal:8844
+          uaa_client_id: nfs-broker-credhub-client
+          uaa_client_secret: ((nfs-broker-credhub-uaa-client-secret))
+          ca_cert: |
+            ((credhub_ca.certificate))
+          uaa_ca_cert: |
+            ((uaa_ca.certificate))

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -25,6 +25,7 @@ test_experimental_ops() {
       check_interpolation "enable-bpm.yml"
       check_interpolation "enable-iptables-logger.yml"
       check_interpolation "enable-mysql-tls.yml"
+      check_interpolation "enable-nfs-volume-service-credhub.yml"
       check_interpolation "enable-oci-phase-1.yml"
       check_interpolation "enable-routing-integrity.yml"
       check_interpolation "enable-smb-volume-service.yml"
@@ -36,6 +37,7 @@ test_experimental_ops() {
 
       check_interpolation "infrastructure-metrics.yml"
       check_interpolation "migrate-cf-mysql-to-pxc.yml"
+      check_interpolation "name: migrate-nfsbroker-mysql-to-credhub.yml" "${home}/operations/enable-nfs-volume-service.yml" "-o migrate-nfsbroker-mysql-to-credhub.yml" -l "${home}/operations/example-vars-files/vars-migrate-nfsbroker-mysql-to-credhub.yml"
 
       check_interpolation "name: perm-service.yml" "enable-mysql-tls.yml" "-o perm-service.yml -v perm_uaa_clients_cc_perm_secret=perm_secret -v perm_uaa_clients_perm_monitor_secret=perm_monitor_secret"
       check_interpolation "name: perm-service-with-pxc-release.yml" "perm-service.yml" "-o use-pxc.yml" "-o perm-service-with-pxc-release.yml -v perm_uaa_clients_cc_perm_secret=perm_secret -v perm_uaa_clients_perm_monitor_secret=perm_monitor_secret"


### PR DESCRIPTION
### WHAT is this change about?

We've been using these ops-files in our CI along with the old `secure-service-credentials.yml` experimental ops-file to enable credhub support for NFS volume services.

### WHY is this change being made (What problem is being addressed)?

Now that credhub is GA in v4.0.0, we want to add them to cf-d as experimental ops-files.

### Please provide contextual information.

[#160035537](https://www.pivotaltracker.com/story/show/160035537)

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO but they are tested in our acceptance test suite (PATs)

### How should this change be described in cf-deployment release notes?

New Ops-files

- operations/experimental/enable-nfs-volume-service-credhub.yml
  - NFS volume release v1.4.0 introduces support for using CredHub instead of a SQL database to store state for nfs broker. CredHub has the advantage that it encrypts data at rest and is therefore a more secure store for service instance and service binding metadata. CredHub is required if you are using the LDAP integration, and you wish to specify user credentials at service instance creation time, rather than at service binding time.
- operations/experimental/migrate-nfsbroker-mysql-to-credhub.yml
  - If you have been running your NFS broker with a MySQL database to store state, this ops-file creates an errand called `migrate_mysql_to_credhub` to allow you to migrate your service bindings and instances from MySQL to Credhub.

### Does this PR introduce a breaking change? 

- [ ] YES --- does it really have to?
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [x] YES --- does it really have to?
- [ ] NO

If migration is required, it adds a short-lived errand VM.

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._

@julian-hj @paulcwarren @mariash 