### PR TITLE
Export new log-cache metrics

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1252,6 +1252,14 @@ instance_groups:
         source_id: log-cache
         addr: http://localhost:6060/debug/vars
         template: "{{.LogCache.AvailableSystemMemory}}"
+      - name: promql-instant-query-time
+        source_id: log-cache
+        addr: http://localhost:6060/debug/vars
+        template: "{{.LogCache.PromQLInstantQueryTime}}"
+      - name: promql-range-query-time
+        source_id: log-cache
+        addr: http://localhost:6060/debug/vars
+        template: "{{.LogCache.PromQLRangeQueryTime}}"
 
         # CF Auth Proxy
       - name: last-uaa-latency


### PR DESCRIPTION
### WHAT is this change about?

_This adds new SLI metrics for log-cache's PromQL endpoints._

### WHY is this change being made (What problem is being addressed)?

_log-cache allows users to subset the metrics that are forwarded from the component; we added these metrics in recent releases of log-cache, and need this manifest change for them to be visible._

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?

_Export additional log-cache SLI metrics._



### Does this PR introduce a breaking change? 

_Nope, just exports some gauges._

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@jtuchscherer @toddboom @hdub2 
