### PR TITLE
Add enable-create-swap-delete ops file

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -32,6 +32,7 @@ and the ops-files will be removed.
 | [`enable-bits-service-consul.yml`](enable-bits-service-consul.yml) | Registers the bits-service [bits-service](https://github.com/cloudfoundry-incubator/bits-service) job via consul | Requires `bits-service.yml` from the same directory. |
 | [`enable-bpm.yml`](enable-bpm.yml) | **DEPRECATED**. BPM for these components is enabled in `cf-deployment.yml`. Enables the [BOSH Process Manager](https://github.com/cloudfoundry-incubator/bpm-release) for several BOSH jobs. | |
 | [`enable-bpm-garden.yml`](enable-bpm-garden.yml) | Enables the [BOSH Process Manager](https://github.com/cloudfoundry-incubator/bpm-release) for Garden. This ops file cannot be deployed in conjunction with `use-garden-containerd.yml` | |
+| [`enable-create-swap-delete.yml`](enable-create-swap-delete.yml) | Configures the default [`vm_strategy`](https://bosh.io/docs/changing-deployment-vm-strategy/) to be `create-swap-delete`. | Requires BOSH director `v267.7+` |
 | [`enable-iptables-logger.yml`](enable-iptables-logger.yml) | Enables iptables logger. | |
 | [`enable-mysql-tls.yml`](enable-mysql-tls.yml) | Enables TLS on the database job, and secures all client database connections. | |
 | [`enable-oci-phase-1.yml`](enable-oci-phase-1.yml) | Configure Garden to create OCI compatible images. | |

--- a/operations/experimental/enable-create-swap-delete.yml
+++ b/operations/experimental/enable-create-swap-delete.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /update/vm_strategy?
+  value: "create-swap-delete"
+
+- type: replace
+  path: /instance_groups/name=consul/update/vm_strategy?
+  value: "delete-create"

--- a/scripts/test-experimental-ops.sh
+++ b/scripts/test-experimental-ops.sh
@@ -31,6 +31,7 @@ test_experimental_ops() {
       check_interpolation "enable-suspect-actual-lrp-generation.yml"
       check_interpolation "enable-traffic-to-internal-networks.yml"
       check_interpolation "name: enable-tls-cloud-controller-postgres.yml" "${home}/operations/use-postgres.yml" "-o enable-tls-cloud-controller-postgres.yml"
+      check_interpolation "enable-create-swap-delete.yml"
 
       check_interpolation "fast-deploy-with-downtime-and-danger.yml"
 


### PR DESCRIPTION
### WHAT is this change about?

This ops file changes the default `vm_strategy` for all instance groups in cf-deployment to use `create-swap-delete`, instead of the default `delete-create` strategy.

### WHY is this change being made (What problem is being addressed)?

To allow users to experiment with the `create-swap-delete` feature and provide user feedback to the BOSH team.

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/160155346

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO

**Note**: This change does not update the resulting deployment. Only the process by which instances are updated. This should not have any effect on the cf-acceptance-tests.

### How should this change be described in cf-deployment release notes?

Add experimental operation file that configures the default [`vm_strategy`](https://bosh.io/docs/changing-deployment-vm-strategy/) to be `create-swap-delete`. This operations file requires BOSH director `v267.7+`

### Does this PR introduce a breaking change? 

No.

### Will this change increase the VM footprint of cf-deployment?

- [x] YES --- does it really have to?
- [ ] NO

The VM footprint will be temporarily increased during a deploy. This is due to asynchronous deletion of VMs.

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@mfine30 