### PR TITLE
Disable components from registering as Consul services

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -393,6 +393,7 @@ instance_groups:
             ca_cert: "((service_cf_internal_ca.certificate))"
             client_cert: "((diego_rep_client.certificate))"
             client_key: "((diego_rep_client.private_key))"
+      enable_consul_service_registration: false
       loggregator: &diego_loggregator_client_properties
         use_v2_api: true
         ca_cert: "((loggregator_ca.certificate))"
@@ -436,6 +437,7 @@ instance_groups:
             db_username: locket
             db_password: "((locket_database_password))"
             db_driver: mysql
+      enable_consul_service_registration: false
       loggregator:
         use_v2_api: true
         ca_cert: "((loggregator_ca.certificate))"
@@ -835,6 +837,7 @@ instance_groups:
     properties:
       bpm:
         enabled: true
+      enable_consul_service_registration: false
       logging:
         format:
           timestamp: "rfc3339"
@@ -1042,6 +1045,7 @@ instance_groups:
           server_cert: "((diego_auctioneer_server.certificate))"
           server_key: "((diego_auctioneer_server.private_key))"
           skip_consul_lock: true
+      enable_consul_service_registration: false
       loggregator: *diego_loggregator_client_properties
       logging:
         format:
@@ -1107,6 +1111,7 @@ instance_groups:
           uaa:
             ca_cert: "((uaa_ca.certificate))"
           bbs: *diego_bbs_client_properties
+      enable_consul_service_registration: false
       loggregator: *diego_loggregator_client_properties
       logging:
         format:
@@ -1358,6 +1363,7 @@ instance_groups:
           - ((application_ca.certificate))
           - ((credhub_ca.certificate))
           - ((uaa_ca.certificate))
+      enable_consul_service_registration: false
       enable_declarative_healthcheck: true
       loggregator: *diego_loggregator_client_properties
       tls:

--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -47,6 +47,7 @@
           uaa_secret: "((uaa_clients_ssh-proxy_secret))"
         ssl:
           skip_cert_verify: true
+      enable_consul_service_registration: false
       logging:
         format:
           timestamp: "rfc3339"


### PR DESCRIPTION
### WHAT is this change about?

This configuration has the same effect as the operations at https://github.com/cloudfoundry/cf-deployment/blob/v4.5.0/operations/experimental/disable-consul.yml#L50-L67 and https://github.com/cloudfoundry/cf-deployment/blob/v4.5.0/operations/experimental/disable-consul-bosh-lite.yml#L4-L6, which were omitted in https://github.com/cloudfoundry/cf-deployment/commit/3cab0090afdfc9ec5e0f701800e24d3309d4051f when applying these operations to cf-deployment.yml.

### WHY is this change being made (What problem is being addressed)?

Without opting these components out of maintaining their own service registrations, they produce a significant volume of logs about their failure to connect to a local Consul agent.

### Please provide contextual information.

cf-deployment v5.0.0 removed Consul entirely.


### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO, but this change would not affect CATs.



### How should this change be described in cf-deployment release notes?

Bug fix: Opt Diego components out of Consul service registration now that Consul has been removed.


### Does this PR introduce a breaking change? 

No.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

Given the frequency at which the components attempt to establish their Consul service registrations, the log output is pretty chatty.

### Tag your pair, your PM, and/or team!

/cc @cloudfoundry/cf-diego @heyjcollins @staylor14 