### PR TITLE
fix bosh-lite directions for credhub

### DIFF
--- a/operations/use-offline-windows2016fs.yml
+++ b/operations/use-offline-windows2016fs.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /releases/name=windows2016fs?
+  path: /releases/name=windows2016fs
   value:
     name: windows2016fs
     version: 1.8.0


### PR DESCRIPTION
Deployment guide needs updating with regards to bosh-lite and credhub.

1.) I believe there are two credhubs, you must target the right one.
- in PCF
- in BOSH
credhub api --server api.bosh-lite.com - this goes to
Name:    api.bosh-lite.com
Address: 10.244.0.34

must use IP and correct port for local bosh-lite Director to target, e.g.
192.168.50.6:8844

2.) setting correct cert in the env var for credhub login, with a newline between certs

3.) to login to credhub you need to set
export CREDHUB_CLIENT=credhub-admin

4.) add some detail about logging in as cf admin


### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO



### How should this change be described in cf-deployment release notes?

see above.


### Does this PR introduce a breaking change? 

it's a doc only fix.




### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

no



### What is the level of urgency for publishing this change?

no urgency from my end



### Tag your pair, your PM, and/or team!

@emalm 
