### PR TITLE
Add RLP Gateway to log-api

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1643,6 +1643,26 @@ instance_groups:
           reverse_log_proxy:
             cert: "((loggregator_tls_rlp.certificate))"
             key: "((loggregator_tls_rlp.private_key))"
+  - name: reverse_log_proxy_gateway
+    release: loggregator
+    properties:
+      http:
+        address: "0.0.0.0:8088"
+      logs_provider:
+        ca_cert: "((loggregator_rlp_gateway.ca))"
+        client_cert: "((loggregator_rlp_gateway.certificate))"
+        client_key: "((loggregator_rlp_gateway.private_key))"
+      cc:
+        capi_internal_addr: https://cloud-controller-ng.service.cf.internal:9023
+        ca_cert: ((loggregator_rlp_gateway_tls_cc.ca))
+        cert: ((loggregator_rlp_gateway_tls_cc.certificate))
+        key: ((loggregator_rlp_gateway_tls_cc.private_key))
+        common_name: cloud-controller-ng.service.cf.internal
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        client_id: doppler
+        client_secret: ((uaa_clients_doppler_secret))
+        internal_addr: https://uaa.service.cf.internal:8443
   - name: route_registrar
     release: routing
     properties:
@@ -1659,6 +1679,12 @@ instance_groups:
           uris:
           - doppler.((system_domain))
           - "*.doppler.((system_domain))"
+        - name: rlp-gateway
+          port: 8088
+          registration_interval: 20s
+          uris:
+          - log-stream.((system_domain))
+          - "*.log-stream.((system_domain))"
 - name: credhub
   azs: [z1, z2]
   instances: 2
@@ -1988,6 +2014,13 @@ variables:
     common_name: trafficcontroller
     extended_key_usage:
     - client_auth
+- name: loggregator_rlp_gateway_tls_cc
+  type: certificate
+  options:
+    ca: service_cf_internal_ca
+    common_name: rlp-gateway
+    extended_key_usage:
+    - client_auth
 - name: loggregator_tls_rlp
   type: certificate
   options:
@@ -1996,6 +2029,13 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+- name: loggregator_rlp_gateway
+  type: certificate
+  options:
+    ca: loggregator_ca
+    common_name: rlp_gateway
+    extended_key_usage:
+    - client_auth
 - name: adapter_rlp_tls
   type: certificate
   options:

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1649,12 +1649,12 @@ instance_groups:
       http:
         address: "0.0.0.0:8088"
       logs_provider:
-        ca_cert: "((loggregator_rlp_gateway.ca))"
+        ca_cert: "((loggregator_ca.certificate))"
         client_cert: "((loggregator_rlp_gateway.certificate))"
         client_key: "((loggregator_rlp_gateway.private_key))"
       cc:
         capi_internal_addr: https://cloud-controller-ng.service.cf.internal:9023
-        ca_cert: ((loggregator_rlp_gateway_tls_cc.ca))
+        ca_cert: ((service_cf_internal_ca.certificate))
         cert: ((loggregator_rlp_gateway_tls_cc.certificate))
         key: ((loggregator_rlp_gateway_tls_cc.private_key))
         common_name: cloud-controller-ng.service.cf.internal


### PR DESCRIPTION
### WHAT is this change about?

Add the Reverse Log Proxy (RLP) Gateway to the log-api instance group.

### WHY is this change being made (What problem is being addressed)?

This job exposes the Loggregator V2 API over Server Sent Events (SSE) via the go-router. This will provide users a more flexible API to stream logs and metrics.

### Please provide contextual information.

* https://github.com/cloudfoundry/loggregator-release#rlp-gateway
* https://github.com/cloudfoundry/loggregator-release/blob/3a8f04a2e250ac6b15fcf8903cb5e0fe90fdac05/jobs/reverse_log_proxy_gateway/spec


### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES (Using [ops-file](https://github.com/cloudfoundry/loggregator-release/blob/develop/manifests/operations/add-rlp-gateway-to-cf.yml))
- [ ] NO

### How should this change be described in cf-deployment release notes?

Exposes the Loggregator V2 API via the go-router using JSON over Server Sent Events.

### Does this PR introduce a breaking change? 

No. Loggregator V1 API will continue to work as normal.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@ahevenor @MasslessParticle 
