### PR TITLE
Default experimental_containerd_mode to true

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1347,10 +1347,13 @@ instance_groups:
           ((application_ca.certificate))
           ((credhub_ca.certificate))
           ((uaa_ca.certificate))
+  - name: containerd
+    release: garden-runc
   - name: garden
     release: garden-runc
     properties:
       garden:
+        experimental_containerd_mode: true
         cleanup_process_dirs_on_wait: true
         debug_listen_address: 127.0.0.1:17019
         default_container_grace_time: 0

--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -44,7 +44,8 @@ and the ops-files will be removed.
 | [`rootless-containers.yml`](rootless-containers.yml) | Enable rootless garden-runc containers. | Requires garden-runc 1.9.5 or later and grootfs 0.27.0 or later. This ops file cannot be deployed in conjunction with `use-garden-containerd.yml` |
 | [`set-cpu-weight.yml`](set-cpu-weight.yml) | CPU shares for each garden container are proportional to its memory limits. | |
 | [`use-compiled-releases-windows.yml`](use-compiled-releases-windows.yml) | Reverts to source version of releases required for Windows cells | Intended for use with `use-compiled-releases.yml` and any of `windows*-cell.yml` |
-| [`use-garden-containerd.yml`](use-garden-containerd.yml) | Configure Garden to create containers via containerd. This ops file cannot be deployed in conjunction with either `rootless-containers.yml` or `enable-bpm-garden.yml`. | |
+| [`use-garden-containerd.yml`](use-garden-containerd.yml) | **DEPRECATED:** Containerd is now enabled by default in `cf-deployment.yml`.
+| [`use-native-garden-runc-runner.yml`](use-native-garden-runc-runner.yml) | Configure Garden to **not** create containers via containerd, using the native runner instead.
 | [`use-latest-windows1803-stemcell.yml`](use-latest-windows1803-stemcell.yml) | **DEPRECATED: use `../use-latest-windows1803-cell.yml`**| Requires `windows1803-cell.yml` |
 | [`use-logcache-for-cloud-controller-app-stats.yml`](use-logcache-for-cloud-controller-app-stats.yml) | Configure Cloud Controller to use Log Cache instead of Traffic Controller for app container metrics. | |
 | [`use-pxc-for-smb-volume-service.yml`](use-pxc-for-smb-volume-service.yml) | **DEPRECATED: Pxc has been removed from smb-volume-service** | |

--- a/operations/experimental/enable-bpm-garden.yml
+++ b/operations/experimental/enable-bpm-garden.yml
@@ -1,5 +1,4 @@
 ---
-# enable-bpm-garden.yml cannot be deployed with use-garden-containerd.yml
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/bpm?/enabled
   value: true
@@ -49,3 +48,10 @@
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties?/grootfs/skip_mount
   value: true
+
+# Disable containerd
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=containerd?
+
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/experimental_containerd_mode?

--- a/operations/experimental/rootless-containers.yml
+++ b/operations/experimental/rootless-containers.yml
@@ -1,6 +1,5 @@
 ---
 # Requires grootfs 0.27.0 or later, and garden-runc 1.9.5 or later.
-# rootless-containers.yml cannot be deployed with use-garden-containerd.yml
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/experimental_rootless_mode?
@@ -9,3 +8,10 @@
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties?/grootfs/skip_mount
   value: true
+
+# Disable containerd
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=containerd?
+
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/experimental_containerd_mode?

--- a/operations/experimental/use-garden-containerd.yml
+++ b/operations/experimental/use-garden-containerd.yml
@@ -1,14 +1,2 @@
 ---
-# use-garden-containerd.yml cannot be deployed with either rootless-containerd.yml or enable-bpm-garden.yml
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/-
-  value:
-    name: containerd
-    release: garden-runc
-    properties:
-      garden:
-        experimental_containerd_mode: true
-
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/experimental_containerd_mode?
-  value: true
+# Deprecated. experimental_containerd_mode is now enabled by default in Garden.

--- a/operations/experimental/use-native-garden-runc-runner.yml
+++ b/operations/experimental/use-native-garden-runc-runner.yml
@@ -1,0 +1,6 @@
+---
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=containerd?
+
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/experimental_containerd_mode?

--- a/operations/test/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/test/add-persistent-isolation-segment-diego-cell.yml
@@ -29,10 +29,13 @@
             ((application_ca.certificate))
             ((credhub_ca.certificate))
             ((uaa_ca.certificate))
+    - name: containerd
+      release: garden-runc
     - name: garden
       release: garden-runc
       properties:
         garden:
+          experimental_containerd_mode: true
           cleanup_process_dirs_on_wait: true
           default_container_grace_time: 0
           destroy_containers_on_start: true

--- a/scripts/test-experimental.sh
+++ b/scripts/test-experimental.sh
@@ -44,6 +44,7 @@ test_experimental_ops() {
       check_interpolation "name: use-compiled-releases-windows.yml" "${home}/operations/use-compiled-releases.yml" "-o ${home}/operations/windows2012R2-cell.yml" "-o use-compiled-releases-windows.yml"
       check_interpolation "use-create-swap-delete-vm-strategy.yml"
       check_interpolation "use-garden-containerd.yml"
+      check_interpolation "use-native-garden-runc-runner.yml"
       version=$(bosh interpolate ${home}/cf-deployment.yml -o windows1803-cell.yml -o use-latest-windows1803-stemcell.yml --path=/stemcells/alias=windows1803/version)
       if [ "${version}" == "latest" ]; then
         pass "use-latest-windows1803-stemcell.yml"


### PR DESCRIPTION
### WHAT is this change about?

This will default the runtime wrapper in Garden to containerd.

### WHY is this change being made (What problem is being addressed)?

Containerd has been running in PWS for some time and this is part of our plan to fully move this to be the default container lifecycle management.

### Please provide contextual information.
https://www.pivotaltracker.com/story/show/161584005



### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO



### How should this change be described in cf-deployment release notes?

Operators will likely not notice anything unless they are currently using the operations/experimental/use-garden-containerd.yml ops file.

Containerd is not yet compatible with garden bpm or rootless, so containerd will be disabled if either use-bpm-garden.yml or rootless-containers.yml is specified.



### Does this PR introduce a breaking change? 

No



### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

@BooleanCat 