### PR TITLE
Update enable_bpm_garden

### DIFF
--- a/operations/experimental/enable-bpm-garden.yml
+++ b/operations/experimental/enable-bpm-garden.yml
@@ -25,7 +25,7 @@
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/additional_bpm_volumes?
   value:
-    - "/var/vcap/data/rep/shared_data"
+    - "/var/vcap/data/rep/shared/garden"
     - "/var/vcap/data/netplugin-server/sockets"
 
 - type: replace
@@ -39,3 +39,13 @@
         plugin_extra_args:
           - "--configFile"
           - "/var/vcap/jobs/garden-cni/config/adapter.json"
+
+# Rootless configuration
+# Requires grootfs 0.27.0 or later, and garden-runc 1.9.5 or later.
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/experimental_rootless_mode?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties?/grootfs/skip_mount
+  value: true


### PR DESCRIPTION
### WHAT is this change about?

This updates the shared data dir for garden and rep in garden's additional_volumes list.
Rootless containers are also enabled by default when garden is in bpm. Rootless and BPM for garden previously were enabled via separate ops files, but Garden does not intend for BPM to be used without rootless containers.

### WHY is this change being made (What problem is being addressed)?

These changes are being made to push forward with running unprivileged containers in CF.

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/160886256
https://www.pivotaltracker.com/story/show/157735968


### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO


### How should this change be described in cf-deployment release notes?

Experimentally run rootless Garden containers in BPM.


### Does this PR introduce a breaking change? 

Enabling rootless and/or BPM for garden requires recreation of all diego-cells.


### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**


### Important to note
We have a slight chicken and egg situation here, this ops file will only work once Garden has released 1.16.7 and Diego has released 2.20.0, but first we need Diego to enable it in their pipeline, and for that this ops file needs to exist.
Given that right now using the current `enable-bpm-garden.yml` ops file does not work (especially not with `rootless-containers.yml`), we hope this can be merged anyway.
Once this is merged and Garden and Diego are released then we can advise that the feature is safe to use.