### PR TITLE
Add oidc provider ops file [#160692210]

### DIFF
--- a/operations/test/README.md
+++ b/operations/test/README.md
@@ -1,0 +1,18 @@
+# cf-deployment Test Ops-files
+
+This is the README for Test Ops-files. To learn more about `cf-deployment`, go to the main [README](../../README.md). 
+
+The opsfile in this directory are meant for testing and are **not meant for production environments**.
+
+They may change without notice.
+
+- For general Ops-files, check out the [Ops-file README](../README.md).
+- For experimental Ops-files, check out the [Experimental Ops-file README](../experimental/README.md)
+- For Community Ops-files, check out the [Community Ops-file README](../community/README.md).
+- For Addons Ops-files that can be applied to manifests or runtime configs, check out the [Addons Ops-file README](../addons/README.md).
+- For Backup and Restore Ops-files (for configuring your deployment for use with [BBR](https://github.com/cloudfoundry-incubator/bosh-backup-and-restore)), checkout the [Backup and Restore Ops-files README](../backup-and-restore/README.md).
+
+| Name | Purpose | Notes |
+|:---  |:---     |:---   |
+| [`add-oidc-provider.yml `](add-oidc-provider.yml) | Allows testing of UAA with users authenticated via an OIDC provider | Creates a second UAA instance group that acts as the OIDC provider |
+

--- a/operations/test/add-oidc-provider.yml
+++ b/operations/test/add-oidc-provider.yml
@@ -1,0 +1,170 @@
+---
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/login/oauth?/providers
+  value:
+    cli-oidc-provider:
+      type: oidc1.0
+      discoveryUrl: https://uaa-oidc.service.cf.internal:8443/.well-known/openid-configuration
+      scopes:
+        - openid
+      linkText: My other uaa Oauth Provider
+      showLinkText: true
+      addShadowUserOnLogin: true
+      relyingPartyId: rp_oidc_admin
+      relyingPartySecret: ((rp_oidc_provider_admin_secret))
+      skipSslValidation: true
+      storeCustomAttributes: true
+      passwordGrantEnabled: true
+      attributeMappings:
+        given_name: given_name
+        family_name: family_name
+        user_name: user_name
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: uaa-oidc
+    instances: 1
+    azs: [z1, z2, z3]
+    vm_type: default
+    stemcell: default
+    persistent_disk: 500
+    networks:
+    - name: default
+    jobs:
+    - name: uaa
+      release: uaa
+      properties:
+        encryption:
+          active_key_label: 'key-1'
+          encryption_keys:
+            - label: 'key-1'
+              passphrase: "((uaa_oidc_encryption_key_passphrase))"
+        uaadb:
+          databases:
+          - name: uaa_oidc
+            tag: uaa
+          db_scheme: mysql
+          port: 3306
+          roles:
+          - name: uaa-oidc
+            password: "((uaa_oidc_database_password))"
+            tag: admin
+        uaa:
+          url: https://uaa-oidc.service.cf.internal:8443
+          jwt:
+            policy:
+              active_key_id: key-1
+              keys:
+                key-1:
+                  signingKey: ((uaa-oidc-key1.private_key))
+          sslCertificate: ((uaa-oidc_tls.certificate))
+          sslPrivateKey: ((uaa-oidc_tls.private_key))
+          clients:
+            rp_oidc_admin:
+              authorized-grant-types: authorization_code,client_credentials,refresh_token,user_token,password,urn:ietf:params:oauth:grant-type:saml2-bearer,implicit
+              redirect-uri: https://uaa.service.cf.internal:8443/login/callback/cli-oidc-provider
+              scope: openid,uaa.admin,clients.read,clients.write,clients.secret,scim.read,scim.write,clients.admin,uaa.user
+              authorities: uaa.admin,clients.admin
+              secret: ((rp_oidc_provider_admin_secret))
+          scim:
+            user:
+              override: true
+            users:
+              - name: admin-oidc
+                password: "((uaa_oidc_admin_password))"
+                groups:
+                  - uaa.admin
+        login:
+          protocol: https
+          saml:
+            activeKeyId: key1
+            keys:
+              key1:
+                key: ((saml_oidc-key1.private_key))
+                passphrase: ((saml_oidc_key1_passphrase))
+                certificate: ((saml_oidc-key1.certificate))
+
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: uaa-oidc.service.cf.internal
+    targets:
+    - query: '*'
+      instance_group: uaa-oidc
+      deployment: cf
+      network: default
+      domain: bosh
+
+- type: replace
+  path: /instance_groups/name=database/jobs/name=mysql/properties/cf_mysql/mysql/seeded_databases?/-
+  value:
+    name: uaa_oidc
+    username: uaa-oidc
+    password: "((uaa_oidc_database_password))"
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: uaa_oidc_admin_password
+    type: password
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: uaa_oidc_database_password
+    type: password
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: uaa_oidc_encryption_key_passphrase
+    type: password
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: rp_oidc_provider_admin_secret
+    type: password
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: saml_oidc_key1_passphrase
+    type: password
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: uaa-oidc-key1
+    type: rsa
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: uaa-oidc_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: uaa-oidc
+      alternative_names: ["*.uaa-oidc.service.cf.internal"]
+      extended_key_usage:
+      - server_auth
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: saml_oidc-key1
+    type: certificate
+    options:
+      ca: uaa-oidc_ca
+      common_name: saml_oidc
+
+- type: replace
+  path: /variables?/-
+  value:
+    name: uaa-oidc_tls
+    type: certificate
+    options:
+      ca: uaa-oidc_ca
+      common_name: uaa-oidc.service.cf.internal

--- a/scripts/test-test-ops.sh
+++ b/scripts/test-test-ops.sh
@@ -13,6 +13,7 @@ test_test_ops() {
       check_interpolation "alter-ssh-proxy-redirect-uri.yml"
       check_interpolation "name: disable_windows_consul_agent_nameserver_overwriting.yml" "${home}/operations/windows2012R2-cell.yml" "-o disable_windows_consul_agent_nameserver_overwriting.yml"
       check_interpolation "name: windows2016-debug.yml" "${home}/operations/windows2012R2-cell.yml"
+      check_interpolation "add-oidc-provider.yml"
     popd > /dev/null # operations/test
   popd > /dev/null
   exit $exit_code


### PR DESCRIPTION
Signed-off-by: Magesh Kumar Murali <mmurali@pivotal.io>
Co-authored-by: Ryan Tang  <rtang@pivotal.io>

### WHAT is this change about?

This change allows for testing of a UAA with users authenticated with an OIDC provider.

### WHY is this change being made (What problem is being addressed)?

We are trying to share some test Cloud Foundry environments with other teams. Both of our teams view cf-deployment as the canonical place for ops files.

### Please provide contextual information.

We had a couple of in-person conversations. Happy to provide more written docs if that helps.
https://www.pivotaltracker.com/story/show/160692210

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?

Should not affect cf-deployment release notes. Though we can say "added an ops file to help platform developers test their system" if we'd like.

### Does this PR introduce a breaking change? 
No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component
- [X] None of the above


### What is the level of urgency for publishing this change?

- [X ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@ryantang  @tjvman @abbyachau 