### PR TITLE
add test server ops files for NFS and SMB

### DIFF
--- a/operations/test/README.md
+++ b/operations/test/README.md
@@ -17,4 +17,5 @@ They may change without notice.
 | Name | Purpose | Notes |
 |:---  |:---     |:---   |
 | [`add-oidc-provider.yml `](add-oidc-provider.yml) | Allows testing of UAA with users authenticated via an OIDC provider | Creates a second UAA instance group that acts as the OIDC provider |
-
+| [`enable-nfs-test-server.yml`](enable-nfs-test-server.yml) | adds an NFS server to the deployment | nfstestserver can be reached at nfstestserver.service.cf.internal for acceptance testing purposes |
+| [`enable-smb-test-server.yml`](enable-smb-test-server.yml) | adds an SMB server to the deployment | smbtestserver can be reached at smbtestserver.service.cf.internal for acceptance testing purposes |

--- a/operations/test/enable-nfs-test-server.yml
+++ b/operations/test/enable-nfs-test-server.yml
@@ -1,0 +1,25 @@
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: nfstestserver
+    azs: [z1]
+    instances: 1
+    stemcell: default
+    vm_type: medium
+    networks: [ name: default ]
+    jobs:
+    - name: nfstestserver
+      release: nfs-volume
+      properties:
+        nfstestserver: {}
+
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=nfstestserver.service.cf.internal?
+  value:
+    domain: nfstestserver.service.cf.internal
+    targets:
+    - query: '*'
+      instance_group: nfstestserver
+      deployment: cf
+      network: default
+      domain: bosh

--- a/operations/test/enable-smb-test-server.yml
+++ b/operations/test/enable-smb-test-server.yml
@@ -1,0 +1,27 @@
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: smbtestserver
+    azs: [z1]
+    instances: 1
+    stemcell: default
+    vm_type: medium
+    persistent_disk_type: 10GB
+    networks: [ name: default ]
+    jobs:
+    - name: smbtestserver
+      release: smb-volume
+      properties:
+        username: ((smb-username))
+        password: ((smb-password))
+
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=smbtestserver.service.cf.internal?
+  value:
+    domain: smbtestserver.service.cf.internal
+    targets:
+    - query: '*'
+      instance_group: smbtestserver
+      deployment: cf
+      network: default
+      domain: bosh


### PR DESCRIPTION
add test server ops files for NFS and SMB to cf-d test folder to make it easier for other teams to run CATS volume services tests [#161456111](https://www.pivotaltracker.com/story/show/161456111)

### WHAT is this change about?

This change adds two new ops files to the test directory that run test file server jobs within the cf deployment, and make those servers available to the rest of the deployment via bosh DNS

### WHY is this change being made (What problem is being addressed)?

The persi team recently submitted a volume service smoke test to CATS as an optional test suite.  In order for other teams to be able to run that smoke test, however, they need some sort of NFS or SMB file server that their test application can connect to.  For our own acceptance tests, we have included these ops files in our own git repos for quite some time, but we have found that other teams are generally reluctant to pull in ops files from multiple sources, so we'd like to include these test files in cf-d.

### Please provide contextual information.

our tracker story: [#161456111](https://www.pivotaltracker.com/story/show/161456111)
our recent CATS PR: https://github.com/cloudfoundry/cf-acceptance-tests/pull/348

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [ ] NO
- [x] SORT OF

We have tested the NFS ops file against the new tests that we've submitted to CATS, but those aren't accepted yet.  Having said that, there's no reason to believe that these changes would break the rest of CATS.

### How should this change be described in cf-deployment release notes?

I don't think it is necessary to describe this change in the release notes.

### Does this PR introduce a breaking change? 

No.

### Will this change increase the VM footprint of cf-deployment?

- [x] YES --- but only if someone includes the new ops files
- [ ] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component
- [x] No

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@julian-hj @mariash @paulcwarren @davewalter 