### PR TITLE
Add ops-file for using an external db with cc_deployment_updater

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -20,6 +20,7 @@ and the ops-files will be removed.
 |:---  |:---     |:---   |
 | [`add-credhub-lb.yml`](add-credhub-lb.yml) | Use load balancer to expose external address for CredHub. | |
 | [`add-deployment-updater.yml`](add-deployment-updater.yml) | Add `cc_deployment_updater` job to `scheduler` vm, which enables zero downtime app deployments. | |
+| [`add-deployment-updater-external-db.yml`](add-deployment-updater-external-db.yml) | Use an external database for the `cc_deployment_updater` job. | Requires `add-deployment-updater.yml` and `use-external-dbs.yml` |
 | [`add-deployment-updater-postgres.yml`](add-deployment-updater-postgres.yml) | Use a postgres database for the `cc_deployment_updater` job. | Requires `add-deployment-updater.yml` |
 | [`add-cflinuxfs3.yml`](add-cflinuxfs3.yml) | Add the cflinuxfs3 [stack](https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html) and buildpacks | Use this opsfile for testing component and app compatibility with cflinuxfs3 in advance of changing the default rootfs. |
 | [`bits-service.yml`](bits-service.yml) | **DEPRECATED: Promoted to `operations/bits-service/use-bits-service.yml` and will be removed in the next major release** Adds the [bits-service](https://github.com/cloudfoundry-incubator/bits-service) job and enables it in the cloud-controller. | Also requires one of `bits-service-{local,webdav,s3}.yml` from the same directory. |

--- a/operations/experimental/add-deployment-updater-external-db.yml
+++ b/operations/experimental/add-deployment-updater-external-db.yml
@@ -1,0 +1,20 @@
+---
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/db_scheme
+  value: &external_cc_database_scheme "((external_database_type))"
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/port
+  value: &external_cc_database_port "((external_database_port))"
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/databases/tag=cc/name
+  value: &external_cc_database_name "((external_cc_database_name))"
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/address?
+  value: &external_cc_database_address "((external_cc_database_address))"
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/roles/name=cloud_controller/password
+  value: &external_cc_database_password "((external_cc_database_password))"
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/roles/name=cloud_controller/name
+  value: &external_cc_database_username "((external_cc_database_username))"
+  

--- a/scripts/test-experimental.sh
+++ b/scripts/test-experimental.sh
@@ -58,7 +58,7 @@ test_experimental_ops() {
 
       check_interpolation "add-deployment-updater.yml"
       check_interpolation "name: add-deployment-updater-postgres.yml" "add-deployment-updater.yml" "-o add-deployment-updater-postgres.yml"
-
+      check_interpolation "name: add-deployment-updater-external-db.yml" "${home}/operations/use-external-dbs.yml" "-o add-deployment-updater.yml" "-o add-deployment-updater-external-db.yml" "-l ${home}/operations/example-vars-files/vars-use-external-dbs.yml"
       check_interpolation "windows1803-cell.yml"
       check_interpolation "name: windows-component-syslog-ca.yml" "windows-enable-component-syslog.yml" "-o windows-component-syslog-ca.yml" "-l ${home}/operations/addons/example-vars-files/vars-enable-component-syslog.yml"
       check_interpolation "name: windows-enable-component-syslog.yml" "windows-enable-component-syslog.yml" "-l ${home}/operations/addons/example-vars-files/vars-enable-component-syslog.yml"


### PR DESCRIPTION
### WHAT is this change about?

Adds an experimental ops-file for beta users who wish to use the
cc_deployment_updater (enables usage of the experimental zero downtime
app deployment feature) component with an external database

### WHY is this change being made (What problem is being addressed)?

The beta users that we expect to be trying out this feature use an external database for CCDB.

### Please provide contextual information.

* https://www.pivotaltracker.com/story/show/161331073
* https://www.pivotaltracker.com/n/projects/2090335/stories/161233272
* https://github.com/cloudfoundry/cf-deployment/pull/630


### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO

Did not run CATS. I'm currently deploying an environment that uses an external Google Cloud SQL db and will test the zero downtime app push command explicitly.

**Edit:** Yep it works.

### How should this change be described in cf-deployment release notes?

Same way you're describing https://github.com/cloudfoundry/cf-deployment/pull/630, but say it will enable the use of an external database.


### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@charleshansen @SocalNick @shauravg 