### PR TITLE
Add expvar forwarder job to loggregator-agent addon

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -26,6 +26,71 @@ addons:
           agent:
             cert: "((loggregator_tls_agent.certificate))"
             key: "((loggregator_tls_agent.private_key))"
+  - name: loggr-expvar-forwarder
+    release: loggregator-agent
+    properties:
+      log_agent:
+        ca_cert: "((expvar_forwarder.ca))"
+        client_cert: "((expvar_forwarder.certificate))"
+        client_key: "((expvar_forwarder.private_key))"
+      default_source_id: metron
+      counters:
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: dropped
+        template: "{{.Agent.Dropped}}"
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: dropped
+        template: "{{.Agent.DroppedEgressV2}}"
+        tags:
+          direction: egress
+          metric_version: "2.0"
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: dropped
+        template: "{{.Agent.DroppedIngressV2}}"
+        tags:
+          direction: ingress
+          metric_version: "2.0"
+
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: egress
+        template: "{{.Agent.Egress}}"
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: egress
+        template: "{{.Agent.EgressV2}}"
+        tags:
+          metric_version: "2.0"
+
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: ingress
+        template: "{{.Agent.Ingress}}"
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: ingress
+        template: "{{.Agent.IngressV2}}"
+        tags:
+          metric_version: "2.0"
+
+      gauges:
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: average_envelopes
+        unit: bytes/minute
+        template: "{{.Agent.AverageEnvelope}}"
+        tags:
+          loggregator: v1
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: average_envelopes
+        unit: bytes/minute
+        template: "{{.Agent.AverageEnvelopeV2}}"
+        tags:
+          metric_version: "2.0"
+          loggregator: v2
+
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: origin_mappings
+        unit: bytes/minute
+        template: "{{.Agent.OriginMappingsV2}}"
+        tags:
+          metric_version: "2.0"
+
 - name: bpm
   include:
     stemcell:
@@ -1775,6 +1840,21 @@ variables:
   options:
     is_ca: true
     common_name: loggregatorCA
+- name: expvar_forwarder
+  type: certificate
+  options:
+    ca: loggregator_ca
+    common_name: expvar_forwarder
+    alternative_names:
+    - metron
+    - agent
+    - localhost
+    - 127.0.0.1
+    - ip6-localhost
+    - ::1
+    extended_key_usage:
+    - client_auth
+    - server_auth
 - name: loggregator_tls_statsdinjector
   type: certificate
   options:

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1845,16 +1845,8 @@ variables:
   options:
     ca: loggregator_ca
     common_name: expvar_forwarder
-    alternative_names:
-    - metron
-    - agent
-    - localhost
-    - 127.0.0.1
-    - ip6-localhost
-    - ::1
     extended_key_usage:
     - client_auth
-    - server_auth
 - name: loggregator_tls_statsdinjector
   type: certificate
   options:

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -30,7 +30,7 @@ addons:
     release: loggregator-agent
     properties:
       log_agent:
-        ca_cert: "((expvar_forwarder.ca))"
+        ca_cert: "((loggregator_ca.certificate))"
         client_cert: "((expvar_forwarder.certificate))"
         client_key: "((expvar_forwarder.private_key))"
       default_source_id: metron


### PR DESCRIPTION
### WHAT is this change about?

The loggregator agent has moved all its metrics to a health endpoint served up by the `expvar` package in the Golang stdlib. This PR adds a job to read the metrics from that endpoint and send them to the loggregator system.

This change requires `loggregator-agent-release` v3.0 which has not yet been cut. We will be cutting that release soon.

### WHY is this change being made (What problem is being addressed)?

We believe that Loggregator component metrics should be accessible when there are issues with reading metrics from the firehose.

### Please provide contextual information.

* https://www.pivotaltracker.com/story/show/161400481
* https://www.pivotaltracker.com/story/show/161236250

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES (In our pipelines)
- [ ] NO

### How should this change be described in cf-deployment release notes?

Metrics can be retrieved from the Loggregator Agent via HTTP by sending a `GET` request to `localhost:<PPROF_PORT>/debug/vars` from the local VM.

### Does this PR introduce a breaking change? 

Yes and no, all the metrics should appear in the firehose as they were before, however the expvar forwarder is required to continue receiving those metrics in the firehose.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

/cc @jtuchscherer @MasslessParticle 
