### PR TITLE
Log cache certs reference variables from CA variables

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1178,7 +1178,7 @@ instance_groups:
       egress_port: 8080
       health_addr: localhost:6060
       tls:
-        ca_cert: ((log_cache.ca))
+        ca_cert: ((log_cache_ca.certificate))
         cert: ((log_cache.certificate))
         key: ((log_cache.private_key))
     release: log-cache
@@ -1192,7 +1192,7 @@ instance_groups:
     properties:
       logs_provider:
         tls:
-          ca_cert: ((logs_provider.ca))
+          ca_cert: ((loggregator_ca.certificate))
           cert: ((logs_provider.certificate))
           key: ((logs_provider.private_key))
     release: log-cache
@@ -1294,7 +1294,7 @@ instance_groups:
   - name: log-cache-cf-auth-proxy
     properties:
       cc:
-        ca_cert: ((log_cache_tls_cc_auth_proxy.ca))
+        ca_cert: ((service_cf_internal_ca.certificate))
         capi_internal_addr: https://cloud-controller-ng.service.cf.internal:9023
         cert: ((log_cache_tls_cc_auth_proxy.certificate))
         common_name: cloud-controller-ng.service.cf.internal

--- a/scripts/semantic-tests.sh
+++ b/scripts/semantic-tests.sh
@@ -113,6 +113,23 @@ test_add_persistent_isolation_segment_diego_cell() {
   fi
 }
 
+test_all_cas_references_from_ca_variables() {
+  local invalid_ca_references
+  local exit_code
+
+  set +e
+    invalid_ca_references=$(grep -E '\(\(.*\.ca\)\)' cf-deployment.yml)
+    exit_code=$?
+  set -e
+
+  if [[ $exit_code == 0 ]]; then
+    fail "CAs should be referenced from their CA variables: $invalid_ca_references"
+  else
+    pass "CA are referenced from CA variables in cf-deployment.yml"
+  fi
+}
+
+
 semantic_tests() {
   # padded for pretty output
   suite_name="semantic    "
@@ -124,6 +141,7 @@ semantic_tests() {
     test_use_compiled_releases
     test_use_trusted_ca_cert_for_apps_doesnt_overwrite_existing_trusted_cas
     test_add_persistent_isolation_segment_diego_cell
+    test_all_cas_references_from_ca_variables
   popd > /dev/null
   exit $exit_code
 }


### PR DESCRIPTION
### WHAT is this change about?

This change switches CA references introduced by #535 to be from their respective CA variables rather than certificate variables.

### WHY is this change being made (What problem is being addressed)?

This reduces log availability downtime during CA rotation.

### Please provide contextual information.

More information about why CAs need to be referenced this way is described in #305 

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?
N/A

### How should this change be described in cf-deployment release notes?

Switch log cache CA references to reduce log availability downtime during CA rotation.

### Does this PR introduce a breaking change? 
No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
