### PR TITLE
Register SMB Volume Service Broker when the azurefilebrokerpush Errand is Run

### DIFF
--- a/operations/experimental/enable-smb-volume-service.yml
+++ b/operations/experimental/enable-smb-volume-service.yml
@@ -36,7 +36,6 @@
         domain: ((system_domain))
         organization: system
         password: ((azurefile-broker-password))
-        register_broker: false
         service_id: azurefile-volume
         service_name: azurefile-service
         skip_cert_verify: true


### PR DESCRIPTION
### WHAT is this change about?

Register the SMB volume service broker when the azurefilebrokerpush errand is run.

### WHY is this change being made (What problem is being addressed)?

This change mirrors a [recent change](https://github.com/cloudfoundry/cf-deployment/pull/592) to make the same change to the nfsbrokerpush errand configuration. It eliminates the need to either use a separate errand to do this, or to do it manually.

### Please provide contextual information.

This should have been included in the [PR](https://github.com/cloudfoundry/cf-deployment/pull/593) that added this ops-file. See also the [corresponding PR](https://github.com/cloudfoundry/cf-deployment/pull/592) to change the nfsbrokerpush.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO - This isn't applicable as CATs doesn't test the SMB broker. However, it has passed our acceptance tests in our CI.

### How should this change be described in cf-deployment release notes?

Updated Ops-files
operations/experimental/enable-smb-volume-service.yml - Register the SMB volume service broker when the azurefilebrokerpush errand is run.

### Does this PR introduce a breaking change? 

- [ ] YES --- does it really have to?
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@julian-hj @paulcwarren @mariash 