### PR TITLE
Logging cert dns names

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1794,6 +1794,8 @@ variables:
     common_name: statsdinjector
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - uaa.service.cf.internal
 - name: loggregator_tls_agent
   type: certificate
   options:
@@ -1810,6 +1812,8 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - doppler.service.cf.internal
 - name: loggregator_tls_tc
   type: certificate
   options:
@@ -1818,6 +1822,8 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - log-api.service.cf.internal
 - name: loggregator_tls_cc_tc
   type: certificate
   options:
@@ -1825,6 +1831,8 @@ variables:
     common_name: trafficcontroller
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - log-api.service.cf.internal
 - name: loggregator_rlp_gateway_tls_cc
   type: certificate
   options:
@@ -1832,6 +1840,8 @@ variables:
     common_name: rlp-gateway
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - log-api.service.cf.internal
 - name: loggregator_tls_rlp
   type: certificate
   options:
@@ -1840,6 +1850,8 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - log-api.service.cf.internal
 - name: loggregator_rlp_gateway
   type: certificate
   options:
@@ -1847,6 +1859,8 @@ variables:
     common_name: rlp_gateway
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - log-api.service.cf.internal
 - name: adapter_rlp_tls
   type: certificate
   options:
@@ -1855,6 +1869,8 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - adapter.service.cf.internal
 - name: scheduler_api_tls
   type: certificate
   options:
@@ -1863,6 +1879,8 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - scheduler.service.cf.internal
 - name: adapter_tls
   type: certificate
   options:
@@ -1871,6 +1889,8 @@ variables:
     extended_key_usage:
     - server_auth
     - client_auth
+    alternative_names:
+    - adapter.service.cf.internal
 - name: scheduler_client_tls
   type: certificate
   options:
@@ -1878,14 +1898,18 @@ variables:
     common_name: ss-scheduler
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - scheduler.service.cf.internal
 - name: logs_provider
+  type: certificate
   options:
     ca: loggregator_ca
     common_name: log-cache
     extended_key_usage:
     - client_auth
     - server_auth
-  type: certificate
+    alternative_names:
+    - doppler.service.cf.internal
 - name: log_cache_ca
   options:
     common_name: log-cache


### PR DESCRIPTION
### WHAT is this change about?

Add instance group dns names to loggregator certs

### WHY is this change being made (What problem is being addressed)?

Loggregator has received feedback that other teams would like the components to use the DNS name as a Common Name because many clients expect this as the default behavior.

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/161725971

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO



### How should this change be described in cf-deployment release notes?

Loggregator certs now include DNS names as alternative names.



### Does this PR introduce a breaking change? 

No, but -- the new alternative names won't be present on the certs unless the operator regenerates them

**Examples of breaking changes:**
- changes the name of a job or instance group
- moves a job to a different instance group
- deletes a job or instance group
- changes the name of a credential



### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._

@johncornish @jtuchscherer 