### PR TITLE
Remove unused tps.listener_enabled property

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1234,7 +1234,6 @@ instance_groups:
             ca_cert: "((service_cf_internal_ca.certificate))"
             client_cert: "((cc_bridge_tps.certificate))"
             client_key: "((cc_bridge_tps.private_key))"
-          listener_enabled: false
   - name: ssh_proxy
     release: diego
     properties:


### PR DESCRIPTION
This was removed from capi-release in v1.54.0

### WHAT is this change about?

Removing an unused property.

### WHY is this change being made (What problem is being addressed)?

The property is unused, so it's just cruft.

### Please provide contextual information.

https://github.com/cloudfoundry/capi-release/releases/tag/1.54.0

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO

### How should this change be described in cf-deployment release notes?

I don't think it's worth mentioning.

### Does this PR introduce a breaking change? 

Not unless people are still using really old capi-release versions somehow.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
- [X] Not at all urgent



### Tag your pair, your PM, and/or team!

I think it's just me :)
