### PR TITLE
Loggregator iso segments

### DIFF
--- a/interpolated
+++ b/interpolated
@@ -1,0 +1,2893 @@
+addons:
+- exclude:
+    instance_groups:
+    - name: isolated-diego-cell
+    - name: isolated-doppler
+    - name: isolated-log-api
+  include:
+    stemcell:
+    - os: ubuntu-xenial
+  jobs:
+  - consumes:
+      doppler:
+        from: doppler
+    name: loggregator_agent
+    properties:
+      loggregator:
+        tls:
+          agent:
+            cert: ((loggregator_tls_agent.certificate))
+            key: ((loggregator_tls_agent.private_key))
+          ca_cert: ((loggregator_ca.certificate))
+    release: loggregator-agent
+  name: loggregator_agent
+- include:
+    stemcell:
+    - os: ubuntu-xenial
+  jobs:
+  - name: bpm
+    release: bpm
+  name: bpm
+- jobs:
+  - name: bosh-dns-aliases
+    properties:
+      aliases:
+      - domain: _.cell.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: diego-cell
+          network: default
+          query: _
+        - deployment: cf
+          domain: bosh
+          instance_group: windows2012R2-cell
+          network: default
+          query: _
+        - deployment: cf
+          domain: bosh
+          instance_group: windows2016-cell
+          network: default
+          query: _
+        - deployment: cf
+          domain: bosh
+          instance_group: isolated-diego-cell
+          network: default
+          query: _
+      - domain: auctioneer.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: scheduler
+          network: default
+          query: q-s4
+      - domain: bbs.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: diego-api
+          network: default
+          query: q-s4
+      - domain: bits.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: bits
+          network: default
+          query: '*'
+      - domain: blobstore.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: singleton-blobstore
+          network: default
+          query: '*'
+      - domain: cc-uploader.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: api
+          network: default
+          query: '*'
+      - domain: cloud-controller-ng.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: api
+          network: default
+          query: '*'
+      - domain: credhub.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: credhub
+          network: default
+          query: '*'
+      - domain: doppler.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: doppler
+          network: default
+          query: '*'
+      - domain: file-server.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: api
+          network: default
+          query: '*'
+      - domain: gorouter.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: router
+          network: default
+          query: '*'
+      - domain: locket.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: diego-api
+          network: default
+          query: '*'
+      - domain: loggregator-trafficcontroller.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: log-api
+          network: default
+          query: '*'
+      - domain: policy-server.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: api
+          network: default
+          query: '*'
+      - domain: reverse-log-proxy.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: log-api
+          network: default
+          query: '*'
+      - domain: routing-api.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: api
+          network: default
+          query: '*'
+      - domain: silk-controller.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: diego-api
+          network: default
+          query: '*'
+      - domain: sql-db.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: database
+          network: default
+          query: '*'
+      - domain: ssh-proxy.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: scheduler
+          network: default
+          query: '*'
+      - domain: tps.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: scheduler
+          network: default
+          query: '*'
+      - domain: uaa.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: uaa
+          network: default
+          query: '*'
+      - domain: isolated-doppler.service.cf.internal
+        targets:
+        - deployment: cf
+          domain: bosh
+          instance_group: isolated-doppler
+          network: default
+          query: '*'
+    release: bosh-dns-aliases
+  name: bosh-dns-aliases
+instance_groups:
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: smoke_tests
+    properties:
+      bpm:
+        enabled: true
+      smoke_tests:
+        api: https://api.((system_domain))
+        apps_domain: ((system_domain))
+        cf_dial_timeout_in_seconds: 300
+        org: cf_smoke_tests_org
+        password: ((cf_bosh_password))
+        skip_ssl_validation: true
+        space: cf_smoke_tests_space
+        user: bosh
+    release: cf-smoke-tests
+  - name: cf-cli-6-linux
+    release: cf-cli
+  lifecycle: errand
+  name: smoke-tests
+  networks:
+  - name: default
+  stemcell: default
+  update:
+    serial: true
+  vm_type: minimal
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - name: nats
+    properties:
+      nats:
+        password: ((nats_password))
+        user: nats
+    provides:
+      nats:
+        as: nats
+        shared: true
+    release: nats
+  name: nats
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - consumes:
+      reverse_log_proxy:
+        from: reverse_log_proxy
+    name: adapter
+    properties:
+      scalablesyslog:
+        adapter:
+          logs:
+            addr: reverse-log-proxy.service.cf.internal:8082
+          tls:
+            ca: ((loggregator_ca.certificate))
+            cert: ((adapter_tls.certificate))
+            cn: ss-adapter
+            key: ((adapter_tls.private_key))
+        adapter_rlp:
+          tls:
+            ca: ((loggregator_ca.certificate))
+            cert: ((adapter_rlp_tls.certificate))
+            cn: reverselogproxy
+            key: ((adapter_rlp_tls.private_key))
+    release: cf-syslog-drain
+  name: adapter
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: mysql
+    properties:
+      cf_mysql:
+        mysql:
+          admin_password: ((cf_mysql_mysql_admin_password))
+          binlog_enabled: false
+          cluster_health:
+            password: ((cf_mysql_mysql_cluster_health_password))
+          galera_healthcheck:
+            db_password: ((cf_mysql_mysql_galera_healthcheck_password))
+            endpoint_password: ((cf_mysql_mysql_galera_healthcheck_endpoint_password))
+            endpoint_username: galera_healthcheck
+          port: 13306
+          seeded_databases:
+          - name: cloud_controller
+            password: ((cc_database_password))
+            username: cloud_controller
+          - name: credhub
+            password: ((credhub_database_password))
+            username: credhub
+          - name: diego
+            password: ((diego_database_password))
+            username: diego
+          - name: network_connectivity
+            password: ((network_connectivity_database_password))
+            username: network_connectivity
+          - name: network_policy
+            password: ((network_policy_database_password))
+            username: network_policy
+          - name: routing-api
+            password: ((routing_api_database_password))
+            username: routing-api
+          - name: uaa
+            password: ((uaa_database_password))
+            username: uaa
+          - name: locket
+            password: ((locket_database_password))
+            username: locket
+    release: cf-mysql
+  - name: proxy
+    properties:
+      cf_mysql:
+        proxy:
+          api_password: ((cf_mysql_proxy_api_password))
+    release: cf-mysql
+  migrated_from:
+  - name: mysql
+  - name: singleton-database
+  name: database
+  networks:
+  - name: default
+  persistent_disk_type: 10GB
+  stemcell: default
+  update:
+    serial: true
+  vm_type: small
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - name: cfdot
+    properties:
+      tls:
+        ca_certificate: ((service_cf_internal_ca.certificate))
+        certificate: ((diego_rep_client.certificate))
+        private_key: ((diego_rep_client.private_key))
+    release: diego
+  - name: bbs
+    properties:
+      bpm:
+        enabled: true
+      diego:
+        bbs:
+          active_key_label: key-2016-06
+          auctioneer:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            client_cert: ((diego_auctioneer_client.certificate))
+            client_key: ((diego_auctioneer_client.private_key))
+          ca_cert: ((service_cf_internal_ca.certificate))
+          detect_consul_cell_registrations: false
+          encryption_keys:
+          - label: key-2016-06
+            passphrase: ((diego_bbs_encryption_keys_passphrase))
+          rep:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            client_cert: ((diego_rep_client.certificate))
+            client_key: ((diego_rep_client.private_key))
+            require_tls: true
+          server_cert: ((diego_bbs_server.certificate))
+          server_key: ((diego_bbs_server.private_key))
+          skip_consul_lock: true
+          sql:
+            db_driver: mysql
+            db_host: sql-db.service.cf.internal
+            db_password: ((diego_database_password))
+            db_port: 3306
+            db_schema: diego
+            db_username: diego
+      enable_consul_service_registration: false
+      logging:
+        format:
+          timestamp: rfc3339
+      loggregator:
+        ca_cert: ((loggregator_ca.certificate))
+        cert: ((loggregator_tls_agent.certificate))
+        key: ((loggregator_tls_agent.private_key))
+        use_v2_api: true
+    release: diego
+  - name: silk-controller
+    properties:
+      ca_cert: ((silk_ca.certificate))
+      database:
+        host: sql-db.service.cf.internal
+        name: network_connectivity
+        password: ((network_connectivity_database_password))
+        port: 3306
+        type: mysql
+        username: network_connectivity
+      server_cert: ((silk_controller.certificate))
+      server_key: ((silk_controller.private_key))
+      silk_daemon:
+        ca_cert: ((silk_ca.certificate))
+        client_cert: ((silk_daemon.certificate))
+        client_key: ((silk_daemon.private_key))
+    release: silk
+  - name: locket
+    properties:
+      bpm:
+        enabled: true
+      diego:
+        locket:
+          sql:
+            db_driver: mysql
+            db_host: sql-db.service.cf.internal
+            db_password: ((locket_database_password))
+            db_port: 3306
+            db_schema: locket
+            db_username: locket
+      enable_consul_service_registration: false
+      logging:
+        format:
+          timestamp: rfc3339
+      loggregator:
+        ca_cert: ((loggregator_ca.certificate))
+        cert: ((loggregator_tls_agent.certificate))
+        key: ((loggregator_tls_agent.private_key))
+        use_v2_api: true
+      tls:
+        ca_cert: ((service_cf_internal_ca.certificate))
+        cert: ((diego_locket_server.certificate))
+        key: ((diego_locket_server.private_key))
+    release: diego
+  migrated_from:
+  - name: diego-bbs
+  name: diego-api
+  networks:
+  - name: default
+  stemcell: default
+  update:
+    serial: true
+  vm_type: small
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - name: uaa
+    properties:
+      bpm:
+        enabled: true
+      encryption:
+        active_key_label: default_key
+        encryption_keys:
+        - label: default_key
+          passphrase: ((uaa_default_encryption_passphrase))
+      login:
+        saml:
+          activeKeyId: key-1
+          keys:
+            key-1:
+              certificate: ((uaa_login_saml.certificate))
+              key: ((uaa_login_saml.private_key))
+              passphrase: ""
+      uaa:
+        admin:
+          client_secret: ((uaa_admin_client_secret))
+        clients:
+          cc-service-dashboards:
+            authorities: clients.read,clients.write,clients.admin
+            authorized-grant-types: client_credentials
+            scope: openid,cloud_controller_service_permissions.read
+            secret: ((uaa_clients_cc-service-dashboards_secret))
+          cc_routing:
+            authorities: routing.router_groups.read
+            authorized-grant-types: client_credentials
+            secret: ((uaa_clients_cc-routing_secret))
+          cc_service_key_client:
+            authorities: credhub.read,credhub.write
+            authorized-grant-types: client_credentials
+            secret: ((uaa_clients_cc_service_key_client_secret))
+          cf:
+            access-token-validity: 600
+            authorities: uaa.none
+            authorized-grant-types: password,refresh_token
+            override: true
+            refresh-token-validity: 2592000
+            scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor,perm.admin
+            secret: ""
+          cloud_controller_username_lookup:
+            authorities: scim.userids
+            authorized-grant-types: client_credentials
+            secret: ((uaa_clients_cloud_controller_username_lookup_secret))
+          credhub_admin_client:
+            authorities: credhub.read,credhub.write
+            authorized-grant-types: client_credentials
+            secret: ((credhub_admin_client_secret))
+          doppler:
+            authorities: uaa.resource
+            authorized-grant-types: client_credentials
+            override: true
+            secret: ((uaa_clients_doppler_secret))
+          gorouter:
+            authorities: routing.routes.read
+            authorized-grant-types: client_credentials
+            secret: ((uaa_clients_gorouter_secret))
+          isolated-doppler:
+            authorities: uaa.resource
+            authorized-grant-types: client_credentials
+            override: true
+            secret: ((uaa_clients_isolated_doppler_secret))
+          network-policy:
+            authorities: uaa.resource,cloud_controller.admin_read_only
+            authorized-grant-types: client_credentials
+            secret: ((uaa_clients_network_policy_secret))
+          routing_api_client:
+            authorities: routing.routes.write,routing.routes.read,routing.router_groups.read
+            authorized-grant-types: client_credentials
+            secret: ((uaa_clients_routing_api_client_secret))
+          ssh-proxy:
+            authorized-grant-types: authorization_code
+            autoapprove: true
+            override: true
+            redirect-uri: https://uaa.((system_domain))/login
+            scope: openid,cloud_controller.read,cloud_controller.write,cloud_controller.admin
+            secret: ((uaa_clients_ssh-proxy_secret))
+          tcp_emitter:
+            authorities: routing.routes.write,routing.routes.read
+            authorized-grant-types: client_credentials
+            secret: ((uaa_clients_tcp_emitter_secret))
+          tcp_router:
+            authorities: routing.routes.read
+            authorized-grant-types: client_credentials
+            secret: ((uaa_clients_tcp_router_secret))
+        jwt:
+          policy:
+            active_key_id: key-1
+            keys:
+              key-1:
+                signingKey: ((uaa_jwt_signing_key.private_key))
+        logging_level: INFO
+        scim:
+          users:
+          - groups:
+            - cloud_controller.admin
+            - doppler.firehose
+            - network.admin
+            - openid
+            - routing.router_groups.read
+            - routing.router_groups.write
+            - scim.read
+            - scim.write
+            name: admin
+            password: ((cf_admin_password))
+          - groups:
+            - cloud_controller.admin
+            - doppler.firehose
+            - openid
+            - routing.router_groups.read
+            - routing.router_groups.write
+            - scim.read
+            - scim.write
+            name: bosh
+            password: ((cf_bosh_password))
+        sslCertificate: ((uaa_ssl.certificate))
+        sslPrivateKey: ((uaa_ssl.private_key))
+        url: https://uaa.((system_domain))
+        zones:
+          internal:
+            hostnames:
+            - uaa.service.cf.internal
+      uaadb:
+        databases:
+        - name: uaa
+          tag: uaa
+        db_scheme: mysql
+        port: 3306
+        roles:
+        - name: uaa
+          password: ((uaa_database_password))
+          tag: admin
+    release: uaa
+  - name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - health_check:
+            name: uaa-healthcheck
+            script_path: /var/vcap/jobs/uaa/bin/health_check
+          name: uaa
+          port: 8080
+          registration_interval: 10s
+          tags:
+            component: uaa
+          uris:
+          - uaa.((system_domain))
+          - '*.uaa.((system_domain))'
+          - login.((system_domain))
+          - '*.login.((system_domain))'
+    release: routing
+  - name: statsd_injector
+    properties:
+      loggregator:
+        tls:
+          ca_cert: ((loggregator_ca.certificate))
+          statsd_injector:
+            cert: ((loggregator_tls_statsdinjector.certificate))
+            key: ((loggregator_tls_statsdinjector.private_key))
+    release: statsd-injector
+  name: uaa
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: blobstore
+    properties:
+      blobstore:
+        admin_users:
+        - password: ((blobstore_admin_users_password))
+          username: blobstore-user
+        secure_link:
+          secret: ((blobstore_secure_link_secret))
+        tls:
+          cert: ((blobstore_tls.certificate))
+          private_key: ((blobstore_tls.private_key))
+      system_domain: ((system_domain))
+    release: capi
+  - name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: blobstore
+          port: 8080
+          registration_interval: 20s
+          tags:
+            component: blobstore
+          uris:
+          - blobstore.((system_domain))
+    release: routing
+  migrated_from:
+  - name: blobstore
+  name: singleton-blobstore
+  networks:
+  - name: default
+  persistent_disk_type: 100GB
+  stemcell: default
+  update:
+    serial: true
+  vm_type: small
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - consumes:
+      log-cache:
+        from: log_cache
+    name: cloud_controller_ng
+    properties:
+      app_domains:
+      - ((system_domain))
+      app_ssh:
+        host_key_fingerprint: ((diego_ssh_proxy_host_key.public_key_fingerprint))
+      cc:
+        buildpacks:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        bulk_api_password: ((cc_bulk_api_password))
+        database_encryption:
+          current_key_label: encryption_key_0
+          keys:
+            encryption_key_0: ((cc_db_encryption_key))
+        db_encryption_key: ((cc_db_encryption_key))
+        default_running_security_groups:
+        - public_networks
+        - dns
+        default_staging_security_groups:
+        - public_networks
+        - dns
+        droplets:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        install_buildpacks:
+        - name: staticfile_buildpack
+          package: staticfile-buildpack-cflinuxfs2
+        - name: java_buildpack
+          package: java-buildpack-cflinuxfs2
+        - name: ruby_buildpack
+          package: ruby-buildpack-cflinuxfs2
+        - name: dotnet_core_buildpack
+          package: dotnet-core-buildpack-cflinuxfs2
+        - name: nodejs_buildpack
+          package: nodejs-buildpack-cflinuxfs2
+        - name: go_buildpack
+          package: go-buildpack-cflinuxfs2
+        - name: python_buildpack
+          package: python-buildpack-cflinuxfs2
+        - name: php_buildpack
+          package: php-buildpack-cflinuxfs2
+        - name: binary_buildpack
+          package: binary-buildpack-cflinuxfs2
+        - name: staticfile_buildpack
+          package: staticfile-buildpack-cflinuxfs3
+        - name: java_buildpack
+          package: java-buildpack-cflinuxfs3
+        - name: ruby_buildpack
+          package: ruby-buildpack-cflinuxfs3
+        - name: dotnet_core_buildpack
+          package: dotnet-core-buildpack-cflinuxfs3
+        - name: nodejs_buildpack
+          package: nodejs-buildpack-cflinuxfs3
+        - name: go_buildpack
+          package: go-buildpack-cflinuxfs3
+        - name: python_buildpack
+          package: python-buildpack-cflinuxfs3
+        - name: php_buildpack
+          package: php-buildpack-cflinuxfs3
+        - name: binary_buildpack
+          package: binary-buildpack-cflinuxfs3
+        internal_api_password: ((cc_internal_api_password))
+        mutual_tls:
+          ca_cert: ((service_cf_internal_ca.certificate))
+          private_key: ((cc_tls.private_key))
+          public_cert: ((cc_tls.certificate))
+        packages:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        public_tls:
+          ca_cert: ((service_cf_internal_ca.certificate))
+          certificate: ((cc_public_tls.certificate))
+          private_key: ((cc_public_tls.private_key))
+        resource_pool:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        security_group_definitions:
+        - name: public_networks
+          rules:
+          - destination: 0.0.0.0-9.255.255.255
+            protocol: all
+          - destination: 11.0.0.0-169.253.255.255
+            protocol: all
+          - destination: 169.255.0.0-172.15.255.255
+            protocol: all
+          - destination: 172.32.0.0-192.167.255.255
+            protocol: all
+          - destination: 192.169.0.0-255.255.255.255
+            protocol: all
+        - name: dns
+          rules:
+          - destination: 0.0.0.0/0
+            ports: "53"
+            protocol: tcp
+          - destination: 0.0.0.0/0
+            ports: "53"
+            protocol: udp
+        stacks:
+        - description: Cloud Foundry Linux-based filesystem (Ubuntu 14.04)
+          name: cflinuxfs2
+        - description: Cloud Foundry Linux-based filesystem (Ubuntu 18.04)
+          name: cflinuxfs3
+        staging_upload_password: ((cc_staging_upload_password))
+        staging_upload_user: staging_user
+      ccdb:
+        databases:
+        - name: cloud_controller
+          tag: cc
+        db_scheme: mysql
+        port: 3306
+        roles:
+        - name: cloud_controller
+          password: ((cc_database_password))
+          tag: admin
+      credhub_api:
+        ca_cert: ((credhub_ca.certificate))
+      router:
+        route_services_secret: ((router_route_services_secret))
+      routing_api:
+        enabled: true
+      ssl:
+        skip_cert_verify: true
+      system_domain: ((system_domain))
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        clients:
+          cc-service-dashboards:
+            secret: ((uaa_clients_cc-service-dashboards_secret))
+          cc_routing:
+            secret: ((uaa_clients_cc-routing_secret))
+          cc_service_key_client:
+            secret: ((uaa_clients_cc_service_key_client_secret))
+          cloud_controller_username_lookup:
+            secret: ((uaa_clients_cloud_controller_username_lookup_secret))
+        url: https://uaa.((system_domain))
+    provides:
+      cloud_controller:
+        as: cloud_controller
+        shared: true
+    release: capi
+  - name: binary-buildpack
+    release: binary-buildpack
+  - name: dotnet-core-buildpack
+    release: dotnet-core-buildpack
+  - name: go-buildpack
+    release: go-buildpack
+  - name: java-buildpack
+    release: java-buildpack
+  - name: nodejs-buildpack
+    release: nodejs-buildpack
+  - name: php-buildpack
+    release: php-buildpack
+  - name: python-buildpack
+    release: python-buildpack
+  - name: ruby-buildpack
+    release: ruby-buildpack
+  - name: staticfile-buildpack
+    release: staticfile-buildpack
+  - name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - health_check:
+            name: api-health-check
+            script_path: /var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check
+            timeout: 6s
+          name: api
+          port: 9022
+          registration_interval: 10s
+          server_cert_domain_san: api.((system_domain))
+          tags:
+            component: CloudController
+          tls_port: 9024
+          uris:
+          - api.((system_domain))
+        - name: policy-server
+          port: 4002
+          registration_interval: 20s
+          uris:
+          - api.((system_domain))/networking
+    release: routing
+  - name: statsd_injector
+    properties:
+      loggregator:
+        tls:
+          ca_cert: ((loggregator_ca.certificate))
+          statsd_injector:
+            cert: ((loggregator_tls_statsdinjector.certificate))
+            key: ((loggregator_tls_statsdinjector.private_key))
+    release: statsd-injector
+  - name: file_server
+    properties:
+      bpm:
+        enabled: true
+      enable_consul_service_registration: false
+      logging:
+        format:
+          timestamp: rfc3339
+      loggregator:
+        ca_cert: ((loggregator_ca.certificate))
+        cert: ((loggregator_tls_agent.certificate))
+        key: ((loggregator_tls_agent.private_key))
+        use_v2_api: true
+    release: diego
+  - name: routing-api
+    properties:
+      routing_api:
+        locket:
+          api_location: locket.service.cf.internal:8891
+          ca_cert: ((service_cf_internal_ca.certificate))
+          client_cert: ((diego_locket_client.certificate))
+          client_key: ((diego_locket_client.private_key))
+        router_groups:
+        - name: default-tcp
+          reservable_ports: 1024-1123
+          type: tcp
+        skip_consul_lock: true
+        sqldb:
+          host: sql-db.service.cf.internal
+          password: ((routing_api_database_password))
+          port: 3306
+          schema: routing-api
+          type: mysql
+          username: routing-api
+        system_domain: ((system_domain))
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        tls_port: 8443
+    release: routing
+  - name: policy-server
+    properties:
+      database:
+        host: sql-db.service.cf.internal
+        name: network_policy
+        password: ((network_policy_database_password))
+        port: 3306
+        type: mysql
+        username: network_policy
+      enable_space_developer_self_service: true
+      uaa_ca: ((uaa_ca.certificate))
+      uaa_client_secret: ((uaa_clients_network_policy_secret))
+    release: cf-networking
+  - name: policy-server-internal
+    properties:
+      ca_cert: ((network_policy_ca.certificate))
+      server_cert: ((network_policy_server.certificate))
+      server_key: ((network_policy_server.private_key))
+    release: cf-networking
+  - name: cc_uploader
+    properties:
+      capi:
+        cc_uploader:
+          cc:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            client_cert: ((cc_bridge_cc_uploader.certificate))
+            client_key: ((cc_bridge_cc_uploader.private_key))
+          mutual_tls:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            server_cert: ((cc_bridge_cc_uploader_server.certificate))
+            server_key: ((cc_bridge_cc_uploader_server.private_key))
+    release: capi
+  name: api
+  networks:
+  - name: default
+  stemcell: default
+  vm_extensions:
+  - 50GB_ephemeral_disk
+  vm_type: small
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - name: cloud_controller_worker
+    properties:
+      cc:
+        buildpacks:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        database_encryption:
+          current_key_label: encryption_key_0
+          keys:
+            encryption_key_0: ((cc_db_encryption_key))
+        db_encryption_key: ((cc_db_encryption_key))
+        droplets:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        internal_api_password: ((cc_internal_api_password))
+        mutual_tls:
+          ca_cert: ((service_cf_internal_ca.certificate))
+          private_key: ((cc_tls.private_key))
+          public_cert: ((cc_tls.certificate))
+        packages:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        resource_pool:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        staging_upload_password: ((cc_staging_upload_password))
+        staging_upload_user: staging_user
+      ccdb:
+        databases:
+        - name: cloud_controller
+          tag: cc
+        db_scheme: mysql
+        port: 3306
+        roles:
+        - name: cloud_controller
+          password: ((cc_database_password))
+          tag: admin
+      routing_api:
+        enabled: true
+      ssl:
+        skip_cert_verify: true
+      system_domain: ((system_domain))
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        clients:
+          cc-service-dashboards:
+            secret: ((uaa_clients_cc-service-dashboards_secret))
+          cc_routing:
+            secret: ((uaa_clients_cc-routing_secret))
+    release: capi
+  name: cc-worker
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - name: gorouter
+    properties:
+      router:
+        backends:
+          cert_chain: ((gorouter_backend_tls.certificate))
+          enable_tls: true
+          private_key: ((gorouter_backend_tls.private_key))
+        ca_certs: |
+          ((application_ca.certificate))
+          ((service_cf_internal_ca.certificate))
+        enable_ssl: true
+        route_services_secret: ((router_route_services_secret))
+        status:
+          password: ((router_status_password))
+          user: router-status
+        tls_pem:
+        - cert_chain: ((router_ssl.certificate))
+          private_key: ((router_ssl.private_key))
+        tracing:
+          enable_zipkin: true
+      routing_api:
+        enabled: true
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        clients:
+          gorouter:
+            secret: ((uaa_clients_gorouter_secret))
+        ssl:
+          port: 8443
+    release: routing
+  name: router
+  networks:
+  - name: default
+  stemcell: default
+  update:
+    serial: true
+  vm_extensions:
+  - cf-router-network-properties
+  vm_type: minimal
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - name: tcp_router
+    properties:
+      tcp_router:
+        oauth_secret: ((uaa_clients_tcp_router_secret))
+        router_group: default-tcp
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        tls_port: 8443
+    release: routing
+  name: tcp-router
+  networks:
+  - name: default
+  stemcell: default
+  vm_extensions:
+  - cf-tcp-router-network-properties
+  vm_type: minimal
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - name: cfdot
+    properties:
+      tls:
+        ca_certificate: ((service_cf_internal_ca.certificate))
+        certificate: ((diego_rep_client.certificate))
+        private_key: ((diego_rep_client.private_key))
+    release: diego
+  - name: auctioneer
+    properties:
+      bpm:
+        enabled: true
+      diego:
+        auctioneer:
+          bbs:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            client_cert: ((diego_bbs_client.certificate))
+            client_key: ((diego_bbs_client.private_key))
+          ca_cert: ((service_cf_internal_ca.certificate))
+          rep:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            client_cert: ((diego_rep_client.certificate))
+            client_key: ((diego_rep_client.private_key))
+            require_tls: true
+          server_cert: ((diego_auctioneer_server.certificate))
+          server_key: ((diego_auctioneer_server.private_key))
+          skip_consul_lock: true
+      enable_consul_service_registration: false
+      logging:
+        format:
+          timestamp: rfc3339
+      loggregator:
+        ca_cert: ((loggregator_ca.certificate))
+        cert: ((loggregator_tls_agent.certificate))
+        key: ((loggregator_tls_agent.private_key))
+        use_v2_api: true
+    release: diego
+  - name: cloud_controller_clock
+    properties:
+      cc:
+        buildpacks:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        database_encryption:
+          current_key_label: encryption_key_0
+          keys:
+            encryption_key_0: ((cc_db_encryption_key))
+        db_encryption_key: ((cc_db_encryption_key))
+        droplets:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        internal_api_password: ((cc_internal_api_password))
+        mutual_tls:
+          ca_cert: ((service_cf_internal_ca.certificate))
+          private_key: ((cc_tls.private_key))
+          public_cert: ((cc_tls.certificate))
+        packages:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        resource_pool:
+          blobstore_type: webdav
+          webdav_config:
+            blobstore_timeout: 5
+            ca_cert: ((service_cf_internal_ca.certificate))
+            password: ((blobstore_admin_users_password))
+            private_endpoint: https://blobstore.service.cf.internal:4443
+            public_endpoint: https://blobstore.((system_domain))
+            username: blobstore-user
+        staging_upload_password: ((cc_staging_upload_password))
+        staging_upload_user: staging_user
+      ccdb:
+        databases:
+        - name: cloud_controller
+          tag: cc
+        db_scheme: mysql
+        port: 3306
+        roles:
+        - name: cloud_controller
+          password: ((cc_database_password))
+          tag: admin
+      routing_api:
+        enabled: true
+      system_domain: ((system_domain))
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        clients:
+          cc-service-dashboards:
+            secret: ((uaa_clients_cc-service-dashboards_secret))
+          cc_routing:
+            secret: ((uaa_clients_cc-routing_secret))
+        ssl:
+          port: 8443
+    release: capi
+  - name: statsd_injector
+    properties:
+      loggregator:
+        tls:
+          ca_cert: ((loggregator_ca.certificate))
+          statsd_injector:
+            cert: ((loggregator_tls_statsdinjector.certificate))
+            key: ((loggregator_tls_statsdinjector.private_key))
+    release: statsd-injector
+  - name: tps
+    properties:
+      capi:
+        tps:
+          bbs:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            client_cert: ((diego_bbs_client.certificate))
+            client_key: ((diego_bbs_client.private_key))
+          cc:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            client_cert: ((cc_bridge_tps.certificate))
+            client_key: ((cc_bridge_tps.private_key))
+          watcher:
+            locket:
+              api_location: locket.service.cf.internal:8891
+            skip_consul_lock: true
+    release: capi
+  - name: ssh_proxy
+    properties:
+      bpm:
+        enabled: true
+      diego:
+        ssh_proxy:
+          bbs:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            client_cert: ((diego_bbs_client.certificate))
+            client_key: ((diego_bbs_client.private_key))
+          enable_cf_auth: true
+          host_key: ((diego_ssh_proxy_host_key.private_key))
+          uaa:
+            ca_cert: ((uaa_ca.certificate))
+          uaa_secret: ((uaa_clients_ssh-proxy_secret))
+      enable_consul_service_registration: false
+      logging:
+        format:
+          timestamp: rfc3339
+      loggregator:
+        ca_cert: ((loggregator_ca.certificate))
+        cert: ((loggregator_tls_agent.certificate))
+        key: ((loggregator_tls_agent.private_key))
+        use_v2_api: true
+    release: diego
+  - name: scheduler
+    properties:
+      scalablesyslog:
+        scheduler:
+          api:
+            url: https://cloud-controller-ng.service.cf.internal:9023
+          tls:
+            api:
+              ca: ((service_cf_internal_ca.certificate))
+              cert: ((scheduler_api_tls.certificate))
+              cn: cloud-controller-ng.service.cf.internal
+              key: ((scheduler_api_tls.private_key))
+            client:
+              adapter_cn: ss-adapter
+              ca: ((loggregator_ca.certificate))
+              cert: ((scheduler_client_tls.certificate))
+              key: ((scheduler_client_tls.private_key))
+    release: cf-syslog-drain
+  - consumes:
+      log-cache:
+        from: log_cache
+    name: log-cache-scheduler
+    release: log-cache
+  - consumes:
+      log-cache:
+        from: log_cache
+    name: log-cache-expvar-forwarder
+    properties:
+      counters: []
+      gauges: []
+      maps:
+      - addr: http://localhost:6064/debug/vars
+        name: worker-assignments
+        source_id: log-cache-scheduler
+        template: '{{.WorkerAssignments | jsonMap}}'
+      - addr: http://localhost:6064/debug/vars
+        name: worker-health
+        source_id: log-cache-scheduler
+        template: '{{.WorkerHealth | jsonMap}}'
+    release: log-cache
+  migrated_from:
+  - name: cc-bridge
+  - name: cc-clock
+  - name: diego-brain
+  name: scheduler
+  networks:
+  - name: default
+  stemcell: default
+  update:
+    serial: true
+  vm_extensions:
+  - diego-ssh-proxy-network-properties
+  vm_type: minimal
+- azs:
+  - z1
+  - z2
+  instances: 4
+  jobs:
+  - name: doppler
+    properties:
+      loggregator:
+        tls:
+          ca_cert: ((loggregator_ca.certificate))
+          doppler:
+            cert: ((loggregator_tls_doppler.certificate))
+            key: ((loggregator_tls_doppler.private_key))
+    provides:
+      doppler:
+        as: doppler
+        shared: true
+    release: loggregator
+  - consumes:
+      log-cache:
+        from: log_cache
+    name: log-cache
+    properties:
+      egress_port: 8080
+      health_addr: localhost:6060
+      tls:
+        ca_cert: ((log_cache_ca.certificate))
+        cert: ((log_cache.certificate))
+        key: ((log_cache.private_key))
+    provides:
+      log-cache:
+        as: log_cache
+        shared: true
+    release: log-cache
+  - consumes:
+      log-cache:
+        from: log_cache
+    name: log-cache-gateway
+    properties:
+      gateway_addr: localhost:8081
+    provides:
+      log-cache-gateway:
+        as: log_cache_gateway
+        shared: true
+    release: log-cache
+  - consumes:
+      log-cache:
+        from: log_cache
+      reverse_log_proxy:
+        from: reverse_log_proxy
+    name: log-cache-nozzle
+    properties:
+      logs_provider:
+        tls:
+          ca_cert: ((loggregator_ca.certificate))
+          cert: ((logs_provider.certificate))
+          key: ((logs_provider.private_key))
+    release: log-cache
+  - consumes:
+      log-cache:
+        from: log_cache
+    name: log-cache-expvar-forwarder
+    properties:
+      counters:
+      - addr: http://localhost:6060/debug/vars
+        name: egress
+        source_id: log-cache
+        template: '{{.LogCache.Egress}}'
+      - addr: http://localhost:6060/debug/vars
+        name: ingress
+        source_id: log-cache
+        template: '{{.LogCache.Ingress}}'
+      - addr: http://localhost:6060/debug/vars
+        name: expired
+        source_id: log-cache
+        template: '{{.LogCache.Expired}}'
+      - addr: http://localhost:6060/debug/vars
+        name: dropped
+        source_id: log-cache
+        template: '{{.LogCache.Dropped}}'
+      - addr: http://localhost:6060/debug/vars
+        name: promql-timeout
+        source_id: log-cache
+        template: '{{.LogCache.PromQLTimeout}}'
+      - addr: http://localhost:6061/debug/vars
+        name: egress
+        source_id: log-cache-nozzle
+        template: '{{.Nozzle.Egress}}'
+      - addr: http://localhost:6061/debug/vars
+        name: ingress
+        source_id: log-cache-nozzle
+        template: '{{.Nozzle.Ingress}}'
+      - addr: http://localhost:6061/debug/vars
+        name: err
+        source_id: log-cache-nozzle
+        template: '{{.Nozzle.Err}}'
+      - addr: http://localhost:6061/debug/vars
+        name: dropped
+        source_id: log-cache-nozzle
+        template: '{{.Nozzle.Dropped}}'
+      gauges:
+      - addr: http://localhost:6060/debug/vars
+        name: cache-period
+        source_id: log-cache
+        template: '{{.LogCache.CachePeriod}}'
+      - addr: http://localhost:6060/debug/vars
+        name: store-size
+        source_id: log-cache
+        template: '{{.LogCache.StoreSize}}'
+      - addr: http://localhost:6060/debug/vars
+        name: total-system-memory
+        source_id: log-cache
+        template: '{{.LogCache.TotalSystemMemory}}'
+      - addr: http://localhost:6060/debug/vars
+        name: available-system-memory
+        source_id: log-cache
+        template: '{{.LogCache.AvailableSystemMemory}}'
+      - addr: http://localhost:6060/debug/vars
+        name: promql-instant-query-time
+        source_id: log-cache
+        template: '{{.LogCache.PromQLInstantQueryTime}}'
+      - addr: http://localhost:6060/debug/vars
+        name: promql-range-query-time
+        source_id: log-cache
+        template: '{{.LogCache.PromQLRangeQueryTime}}'
+      - addr: http://localhost:6065/debug/vars
+        name: last-uaa-latency
+        source_id: log-cache-cf-auth-proxy
+        template: '{{.CFAuthProxy.LastUAALatency}}'
+      - addr: http://localhost:6065/debug/vars
+        name: last-capi-v3-apps-latency
+        source_id: log-cache-cf-auth-proxy
+        template: '{{.CFAuthProxy.LastCAPIV3AppsLatency}}'
+      - addr: http://localhost:6065/debug/vars
+        name: last-capi-v2-list-service-instances-latency
+        source_id: log-cache-cf-auth-proxy
+        template: '{{.CFAuthProxy.LastCAPIV2ListServiceInstancesLatency}}'
+      - addr: http://localhost:6065/debug/vars
+        name: last-capi-v4-log-access-latency
+        source_id: log-cache-cf-auth-proxy
+        template: '{{.CFAuthProxy.LastCAPIV4LogAccessLatency}}'
+      - addr: http://localhost:6065/debug/vars
+        name: last-capi-v2-service-instances-latency
+        source_id: log-cache-cf-auth-proxy
+        template: '{{.CFAuthProxy.LastCAPIV2ServiceInstancesLatency}}'
+      maps: []
+    release: log-cache
+  - name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: log-cache-reverse-proxy
+          port: 8083
+          registration_interval: 20s
+          uris:
+          - log-cache.((system_domain))
+          - '*.log-cache.((system_domain))'
+    release: routing
+  - consumes:
+      log-cache:
+        from: log_cache
+      log-cache-gateway:
+        from: log_cache_gateway
+    name: log-cache-cf-auth-proxy
+    properties:
+      cc:
+        ca_cert: ((service_cf_internal_ca.certificate))
+        capi_internal_addr: https://cloud-controller-ng.service.cf.internal:9023
+        cert: ((log_cache_tls_cc_auth_proxy.certificate))
+        common_name: cloud-controller-ng.service.cf.internal
+        key: ((log_cache_tls_cc_auth_proxy.private_key))
+      proxy_port: 8083
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        client_id: doppler
+        client_secret: ((uaa_clients_doppler_secret))
+        internal_addr: https://uaa.service.cf.internal:8443
+    release: log-cache
+  name: doppler
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - name: cflinuxfs2-rootfs-setup
+    properties:
+      cflinuxfs2-rootfs:
+        trusted_certs: |
+          ((application_ca.certificate))
+          ((credhub_ca.certificate))
+          ((uaa_ca.certificate))
+    release: cflinuxfs2
+  - name: cflinuxfs3-rootfs-setup
+    properties:
+      cflinuxfs3-rootfs:
+        trusted_certs: |
+          ((application_ca.certificate))
+          ((credhub_ca.certificate))
+          ((uaa_ca.certificate))
+    release: cflinuxfs3
+  - name: garden
+    properties:
+      garden:
+        cleanup_process_dirs_on_wait: true
+        debug_listen_address: 127.0.0.1:17019
+        default_container_grace_time: 0
+        deny_networks:
+        - 0.0.0.0/0
+        destroy_containers_on_start: true
+        network_plugin: /var/vcap/packages/runc-cni/bin/garden-external-networker
+        network_plugin_extra_args:
+        - --configFile=/var/vcap/jobs/garden-cni/config/adapter.json
+      grootfs:
+        reserved_space_for_other_jobs_in_mb: 15360
+      logging:
+        format:
+          timestamp: rfc3339
+    release: garden-runc
+  - name: rep
+    properties:
+      bpm:
+        enabled: true
+      containers:
+        trusted_ca_certificates:
+        - ((application_ca.certificate))
+        - ((credhub_ca.certificate))
+        - ((uaa_ca.certificate))
+      diego:
+        executor:
+          instance_identity_ca_cert: ((diego_instance_identity_ca.certificate))
+          instance_identity_key: ((diego_instance_identity_ca.private_key))
+        rep:
+          preloaded_rootfses:
+          - cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs.tar
+          - cflinuxfs3:/var/vcap/packages/cflinuxfs3/rootfs.tar
+      enable_consul_service_registration: false
+      enable_declarative_healthcheck: true
+      logging:
+        format:
+          timestamp: rfc3339
+      loggregator:
+        ca_cert: ((loggregator_ca.certificate))
+        cert: ((loggregator_tls_agent.certificate))
+        key: ((loggregator_tls_agent.private_key))
+        use_v2_api: true
+      tls:
+        ca_cert: ((service_cf_internal_ca.certificate))
+        cert: ((diego_rep_agent_v2.certificate))
+        key: ((diego_rep_agent_v2.private_key))
+    release: diego
+  - name: cfdot
+    properties:
+      tls:
+        ca_certificate: ((service_cf_internal_ca.certificate))
+        certificate: ((diego_rep_client.certificate))
+        private_key: ((diego_rep_client.private_key))
+    release: diego
+  - name: route_emitter
+    properties:
+      bpm:
+        enabled: true
+      diego:
+        route_emitter:
+          bbs:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            client_cert: ((diego_bbs_client.certificate))
+            client_key: ((diego_bbs_client.private_key))
+          local_mode: true
+      logging:
+        format:
+          timestamp: rfc3339
+      loggregator:
+        ca_cert: ((loggregator_ca.certificate))
+        cert: ((loggregator_tls_agent.certificate))
+        key: ((loggregator_tls_agent.private_key))
+        use_v2_api: true
+      tcp:
+        enabled: true
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        client_secret: ((uaa_clients_tcp_emitter_secret))
+    release: diego
+  - name: garden-cni
+    properties:
+      cni_config_dir: /var/vcap/jobs/silk-cni/config/cni
+      cni_plugin_dir: /var/vcap/packages/silk-cni/bin
+    release: cf-networking
+  - name: netmon
+    release: silk
+  - name: vxlan-policy-agent
+    properties:
+      ca_cert: ((network_policy_ca.certificate))
+      client_cert: ((network_policy_client.certificate))
+      client_key: ((network_policy_client.private_key))
+    release: silk
+  - name: silk-daemon
+    properties:
+      ca_cert: ((silk_ca.certificate))
+      client_cert: ((silk_daemon.certificate))
+      client_key: ((silk_daemon.private_key))
+    release: silk
+  - name: silk-cni
+    properties:
+      dns_servers:
+      - 169.254.0.2
+    release: silk
+  name: diego-cell
+  networks:
+  - name: default
+  stemcell: default
+  vm_extensions:
+  - 100GB_ephemeral_disk
+  vm_type: small-highmem
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - consumes:
+      doppler:
+        from: doppler
+      log-cache:
+        from: log_cache
+    name: loggregator_trafficcontroller
+    properties:
+      cc:
+        internal_service_hostname: cloud-controller-ng.service.cf.internal
+        mutual_tls:
+          ca_cert: ((service_cf_internal_ca.certificate))
+        tls_port: 9023
+      loggregator:
+        tls:
+          ca_cert: ((loggregator_ca.certificate))
+          cc_trafficcontroller:
+            cert: ((loggregator_tls_cc_tc.certificate))
+            key: ((loggregator_tls_cc_tc.private_key))
+          trafficcontroller:
+            cert: ((loggregator_tls_tc.certificate))
+            key: ((loggregator_tls_tc.private_key))
+        uaa:
+          client_secret: ((uaa_clients_doppler_secret))
+      ssl:
+        skip_cert_verify: true
+      system_domain: ((system_domain))
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        internal_url: https://uaa.service.cf.internal:8443
+    release: loggregator
+  - consumes:
+      doppler:
+        from: doppler
+    name: reverse_log_proxy
+    properties:
+      loggregator:
+        tls:
+          ca_cert: ((loggregator_ca.certificate))
+          reverse_log_proxy:
+            cert: ((loggregator_tls_rlp.certificate))
+            key: ((loggregator_tls_rlp.private_key))
+    provides:
+      reverse_log_proxy:
+        as: reverse_log_proxy
+        shared: true
+    release: loggregator
+  - consumes:
+      reverse_log_proxy:
+        from: reverse_log_proxy
+    name: reverse_log_proxy_gateway
+    properties:
+      cc:
+        ca_cert: ((service_cf_internal_ca.certificate))
+        capi_internal_addr: https://cloud-controller-ng.service.cf.internal:9023
+        cert: ((loggregator_rlp_gateway_tls_cc.certificate))
+        common_name: cloud-controller-ng.service.cf.internal
+        key: ((loggregator_rlp_gateway_tls_cc.private_key))
+      http:
+        address: 0.0.0.0:8088
+      logs_provider:
+        ca_cert: ((loggregator_ca.certificate))
+        client_cert: ((loggregator_rlp_gateway.certificate))
+        client_key: ((loggregator_rlp_gateway.private_key))
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        client_id: doppler
+        client_secret: ((uaa_clients_doppler_secret))
+        internal_addr: https://uaa.service.cf.internal:8443
+    release: loggregator
+  - name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: loggregator
+          port: 8080
+          registration_interval: 20s
+          uris:
+          - loggregator.((system_domain))
+        - name: doppler
+          port: 8081
+          registration_interval: 20s
+          uris:
+          - doppler.((system_domain))
+          - '*.doppler.((system_domain))'
+        - name: rlp-gateway
+          port: 8088
+          registration_interval: 20s
+          uris:
+          - log-stream.((system_domain))
+          - '*.log-stream.((system_domain))'
+    release: routing
+  name: log-api
+  networks:
+  - name: default
+  stemcell: default
+  update:
+    serial: true
+  vm_type: minimal
+- azs:
+  - z1
+  - z2
+  instances: 2
+  jobs:
+  - name: credhub
+    properties:
+      credhub:
+        authentication:
+          mutual_tls:
+            trusted_cas:
+            - ((application_ca.certificate))
+          uaa:
+            ca_certs:
+            - ((uaa_ca.certificate))
+            url: https://uaa.service.cf.internal:8443
+            verification_key: ((uaa_jwt_signing_key.public_key))
+        authorization:
+          acls:
+            enabled: true
+          permissions:
+          - actors:
+            - uaa-client:credhub_admin_client
+            operations:
+            - read
+            - write
+            - delete
+            - read_acl
+            - write_acl
+            path: /*
+          - actors:
+            - uaa-client:cc_service_key_client
+            operations:
+            - read
+            path: /*
+        data_storage:
+          database: credhub
+          host: sql-db.service.cf.internal
+          password: ((credhub_database_password))
+          port: 3306
+          require_tls: false
+          type: mysql
+          username: credhub
+        encryption:
+          keys:
+          - active: true
+            key_properties:
+              encryption_password: ((credhub_encryption_password))
+            provider_name: internal-provider
+          providers:
+          - name: internal-provider
+            type: internal
+        tls: ((credhub_tls))
+    release: credhub
+  name: credhub
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: rotate_cc_database_key
+    properties: {}
+    release: capi
+  lifecycle: errand
+  name: rotate-cc-database-key
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: cflinuxfs2-rootfs-setup
+    properties:
+      cflinuxfs2-rootfs:
+        trusted_certs: |
+          ((application_ca.certificate))
+          ((credhub_ca.certificate))
+          ((uaa_ca.certificate))
+    release: cflinuxfs2
+  - name: cflinuxfs3-rootfs-setup
+    properties:
+      cflinuxfs3-rootfs:
+        trusted_certs: |
+          ((application_ca.certificate))
+          ((credhub_ca.certificate))
+          ((uaa_ca.certificate))
+    release: cflinuxfs3
+  - name: garden
+    properties:
+      garden:
+        cleanup_process_dirs_on_wait: true
+        default_container_grace_time: 0
+        deny_networks:
+        - 0.0.0.0/0
+        destroy_containers_on_start: true
+        graph_cleanup_threshold_in_mb: 0
+      logging:
+        format:
+          timestamp: rfc3339
+    release: garden-runc
+  - name: rep
+    properties:
+      bpm:
+        enabled: true
+      containers:
+        trusted_ca_certificates:
+        - ((application_ca.certificate))
+        - ((credhub_ca.certificate))
+        - ((uaa_ca.certificate))
+      diego:
+        executor:
+          instance_identity_ca_cert: ((diego_instance_identity_ca.certificate))
+          instance_identity_key: ((diego_instance_identity_ca.private_key))
+        rep:
+          placement_tags:
+          - persistent_isolation_segment
+          preloaded_rootfses:
+          - cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs.tar
+          - cflinuxfs3:/var/vcap/packages/cflinuxfs3/rootfs.tar
+      enable_consul_service_registration: false
+      enable_declarative_healthcheck: true
+      logging:
+        format:
+          timestamp: rfc3339
+      loggregator:
+        ca_cert: ((isolated_loggregator_ca.certificate))
+        cert: ((isolated_loggregator_tls_agent.certificate))
+        key: ((isolated_loggregator_tls_agent.private_key))
+        use_v2_api: true
+      tls:
+        ca_cert: ((service_cf_internal_ca.certificate))
+        cert: ((diego_rep_agent_v2.certificate))
+        key: ((diego_rep_agent_v2.private_key))
+    release: diego
+  - name: route_emitter
+    properties:
+      bpm:
+        enabled: true
+      diego:
+        route_emitter:
+          bbs:
+            ca_cert: ((service_cf_internal_ca.certificate))
+            client_cert: ((diego_bbs_client.certificate))
+            client_key: ((diego_bbs_client.private_key))
+          local_mode: true
+      logging:
+        format:
+          timestamp: rfc3339
+      loggregator:
+        ca_cert: ((isolated_loggregator_ca.certificate))
+        cert: ((isolated_loggregator_tls_agent.certificate))
+        key: ((isolated_loggregator_tls_agent.private_key))
+        use_v2_api: true
+    release: diego
+  - consumes:
+      doppler:
+        from: isolated_doppler
+    name: loggregator_agent
+    properties:
+      doppler:
+        addr: isolated-doppler.service.cf.internal
+      loggregator:
+        tls:
+          agent:
+            cert: ((isolated_loggregator_tls_agent.certificate))
+            key: ((isolated_loggregator_tls_agent.private_key))
+          ca_cert: ((isolated_loggregator_ca.certificate))
+    release: loggregator-agent
+  name: isolated-diego-cell
+  networks:
+  - name: default
+  stemcell: default
+  vm_extensions:
+  - 100GB_ephemeral_disk
+  vm_type: small-highmem
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: doppler
+    properties:
+      loggregator:
+        tls:
+          ca_cert: ((isolated_loggregator_ca.certificate))
+          doppler:
+            cert: ((isolated_loggregator_tls_doppler.certificate))
+            key: ((isolated_loggregator_tls_doppler.private_key))
+    provides:
+      doppler:
+        as: isolated_doppler
+        shared: true
+      loggregator:
+        as: isolated_loggregator
+        shared: true
+    release: loggregator
+  - consumes:
+      doppler:
+        from: isolated_doppler
+    name: loggregator_agent
+    properties:
+      doppler:
+        addr: isolated-doppler.service.cf.internal
+      loggregator:
+        tls:
+          agent:
+            cert: ((isolated_loggregator_tls_agent.certificate))
+            key: ((isolated_loggregator_tls_agent.private_key))
+          ca_cert: ((isolated_loggregator_ca.certificate))
+    release: loggregator-agent
+  - consumes:
+      log-cache:
+        from: isolated_log_cache
+    name: log-cache
+    properties:
+      egress_port: 8080
+      health_addr: localhost:6060
+      tls:
+        ca_cert: ((isolated_log_cache.ca))
+        cert: ((isolated_log_cache.certificate))
+        key: ((isolated_log_cache.private_key))
+    provides:
+      log-cache:
+        as: isolated_log_cache
+        shared: true
+    release: log-cache
+  - consumes:
+      log-cache:
+        from: isolated_log_cache
+      log-cache-gateway:
+        from: isolated_log_cache_gateway
+    name: log-cache-cf-auth-proxy
+    properties:
+      cc:
+        ca_cert: ((isolated_log_cache_tls_cc_auth_proxy.ca))
+        capi_internal_addr: https://cloud-controller-ng.service.cf.internal:9023
+        cert: ((isolated_log_cache_tls_cc_auth_proxy.certificate))
+        common_name: cloud-controller-ng.service.cf.internal
+        key: ((isolated_log_cache_tls_cc_auth_proxy.private_key))
+      proxy_port: 8083
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        client_id: doppler
+        client_secret: ((uaa_clients_doppler_secret))
+        internal_addr: https://uaa.service.cf.internal:8443
+    release: log-cache
+  - consumes:
+      log-cache:
+        from: isolated_log_cache
+    name: log-cache-expvar-forwarder
+    properties:
+      counters:
+      - addr: http://localhost:6060/debug/vars
+        name: egress
+        source_id: isolated-log-cache
+        template: '{{.LogCache.Egress}}'
+      - addr: http://localhost:6060/debug/vars
+        name: ingress
+        source_id: isolated-log-cache
+        template: '{{.LogCache.Ingress}}'
+      - addr: http://localhost:6060/debug/vars
+        name: expired
+        source_id: isolated-log-cache
+        template: '{{.LogCache.Expired}}'
+      - addr: http://localhost:6060/debug/vars
+        name: dropped
+        source_id: isolated-log-cache
+        template: '{{.LogCache.Dropped}}'
+      - addr: http://localhost:6060/debug/vars
+        name: promql-timeout
+        source_id: isolated-log-cache
+        template: '{{.LogCache.PromQLTimeout}}'
+      - addr: http://localhost:6061/debug/vars
+        name: egress
+        source_id: isolated-log-cache-nozzle
+        template: '{{.Nozzle.Egress}}'
+      - addr: http://localhost:6061/debug/vars
+        name: ingress
+        source_id: isolated-log-cache-nozzle
+        template: '{{.Nozzle.Ingress}}'
+      - addr: http://localhost:6061/debug/vars
+        name: err
+        source_id: isolated-log-cache-nozzle
+        template: '{{.Nozzle.Err}}'
+      - addr: http://localhost:6061/debug/vars
+        name: dropped
+        source_id: isolated-log-cache-nozzle
+        template: '{{.Nozzle.Dropped}}'
+      gauges:
+      - addr: http://localhost:6060/debug/vars
+        name: cache-period
+        source_id: isolated-log-cache
+        template: '{{.LogCache.CachePeriod}}'
+      - addr: http://localhost:6060/debug/vars
+        name: store-size
+        source_id: isolated-log-cache
+        template: '{{.LogCache.StoreSize}}'
+      - addr: http://localhost:6060/debug/vars
+        name: total-system-memory
+        source_id: isolated-log-cache
+        template: '{{.LogCache.TotalSystemMemory}}'
+      - addr: http://localhost:6060/debug/vars
+        name: available-system-memory
+        source_id: isolated-log-cache
+        template: '{{.LogCache.AvailableSystemMemory}}'
+      - addr: http://localhost:6060/debug/vars
+        name: promql-instant-query-time
+        source_id: isolated-log-cache
+        template: '{{.LogCache.PromQLInstantQueryTime}}'
+      - addr: http://localhost:6060/debug/vars
+        name: promql-range-query-time
+        source_id: isolated-log-cache
+        template: '{{.LogCache.PromQLRangeQueryTime}}'
+      - addr: http://localhost:6065/debug/vars
+        name: last-uaa-latency
+        source_id: isolated-log-cache-cf-auth-proxy
+        template: '{{.CFAuthProxy.LastUAALatency}}'
+      - addr: http://localhost:6065/debug/vars
+        name: last-capi-v3-apps-latency
+        source_id: isolated-log-cache-cf-auth-proxy
+        template: '{{.CFAuthProxy.LastCAPIV3AppsLatency}}'
+      - addr: http://localhost:6065/debug/vars
+        name: last-capi-v2-list-service-instances-latency
+        source_id: isolated-log-cache-cf-auth-proxy
+        template: '{{.CFAuthProxy.LastCAPIV2ListServiceInstancesLatency}}'
+      - addr: http://localhost:6065/debug/vars
+        name: last-capi-v4-log-access-latency
+        source_id: isolated-log-cache-cf-auth-proxy
+        template: '{{.CFAuthProxy.LastCAPIV4LogAccessLatency}}'
+      - addr: http://localhost:6065/debug/vars
+        name: last-capi-v2-service-instances-latency
+        source_id: isolated-log-cache-cf-auth-proxy
+        template: '{{.CFAuthProxy.LastCAPIV2ServiceInstancesLatency}}'
+      maps: []
+    release: log-cache
+  - consumes:
+      log-cache:
+        from: isolated_log_cache
+    name: log-cache-gateway
+    provides:
+      log-cache-gateway:
+        as: isolated_log_cache_gateway
+        shared: true
+    release: log-cache
+  - consumes:
+      log-cache:
+        from: isolated_log_cache
+      reverse_log_proxy:
+        from: isolated_reverse_log_proxy
+    name: log-cache-nozzle
+    properties:
+      logs_provider:
+        tls:
+          ca_cert: ((isolated_logs_provider.ca))
+          cert: ((isolated_logs_provider.certificate))
+          key: ((isolated_logs_provider.private_key))
+    release: log-cache
+  - name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: isolated-log-cache-reverse-log-proxy
+          port: 8083
+          registration_interval: 20s
+          uris:
+          - iso-log-cache.((system_domain))
+          - '*.iso-log-cache.((system_domain))'
+    release: routing
+  name: isolated-doppler
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - consumes:
+      doppler:
+        from: isolated_doppler
+      log-cache:
+        from: isolated_log_cache
+    name: loggregator_trafficcontroller
+    properties:
+      cc:
+        internal_service_hostname: cloud-controller-ng.service.cf.internal
+        mutual_tls:
+          ca_cert: ((service_cf_internal_ca.certificate))
+        tls_port: 9023
+      loggregator:
+        tls:
+          ca_cert: ((isolated_loggregator_ca.certificate))
+          cc_trafficcontroller:
+            cert: ((isolated_loggregator_tls_cc_tc.certificate))
+            key: ((isolated_loggregator_tls_cc_tc.private_key))
+          trafficcontroller:
+            cert: ((isolated_loggregator_tls_tc.certificate))
+            key: ((isolated_loggregator_tls_tc.private_key))
+        uaa:
+          client: isolated-doppler
+          client_secret: ((uaa_clients_isolated_doppler_secret))
+      ssl:
+        skip_cert_verify: true
+      system_domain: ((system_domain))
+      uaa:
+        ca_cert: ((uaa_ca.certificate))
+        internal_url: https://uaa.service.cf.internal:8443
+    provides:
+      trafficcontroller:
+        as: isolated_trafficcontroller
+    release: loggregator
+  - consumes:
+      doppler:
+        from: isolated_doppler
+    name: reverse_log_proxy
+    properties:
+      loggregator:
+        tls:
+          ca_cert: ((isolated_loggregator_ca.certificate))
+          reverse_log_proxy:
+            cert: ((isolated_loggregator_tls_rlp.certificate))
+            key: ((isolated_loggregator_tls_rlp.private_key))
+    provides:
+      reverse_log_proxy:
+        as: isolated_reverse_log_proxy
+        shared: true
+    release: loggregator
+  - name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: isolated-loggregator
+          port: 8080
+          registration_interval: 20s
+          uris:
+          - iso-loggregator.((system_domain))
+        - name: isolated-doppler
+          port: 8081
+          registration_interval: 20s
+          uris:
+          - iso-doppler.((system_domain))
+          - '*.iso-doppler.((system_domain))'
+    release: routing
+  - consumes:
+      doppler:
+        from: isolated_doppler
+    name: loggregator_agent
+    properties:
+      doppler:
+        addr: isolated-doppler.service.cf.internal
+      loggregator:
+        tls:
+          agent:
+            cert: ((isolated_loggregator_tls_agent.certificate))
+            key: ((isolated_loggregator_tls_agent.private_key))
+          ca_cert: ((isolated_loggregator_ca.certificate))
+    release: loggregator-agent
+  name: isolated-log-api
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: minimal
+- azs:
+  - z1
+  - z2
+  instances: 1
+  jobs:
+  - consumes:
+      log-cache:
+        from: isolated_log_cache
+    name: log-cache-scheduler
+    release: log-cache
+  - consumes:
+      log-cache:
+        from: isolated_log_cache
+    name: log-cache-expvar-forwarder
+    properties:
+      counters: []
+      gauges: []
+      maps:
+      - addr: http://localhost:6064/debug/vars
+        name: worker-assignments
+        source_id: isolated-log-cache-scheduler
+        template: '{{.WorkerAssignments | jsonMap}}'
+      - addr: http://localhost:6064/debug/vars
+        name: worker-health
+        source_id: isolated-log-cache-scheduler
+        template: '{{.WorkerHealth | jsonMap}}'
+    release: log-cache
+  name: isolated-scheduler
+  networks:
+  - name: default
+  persistent_disk_type: 5GB
+  stemcell: default
+  vm_type: minimal
+manifest_version: v6.1.0
+name: cf
+releases:
+- name: binary-buildpack
+  sha1: f0022e0632d31d5bbb0e0a5e424244bad83158a1
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.27
+  version: 1.0.27
+- name: bpm
+  sha1: 4b6ebfdaa467c04855528172b099e565d679e0f5
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=0.13.0
+  version: 0.13.0
+- name: capi
+  sha1: 5756c91740b6cf99f228a2a1120b9234a8dbc9b9
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.72.0
+  version: 1.72.0
+- name: cf-mysql
+  sha1: eb028b258599e465f9fabb395b87e0093c46aa98
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.16.0
+  version: 36.16.0
+- name: cf-networking
+  sha1: 2109a02d8ab56f748261eb63d276b24230068757
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.18.0
+  version: 2.18.0
+- name: cf-smoke-tests
+  sha1: c4fbdefdd3b04242eb53da89396f5f587e20d282
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=40.0.17
+  version: 40.0.17
+- name: cf-syslog-drain
+  sha1: 5b5a2ea2f7a75755e19620eea0672a21704b0660
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=8.0
+  version: "8.0"
+- name: cflinuxfs2
+  sha1: cd40b5e9f220f07ce174cc4bb1257870530234b7
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.247.0
+  version: 1.247.0
+- name: cflinuxfs3
+  sha1: f206cd6d9072371a0ccecc17515a01c5fb58937c
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.37.0
+  version: 0.37.0
+- name: credhub
+  sha1: dd0b607d855a8d23e6fd52b990573570e68bbbf6
+  url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.1.1
+  version: 2.1.1
+- name: diego
+  sha1: 0cd26089729d4e526dd27c47191cc3b9cb3189c6
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.22.0
+  version: 2.22.0
+- name: dotnet-core-buildpack
+  sha1: 188dace870c94749a3abc21cb538c08e0f4f3d8c
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.1.5
+  version: 2.1.5
+- name: garden-runc
+  sha1: 989da8ac06999071d66deb7f957be4dfd49ecdf2
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.17.0
+  version: 1.17.0
+- name: go-buildpack
+  sha1: cde33a1eda5392dd5c887d4d72568aabefb1f20a
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.8.28
+  version: 1.8.28
+- name: java-buildpack
+  sha1: 2e24d3da499fc62fd3f012f13188e7e7e7857c2a
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.16.1
+  version: 4.16.1
+- name: loggregator
+  sha1: 16de255a3d6e0e683668f9d413f41169b6f3666c
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=104.2
+  version: "104.2"
+- name: nats
+  sha1: 2f2c27acdfff81f3519968921686522518ab5783
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=26
+  version: "26"
+- name: nodejs-buildpack
+  sha1: 69c02ed7bfcc145447222b7366d6ad41c07d86e5
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.6.32
+  version: 1.6.32
+- name: php-buildpack
+  sha1: 9c5f9f040135fda81da44c6e1b0a1da878b04bfb
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.3.61
+  version: 4.3.61
+- name: python-buildpack
+  sha1: 03b8618c5940889529e0aa6c129436e17c2a28d3
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.6.21
+  version: 1.6.21
+- name: routing
+  sha1: 6e341a527a0dd2c920b54dea82156ae9bc0b29eb
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.182.0
+  version: 0.182.0
+- name: ruby-buildpack
+  sha1: d696be61e29dd0ea60129df148747831feece51f
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.7.24
+  version: 1.7.24
+- name: silk
+  sha1: 19de0a4097c937ea50df6db0b8b0110703b307f4
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.18.0
+  version: 2.18.0
+- name: staticfile-buildpack
+  sha1: 5851241b881f3315383fe4d2a50ca89fe2a5d331
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.4.32
+  version: 1.4.32
+- name: statsd-injector
+  sha1: 49a38aca12e0fd2ec28f96c780c1971427dda04e
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.5.0
+  version: 1.5.0
+- name: uaa
+  sha1: 2848d9fb65d2d556a918e8045359cf469c241123
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=66.0
+  version: "66.0"
+- name: loggregator-agent
+  sha1: 7532818b5d518b87b57cf36ddc2bf81758f606f9
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=2.3
+  version: "2.3"
+- name: log-cache
+  sha1: 23f9c4767109293b5f8b8a6a07ca31f065bcf88b
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.0.1
+  version: 2.0.1
+- name: bosh-dns-aliases
+  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
+  version: 0.0.3
+- name: cf-cli
+  sha1: 7b727c4c86f2e516e86827a56c5fbff8532aca3e
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.10.0
+  version: 1.10.0
+stemcells:
+- alias: default
+  os: ubuntu-xenial
+  version: "170.5"
+update:
+  canaries: 1
+  canary_watch_time: 30000-1200000
+  max_in_flight: 1
+  serial: false
+  update_watch_time: 5000-1200000
+variables:
+- name: blobstore_admin_users_password
+  type: password
+- name: blobstore_secure_link_secret
+  type: password
+- name: cc_bulk_api_password
+  type: password
+- name: cc_db_encryption_key
+  type: password
+- name: cc_internal_api_password
+  type: password
+- name: cc_staging_upload_password
+  type: password
+- name: cf_mysql_mysql_admin_password
+  type: password
+- name: cf_mysql_mysql_cluster_health_password
+  type: password
+- name: cf_mysql_mysql_galera_healthcheck_endpoint_password
+  type: password
+- name: cf_mysql_mysql_galera_healthcheck_password
+  type: password
+- name: cf_mysql_proxy_api_password
+  type: password
+- name: cc_database_password
+  type: password
+- name: credhub_database_password
+  type: password
+- name: diego_database_password
+  type: password
+- name: uaa_database_password
+  type: password
+- name: routing_api_database_password
+  type: password
+- name: network_policy_database_password
+  type: password
+- name: network_connectivity_database_password
+  type: password
+- name: uaa_default_encryption_passphrase
+  type: password
+- name: silk_ca
+  options:
+    common_name: silk-ca
+    is_ca: true
+  type: certificate
+- name: silk_controller
+  options:
+    ca: silk_ca
+    common_name: silk-controller.service.cf.internal
+    extended_key_usage:
+    - server_auth
+  type: certificate
+- name: silk_daemon
+  options:
+    ca: silk_ca
+    common_name: silk-daemon
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: network_policy_ca
+  options:
+    common_name: networkPolicyCA
+    is_ca: true
+  type: certificate
+- name: network_policy_server
+  options:
+    ca: network_policy_ca
+    common_name: policy-server.service.cf.internal
+    extended_key_usage:
+    - server_auth
+  type: certificate
+- name: network_policy_client
+  options:
+    ca: network_policy_ca
+    common_name: clientName
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: uaa_clients_routing_api_client_secret
+  type: password
+- name: uaa_clients_tcp_emitter_secret
+  type: password
+- name: nats_password
+  type: password
+- name: router_status_password
+  type: password
+- name: cf_admin_password
+  type: password
+- name: cf_bosh_password
+  type: password
+- name: router_route_services_secret
+  type: password
+- name: uaa_admin_client_secret
+  type: password
+- name: uaa_clients_cc-routing_secret
+  type: password
+- name: uaa_clients_cc-service-dashboards_secret
+  type: password
+- name: uaa_clients_cc_service_key_client_secret
+  type: password
+- name: uaa_clients_cloud_controller_username_lookup_secret
+  type: password
+- name: uaa_clients_doppler_secret
+  type: password
+- name: uaa_clients_gorouter_secret
+  type: password
+- name: uaa_clients_network_policy_secret
+  type: password
+- name: uaa_clients_ssh-proxy_secret
+  type: password
+- name: uaa_clients_tcp_router_secret
+  type: password
+- name: diego_bbs_encryption_keys_passphrase
+  type: password
+- name: credhub_encryption_password
+  type: password
+- name: credhub_admin_client_secret
+  type: password
+- name: diego_ssh_proxy_host_key
+  type: ssh
+- name: uaa_jwt_signing_key
+  type: rsa
+- name: service_cf_internal_ca
+  options:
+    common_name: internalCA
+    is_ca: true
+  type: certificate
+- name: blobstore_tls
+  options:
+    ca: service_cf_internal_ca
+    common_name: blobstore.service.cf.internal
+  type: certificate
+- name: diego_auctioneer_client
+  options:
+    ca: service_cf_internal_ca
+    common_name: auctioneer client
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: diego_auctioneer_server
+  options:
+    alternative_names:
+    - '*.auctioneer.service.cf.internal'
+    - auctioneer.service.cf.internal
+    ca: service_cf_internal_ca
+    common_name: auctioneer.service.cf.internal
+    extended_key_usage:
+    - server_auth
+  type: certificate
+- name: diego_bbs_client
+  options:
+    ca: service_cf_internal_ca
+    common_name: bbs client
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: diego_bbs_server
+  options:
+    alternative_names:
+    - '*.bbs.service.cf.internal'
+    - bbs.service.cf.internal
+    ca: service_cf_internal_ca
+    common_name: bbs.service.cf.internal
+    extended_key_usage:
+    - server_auth
+    - client_auth
+  type: certificate
+- name: diego_rep_client
+  options:
+    ca: service_cf_internal_ca
+    common_name: rep client
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: diego_rep_agent_v2
+  options:
+    alternative_names:
+    - '*.cell.service.cf.internal'
+    - cell.service.cf.internal
+    - 127.0.0.1
+    - localhost
+    ca: service_cf_internal_ca
+    common_name: cell.service.cf.internal
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: loggregator_ca
+  options:
+    common_name: loggregatorCA
+    is_ca: true
+  type: certificate
+- name: loggregator_tls_statsdinjector
+  options:
+    ca: loggregator_ca
+    common_name: statsdinjector
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: loggregator_tls_agent
+  options:
+    ca: loggregator_ca
+    common_name: metron
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: loggregator_tls_doppler
+  options:
+    ca: loggregator_ca
+    common_name: doppler
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: loggregator_tls_tc
+  options:
+    ca: loggregator_ca
+    common_name: trafficcontroller
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: loggregator_tls_cc_tc
+  options:
+    ca: service_cf_internal_ca
+    common_name: trafficcontroller
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: loggregator_rlp_gateway_tls_cc
+  options:
+    ca: service_cf_internal_ca
+    common_name: rlp-gateway
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: loggregator_tls_rlp
+  options:
+    ca: loggregator_ca
+    common_name: reverselogproxy
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: loggregator_rlp_gateway
+  options:
+    ca: loggregator_ca
+    common_name: rlp_gateway
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: adapter_rlp_tls
+  options:
+    ca: loggregator_ca
+    common_name: ss-adapter-rlp
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: scheduler_api_tls
+  options:
+    ca: service_cf_internal_ca
+    common_name: ss-scheduler
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: adapter_tls
+  options:
+    ca: loggregator_ca
+    common_name: ss-adapter
+    extended_key_usage:
+    - server_auth
+    - client_auth
+  type: certificate
+- name: scheduler_client_tls
+  options:
+    ca: loggregator_ca
+    common_name: ss-scheduler
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: logs_provider
+  options:
+    ca: loggregator_ca
+    common_name: log-cache
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: log_cache_ca
+  options:
+    common_name: log-cache
+    is_ca: true
+  type: certificate
+- name: log_cache
+  options:
+    alternative_names:
+    - log_cache
+    - log-cache
+    - logcache
+    ca: log_cache_ca
+    common_name: log-cache
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: log_cache_tls_cc_auth_proxy
+  options:
+    ca: service_cf_internal_ca
+    common_name: log-cache
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: router_ca
+  options:
+    common_name: routerCA
+    is_ca: true
+  type: certificate
+- name: router_ssl
+  options:
+    alternative_names:
+    - ((system_domain))
+    - '*.((system_domain))'
+    ca: router_ca
+    common_name: routerSSL
+  type: certificate
+- name: uaa_ca
+  options:
+    common_name: uaaCA
+    is_ca: true
+  type: certificate
+- name: uaa_ssl
+  options:
+    alternative_names:
+    - uaa.service.cf.internal
+    ca: uaa_ca
+    common_name: uaa.service.cf.internal
+  type: certificate
+- name: uaa_login_saml
+  options:
+    ca: uaa_ca
+    common_name: uaa_login_saml
+  type: certificate
+- name: cc_tls
+  options:
+    ca: service_cf_internal_ca
+    common_name: cloud-controller-ng.service.cf.internal
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: cc_public_tls
+  options:
+    alternative_names:
+    - api.((system_domain))
+    - cloud-controller-ng.service.cf.internal
+    ca: service_cf_internal_ca
+    common_name: api.((system_domain))
+  type: certificate
+- name: cc_bridge_tps
+  options:
+    ca: service_cf_internal_ca
+    common_name: tps_watcher
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: cc_bridge_cc_uploader
+  options:
+    ca: service_cf_internal_ca
+    common_name: cc_uploader
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: cc_bridge_cc_uploader_server
+  options:
+    ca: service_cf_internal_ca
+    common_name: cc-uploader.service.cf.internal
+    extended_key_usage:
+    - server_auth
+  type: certificate
+- name: diego_locket_server
+  options:
+    alternative_names:
+    - '*.locket.service.cf.internal'
+    - locket.service.cf.internal
+    ca: service_cf_internal_ca
+    common_name: locket.service.cf.internal
+    extended_key_usage:
+    - server_auth
+  type: certificate
+- name: diego_locket_client
+  options:
+    ca: service_cf_internal_ca
+    common_name: locket client
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: locket_database_password
+  type: password
+- name: application_ca
+  options:
+    common_name: appRootCA
+    is_ca: true
+  type: certificate
+- name: diego_instance_identity_ca
+  options:
+    ca: application_ca
+    common_name: instanceIdentityCA
+    is_ca: true
+  type: certificate
+- name: gorouter_backend_tls
+  options:
+    alternative_names:
+    - gorouter.service.cf.internal
+    ca: service_cf_internal_ca
+    common_name: gorouter_backend_tls
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: credhub_ca
+  options:
+    common_name: credhubServerCa
+    is_ca: true
+  type: certificate
+- name: credhub_tls
+  options:
+    alternative_names:
+    - credhub.service.cf.internal
+    - credhub.((system_domain))
+    ca: credhub_ca
+    common_name: credhub.((system_domain))
+  type: certificate
+- name: isolated_loggregator_ca
+  options:
+    common_name: isolated-loggregatorCA
+    is_ca: true
+  type: certificate
+- name: isolated_loggregator_tls_doppler
+  options:
+    ca: isolated_loggregator_ca
+    common_name: doppler
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: isolated_loggregator_tls_agent
+  options:
+    ca: isolated_loggregator_ca
+    common_name: metron
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: isolated_loggregator_tls_tc
+  options:
+    ca: isolated_loggregator_ca
+    common_name: trafficcontroller
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: isolated_loggregator_tls_rlp
+  options:
+    ca: isolated_loggregator_ca
+    common_name: reverselogproxy
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: isolated_loggregator_tls_cc_tc
+  options:
+    ca: service_cf_internal_ca
+    common_name: trafficcontroller
+    extended_key_usage:
+    - client_auth
+  type: certificate
+- name: uaa_clients_isolated_doppler_secret
+  type: password
+- name: isolated_logs_provider
+  options:
+    ca: isolated_loggregator_ca
+    common_name: isolated-log-cache
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: isolated_log_cache_ca
+  options:
+    common_name: isolated-log-cache
+    is_ca: true
+  type: certificate
+- name: isolated_log_cache
+  options:
+    alternative_names:
+    - log_cache
+    - log-cache
+    ca: isolated_log_cache_ca
+    common_name: log-cache
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+- name: isolated_log_cache_tls_cc_auth_proxy
+  options:
+    ca: service_cf_internal_ca
+    common_name: isolated-log-cache
+    extended_key_usage:
+    - client_auth
+  type: certificate

--- a/operations/test/add-persistent-isolation-segment-infrastructure-metrics.yml
+++ b/operations/test/add-persistent-isolation-segment-infrastructure-metrics.yml
@@ -1,0 +1,124 @@
+- type: remove
+  path: /addons/name=prom_scraper
+
+- type: replace
+  path: /instance_groups/name=nats/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=adapter/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=database/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=uaa/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=singleton-blobstore/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=api/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=doppler/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=log-api/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+
+- type: replace
+  path: /instance_groups/name=isolated-diego-cell/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: isolated_loggregator
+- type: replace
+  path: /instance_groups/name=isolated-doppler/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: isolated_loggregator
+- type: replace
+  path: /instance_groups/name=isolated-log-api/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: isolated_loggregator

--- a/operations/test/add-persistent-isolation-segment-logging-system.yml
+++ b/operations/test/add-persistent-isolation-segment-logging-system.yml
@@ -1,0 +1,499 @@
+---
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: "isolated-doppler.service.cf.internal"
+    targets:
+    - query: "*"
+      instance_group: isolated-doppler
+      deployment: cf
+      network: default
+      domain: bosh
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: isolated-doppler
+    azs:
+    - z1
+    instances: 1
+    vm_type: minimal
+    stemcell: default
+    networks:
+    - name: default
+    jobs:
+    - name: doppler
+      release: loggregator
+      provides:
+        doppler: {as: isolated_doppler, shared: true}
+        loggregator: {as: isolated_loggregator, shared: true}
+      properties:
+        loggregator:
+          tls:
+            ca_cert: "((isolated_loggregator_ca.certificate))"
+            doppler:
+              cert: "((isolated_loggregator_tls_doppler.certificate))"
+              key: "((isolated_loggregator_tls_doppler.private_key))"
+    - name: log-cache
+      release: log-cache
+      provides:
+        log-cache: {as: isolated_log_cache, shared: true}
+      consumes:
+        log-cache: {from: isolated_log_cache}
+      properties:
+        egress_port: 8080
+        health_addr: "localhost:6060"
+        tls:
+          ca_cert: "((isolated_log_cache.ca))"
+          cert: "((isolated_log_cache.certificate))"
+          key: "((isolated_log_cache.private_key))"
+    - name: log-cache-cf-auth-proxy
+      consumes:
+        log-cache: {from: isolated_log_cache}
+        log-cache-gateway: {from: isolated_log_cache_gateway}
+      properties:
+        cc:
+          ca_cert: ((isolated_log_cache_tls_cc_auth_proxy.ca))
+          capi_internal_addr: https://cloud-controller-ng.service.cf.internal:9023
+          cert: ((isolated_log_cache_tls_cc_auth_proxy.certificate))
+          common_name: cloud-controller-ng.service.cf.internal
+          key: ((isolated_log_cache_tls_cc_auth_proxy.private_key))
+        proxy_port: 8083
+        uaa:
+          ca_cert: ((uaa_ca.certificate))
+          client_id: doppler
+          client_secret: ((uaa_clients_doppler_secret))
+          internal_addr: https://uaa.service.cf.internal:8443
+      release: log-cache
+    - name: log-cache-expvar-forwarder
+      release: log-cache
+      consumes:
+        log-cache: {from: isolated_log_cache}
+      properties:
+        maps: []
+        counters:
+        - {name: egress,         source_id: isolated-log-cache,        addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.Egress}}"}
+        - {name: ingress,        source_id: isolated-log-cache,        addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.Ingress}}"}
+        - {name: expired,        source_id: isolated-log-cache,        addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.Expired}}"}
+        - {name: dropped,        source_id: isolated-log-cache,        addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.Dropped}}"}
+        - {name: promql-timeout, source_id: isolated-log-cache,        addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.PromQLTimeout}}"}
+        - {name: egress,         source_id: isolated-log-cache-nozzle, addr: "http://localhost:6061/debug/vars", template: "{{.Nozzle.Egress}}"}
+        - {name: ingress,        source_id: isolated-log-cache-nozzle, addr: "http://localhost:6061/debug/vars", template: "{{.Nozzle.Ingress}}"}
+        - {name: err,            source_id: isolated-log-cache-nozzle, addr: "http://localhost:6061/debug/vars", template: "{{.Nozzle.Err}}"}
+        - {name: dropped,        source_id: isolated-log-cache-nozzle, addr: "http://localhost:6061/debug/vars", template: "{{.Nozzle.Dropped}}"}
+        gauges:
+        - {name: cache-period,                                source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.CachePeriod}}"}
+        - {name: store-size,                                  source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.StoreSize}}"}
+        - {name: total-system-memory,                         source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.TotalSystemMemory}}"}
+        - {name: available-system-memory,                     source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.AvailableSystemMemory}}"}
+        - {name: promql-instant-query-time,                   source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.PromQLInstantQueryTime}}"}
+        - {name: promql-range-query-time,                     source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.PromQLRangeQueryTime}}"}
+        - {name: last-uaa-latency,                            source_id: isolated-log-cache-cf-auth-proxy, addr: "http://localhost:6065/debug/vars", template: "{{.CFAuthProxy.LastUAALatency}}"}
+        - {name: last-capi-v3-apps-latency,                   source_id: isolated-log-cache-cf-auth-proxy, addr: "http://localhost:6065/debug/vars", template: "{{.CFAuthProxy.LastCAPIV3AppsLatency}}"}
+        - {name: last-capi-v2-list-service-instances-latency, source_id: isolated-log-cache-cf-auth-proxy, addr: "http://localhost:6065/debug/vars", template: "{{.CFAuthProxy.LastCAPIV2ListServiceInstancesLatency}}"}
+        - {name: last-capi-v4-log-access-latency,             source_id: isolated-log-cache-cf-auth-proxy, addr: "http://localhost:6065/debug/vars", template: "{{.CFAuthProxy.LastCAPIV4LogAccessLatency}}"}
+        - {name: last-capi-v2-service-instances-latency,      source_id: isolated-log-cache-cf-auth-proxy, addr: "http://localhost:6065/debug/vars", template: "{{.CFAuthProxy.LastCAPIV2ServiceInstancesLatency}}"}
+    - name: log-cache-gateway
+      release: log-cache
+      consumes:
+        log-cache: {from: isolated_log_cache}
+      provides:
+        log-cache-gateway: {as: isolated_log_cache_gateway, shared: true}
+    - name: log-cache-nozzle
+      release: log-cache
+      consumes:
+        reverse_log_proxy: {from: isolated_reverse_log_proxy}
+        log-cache: {from: isolated_log_cache}
+      properties:
+        logs_provider:
+          tls:
+            ca_cert: "((isolated_logs_provider.ca))"
+            cert: "((isolated_logs_provider.certificate))"
+            key: "((isolated_logs_provider.private_key))"
+    - name: route_registrar
+      release: routing
+      properties:
+        route_registrar:
+          routes:
+          - name: isolated-log-cache-reverse-log-proxy
+            port: 8083
+            registration_interval: 20s
+            uris:
+            - iso-log-cache.((system_domain))
+            - "*.iso-log-cache.((system_domain))"
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: isolated-log-api
+    azs:
+    - z1
+    instances: 1
+    vm_type: minimal
+    stemcell: default
+    networks:
+    - name: default
+    jobs:
+    - name: loggregator_trafficcontroller
+      release: loggregator
+      consumes:
+        doppler: {from: isolated_doppler}
+      provides:
+        trafficcontroller: {as: isolated_trafficcontroller}
+      properties:
+        uaa:
+          internal_url: https://uaa.service.cf.internal:8443
+          ca_cert: "((uaa_ca.certificate))"
+        loggregator:
+          tls:
+            cc_trafficcontroller:
+              cert: "((isolated_loggregator_tls_cc_tc.certificate))"
+              key: "((isolated_loggregator_tls_cc_tc.private_key))"
+            ca_cert: "((isolated_loggregator_ca.certificate))"
+            trafficcontroller:
+              cert: "((isolated_loggregator_tls_tc.certificate))"
+              key: "((isolated_loggregator_tls_tc.private_key))"
+          uaa:
+            client_secret: "((uaa_clients_isolated_doppler_secret))"
+            client: isolated-doppler
+        system_domain: "((system_domain))"
+        ssl:
+          skip_cert_verify: true
+        cc:
+          internal_service_hostname: "cloud-controller-ng.service.cf.internal"
+          tls_port: 9023
+          mutual_tls:
+            ca_cert: "((service_cf_internal_ca.certificate))"
+    - name: reverse_log_proxy
+      release: loggregator
+      consumes:
+        doppler: {from: isolated_doppler}
+      provides:
+        reverse_log_proxy: {as: isolated_reverse_log_proxy, shared: true}
+      properties:
+        loggregator:
+          tls:
+            ca_cert: "((isolated_loggregator_ca.certificate))"
+            reverse_log_proxy:
+              cert: "((isolated_loggregator_tls_rlp.certificate))"
+              key: "((isolated_loggregator_tls_rlp.private_key))"
+    - name: route_registrar
+      release: routing
+      properties:
+        route_registrar:
+          routes:
+          - name: isolated-loggregator
+            port: 8080
+            registration_interval: 20s
+            uris:
+            - iso-loggregator.((system_domain))
+          - name: isolated-doppler
+            port: 8081
+            registration_interval: 20s
+            uris:
+            - iso-doppler.((system_domain))
+            - "*.iso-doppler.((system_domain))"
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/isolated-doppler?
+  value:
+    authorities: uaa.resource
+    override: true
+    authorized-grant-types: client_credentials
+    secret: "((uaa_clients_isolated_doppler_secret))"
+
+- type: replace
+  path: /instance_groups/name=adapter/jobs/name=adapter/consumes?
+  value:
+    reverse_log_proxy: {from: reverse_log_proxy}
+
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy/consumes?
+  value:
+    doppler: {from: doppler}
+
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway/consumes?
+  value:
+    reverse_log_proxy: {from: reverse_log_proxy}
+
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/consumes?
+  value:
+    doppler: {from: doppler}
+
+- type: replace
+  path: /addons/name=loggregator_agent/exclude?
+  value: 
+    instance_groups:
+    - isolated-diego-cell
+    - isolated-doppler
+    - isolated-log-api
+
+- type: replace
+  path: /addons/name=loggregator_agent/jobs/name=loggregator_agent
+  value:
+    name: loggregator_agent
+    release: loggregator-agent
+    consumes:
+      doppler:
+        from: doppler
+    properties:
+      loggregator:
+        tls:
+          ca_cert: "((loggregator_ca.certificate))"
+          agent:
+            cert: "((loggregator_tls_agent.certificate))"
+            key: "((loggregator_tls_agent.private_key))"
+
+- type: replace
+  path:  /addons/-
+  value:
+    name: isolated_loggregator_agent
+    include:
+      instance_groups:
+      - isolated-diego-cell
+      - isolated-doppler
+      - isolated-log-api
+    jobs:
+    - name: loggregator_agent
+      release: loggregator-agent
+      consumes:
+        doppler:
+          from: isolated_doppler
+      properties:
+        loggregator:
+          tls:
+            ca_cert: "((isolated_loggregator_ca.certificate))"
+            agent:
+              cert: "((isolated_loggregator_tls_agent.certificate))"
+              key: "((isolated_loggregator_tls_agent.private_key))"
+
+- type: replace
+  path: /instance_groups/name=isolated-diego-cell/jobs/name=rep/properties/loggregator?
+  value:
+    use_v2_api: true
+    ca_cert: "((isolated_loggregator_ca.certificate))"
+    cert: "((isolated_loggregator_tls_agent.certificate))"
+    key: "((isolated_loggregator_tls_agent.private_key))"
+
+- type: replace
+  path: /instance_groups/name=isolated-diego-cell/jobs/name=route_emitter/properties/loggregator?
+  value:
+    use_v2_api: true
+    ca_cert: "((isolated_loggregator_ca.certificate))"
+    cert: "((isolated_loggregator_tls_agent.certificate))"
+    key: "((isolated_loggregator_tls_agent.private_key))"
+
+- type: replace
+  path: /variables/-
+  value:
+    name: isolated_loggregator_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: isolated-loggregatorCA
+
+- type: replace
+  path: /variables/-
+  value:
+    name: isolated_loggregator_tls_doppler
+    type: certificate
+    options:
+      ca: isolated_loggregator_ca
+      common_name: doppler
+      extended_key_usage:
+      - client_auth
+      - server_auth
+- type: replace
+  path: /variables/-
+  value:
+    name: isolated_loggregator_tls_agent
+    type: certificate
+    options:
+      ca: isolated_loggregator_ca
+      common_name: metron
+      extended_key_usage:
+      - client_auth
+      - server_auth
+- type: replace
+  path: /variables/-
+  value:
+    name: isolated_loggregator_tls_tc
+    type: certificate
+    options:
+      ca: isolated_loggregator_ca
+      common_name: trafficcontroller
+      extended_key_usage:
+      - client_auth
+      - server_auth
+- type: replace
+  path: /variables/-
+  value:
+    name: isolated_loggregator_tls_rlp
+    type: certificate
+    options:
+      ca: isolated_loggregator_ca
+      common_name: reverselogproxy
+      extended_key_usage:
+      - client_auth
+      - server_auth
+- type: replace
+  path: /variables/-
+  value:
+    name: isolated_loggregator_tls_cc_tc
+    type: certificate
+    options:
+      ca: service_cf_internal_ca
+      common_name: trafficcontroller
+      extended_key_usage:
+      - client_auth
+- type: replace
+  path: /variables/-
+  value:
+    name: uaa_clients_isolated_doppler_secret
+    type: password
+
+
+
+- type: replace
+  path: /instance_groups/name=isolated-scheduler?
+  value:
+    name: isolated-scheduler
+    azs:
+    - z1
+    - z2
+    instances: 1
+    vm_type: minimal
+    stemcell: default
+    networks:
+    - name: default
+    jobs:
+    - name: log-cache-scheduler
+      release: log-cache
+      consumes:
+        log-cache: {from: isolated_log_cache}
+    - name: log-cache-expvar-forwarder
+      release: log-cache
+      consumes:
+        log-cache: {from: isolated_log_cache}
+      properties:
+        counters: []
+        gauges: []
+        maps:
+        - {name: worker-assignments, source_id: isolated-log-cache-scheduler, addr: "http://localhost:6064/debug/vars", template: "{{.WorkerAssignments | jsonMap}}"}
+        - {name: worker-health,      source_id: isolated-log-cache-scheduler, addr: "http://localhost:6064/debug/vars", template: "{{.WorkerHealth | jsonMap}}"}
+
+- type: replace
+  path: /variables/name=isolated_logs_provider?
+  value:
+    name: isolated_logs_provider
+    type: certificate
+    options:
+      ca: isolated_loggregator_ca
+      common_name: isolated-log-cache
+      extended_key_usage:
+      - client_auth
+      - server_auth
+
+- type: replace
+  path: /variables/name=isolated_log_cache_ca?
+  value:
+    name: isolated_log_cache_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: isolated-log-cache
+
+- type: replace
+  path: /variables/name=isolated_log_cache?
+  value:
+    name: isolated_log_cache
+    type: certificate
+    options:
+      ca: isolated_log_cache_ca
+      common_name: log-cache
+      alternative_names:
+      - log_cache
+      - log-cache
+      extended_key_usage:
+      - client_auth
+      - server_auth
+
+- type: replace
+  path: /variables/name=isolated_log_cache_tls_cc_auth_proxy?
+  value:
+    name: isolated_log_cache_tls_cc_auth_proxy
+    options:
+      ca: service_cf_internal_ca
+      common_name: isolated-log-cache
+      extended_key_usage:
+      - client_auth
+    type: certificate
+
+- type: replace
+  path: /instance_groups/name=isolated-log-api/jobs/name=loggregator_trafficcontroller/consumes/log-cache?
+  value:
+    from: isolated_log_cache
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/consumes?
+  value:
+    log-cache: {from: log_cache}
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache/consumes?
+  value:
+    log-cache: {from: log_cache}
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache/provides/log-cache?
+  value:
+    as: log_cache
+    shared: true
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/consumes?
+  value:
+    log-cache: {from: log_cache}
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/consumes/log-cache-gateway?
+  value:
+    from: log_cache_gateway
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/consumes?
+  value:
+    log-cache: {from: log_cache}
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-gateway/consumes?
+  value:
+    log-cache: {from: log_cache}
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-gateway/provides?/log-cache-gateway?
+  value:
+    as: log_cache_gateway
+    shared: true
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-nozzle/consumes/log-cache?
+  value:
+    from: log_cache
+
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/consumes/log-cache?
+  value:
+    from: log_cache
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/consumes?
+  value:
+    log-cache: {from: log_cache}
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=log-cache-scheduler/consumes?
+  value:
+    log-cache: {from: log_cache}

--- a/operations/test/add-persistent-isolation-segment-syslog-drain.yml
+++ b/operations/test/add-persistent-isolation-segment-syslog-drain.yml
@@ -1,0 +1,142 @@
+---
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: isolated-adapter
+    azs:
+    - z1
+    - z2
+    instances: 2
+    vm_type: minimal
+    stemcell: default
+    networks:
+    - name: default
+    jobs:
+    - name: adapter
+      release: cf-syslog-drain
+      provides:
+        adapter_addrs: {as: isolated_adapter_addrs}
+      consumes:
+        reverse_log_proxy: {from: isolated_reverse_log_proxy}
+      properties:
+        scalablesyslog:
+          adapter:
+            tls:
+              ca: "((isolated_loggregator_ca.certificate))"
+              cert: "((isolated_adapter_tls.certificate))"
+              key: "((isolated_adapter_tls.private_key))"
+              cn: ss-adapter
+            bosh_dns: true
+          adapter_rlp:
+            tls:
+              ca: "((isolated_loggregator_ca.certificate))"
+              cert: "((isolated_adapter_rlp_tls.certificate))"
+              key: "((isolated_adapter_rlp_tls.private_key))"
+              cn: reverselogproxy
+
+# scheduler
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=scheduler/consumes?
+  value:
+    adapter_addrs: {from: adapter_addrs}
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: isolated-scheduler
+    azs:
+    - z1
+    - z2
+    instances: 2
+    vm_type: minimal
+    stemcell: default
+    update:
+      serial: true
+    networks:
+    - name: default
+    jobs:
+    - name: scheduler
+      release: cf-syslog-drain
+      consumes:
+        adapter_addrs: {from: isolated_adapter_addrs}
+      properties:
+        scalablesyslog:
+          scheduler:
+            api:
+              url: https://cloud-controller-ng.service.cf.internal:9023
+            tls:
+              client:
+                ca: "((isolated_loggregator_ca.certificate))"
+                cert: "((isolated_scheduler_client_tls.certificate))"
+                key: "((isolated_scheduler_client_tls.private_key))"
+                adapter_cn: "ss-adapter"
+              api:
+                ca: "((service_cf_internal_ca.certificate))"
+                cert: "((isolated_scheduler_api_tls.certificate))"
+                key: "((isolated_scheduler_api_tls.private_key))"
+                cn: "cloud-controller-ng.service.cf.internal"
+
+
+# metron agent
+- type: replace
+  path: /instance_groups/name=isolated-adapter/jobs/-
+  value:
+    name: loggregator_agent
+    release: loggregator-agent
+    consumes:
+      doppler: {from: isolated_doppler}
+    properties:
+      doppler:
+        addr: "isolated-doppler.service.cf.internal"
+      loggregator:
+        tls:
+          ca_cert: "((isolated_loggregator_ca.certificate))"
+          agent:
+            cert: "((isolated_loggregator_tls_agent.certificate))"
+            key: "((isolated_loggregator_tls_agent.private_key))"
+
+# variables
+- type: replace
+  path: /variables/-
+  value:
+    name: isolated_adapter_tls
+    type: certificate
+    options:
+      ca: isolated_loggregator_ca
+      common_name: ss-adapter
+      extended_key_usage:
+      - server_auth
+      - client_auth
+- type: replace
+  path: /variables/-
+  value:
+    name: isolated_adapter_rlp_tls
+    type: certificate
+    options:
+      ca: isolated_loggregator_ca
+      common_name: ss-adapter-rlp
+      extended_key_usage:
+      - client_auth
+      - server_auth
+- type: replace
+  path: /variables/-
+  value:
+    name: isolated_scheduler_client_tls
+    type: certificate
+    options:
+      ca: isolated_loggregator_ca
+      common_name: ss-scheduler
+      extended_key_usage:
+      - client_auth
+      - server_auth
+- type: replace
+  path: /variables/-
+  value:
+    name: isolated_scheduler_api_tls
+    type: certificate
+    options:
+      ca: service_cf_internal_ca
+      common_name: ss-scheduler
+      extended_key_usage:
+      - client_auth
+      - server_auth

--- a/operations/test/alter-router-for-log-agent.yml
+++ b/operations/test/alter-router-for-log-agent.yml
@@ -1,0 +1,70 @@
+---
+- type: replace
+  path: /instance_groups/name=router/jobs/-
+  value:
+    name: loggregator_agent
+    release: loggregator-agent
+    consumes:
+      doppler:
+        from: doppler
+    properties:
+      loggregator:
+        tls:
+          ca_cert: "((loggregator_ca.certificate))"
+          agent:
+            cert: "((loggregator_tls_agent.certificate))"
+            key: "((loggregator_tls_agent.private_key))"
+- type: replace
+  path: /instance_groups/name=tcp-router/jobs/-
+  value:
+    name: loggregator_agent
+    release: loggregator-agent
+    consumes:
+      doppler:
+        from: doppler
+    properties:
+      loggregator:
+        tls:
+          ca_cert: "((loggregator_ca.certificate))"
+          agent:
+            cert: "((loggregator_tls_agent.certificate))"
+            key: "((loggregator_tls_agent.private_key))"
+- type: replace
+  path: /instance_groups/name=router/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=tcp-router/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: loggregator
+- type: replace
+  path: /instance_groups/name=iso-seg-router/jobs/-
+  value:
+    name: loggregator_agent
+    release: loggregator-agent
+    consumes:
+      doppler:
+        from: isolated_doppler
+    properties:
+      loggregator:
+        tls:
+          ca_cert: "((isolated_loggregator_ca.certificate))"
+          agent:
+            cert: "((isolated_loggregator_tls_agent.certificate))"
+            key: "((isolated_loggregator_tls_agent.private_key))"
+- type: replace
+  path: /instance_groups/name=iso-seg-router/jobs/-
+  value:
+    name: prom_scraper
+    release: loggregator-agent
+    consumes:
+      loggregator:
+        from: isolated_loggregator

--- a/scripts/test-test.sh
+++ b/scripts/test-test.sh
@@ -14,6 +14,10 @@ test_test_ops() {
       check_interpolation "alter-ssh-proxy-redirect-uri.yml"
       check_interpolation "enable-nfs-test-server.yml"
       check_interpolation "enable-smb-test-server.yml" "-v smb-password=FOO.PASS" "-v smb-username=BAR.USER"
+      check_interpolation "name: add-persistent-isolation-segment-logging-system.yml" "add-persistent-isolation-segment-diego-cell.yml" "-o add-persistent-isolation-segment-logging-system.yml"
+      check_interpolation "name: add-persistent-isolation-segment-syslog-drain.yml" "add-persistent-isolation-segment-diego-cell.yml" "-o add-persistent-isolation-segment-logging-system.yml" "-o add-persistent-isolation-segment-syslog-drain.yml"
+      check_interpolation "name: alter-router-for-log-agent.yml" "add-persistent-isolation-segment-router.yml" "-o add-persistent-isolation-segment-diego-cell.yml" "-o add-persistent-isolation-segment-logging-system.yml" "-o alter-router-for-log-agent.yml"
+      check_interpolation "name: add-persistent-isolation-segment-infrastructure-metrics.yml" "${home}/operations/experimental/infrastructure-metrics.yml" "-o add-persistent-isolation-segment-diego-cell.yml" "-o add-persistent-isolation-segment-logging-system.yml" "-o add-persistent-isolation-segment-infrastructure-metrics.yml"
     popd > /dev/null # operations/test
   popd > /dev/null
   exit $exit_code


### PR DESCRIPTION
### WHAT is this change about?

Add ops files to deploy an isolated Loggregator.

### WHY is this change being made (What problem is being addressed)?

To enable isolated Loggregator

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/160112181


### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO



### How should this change be described in cf-deployment release notes?

- Adds ops files to deploy isolated Loggregator and Syslog Drains


### Does this PR introduce a breaking change? 

No


### Will this change increase the VM footprint of cf-deployment?

- [x] YES
- [ ] NO

If the ops files are used, a whole isolated Loggregator will deployed

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@MasslessParticle @jtuchscherer 
