### PR TITLE
The binary buildpack does not get compiled on Windows vms

### DIFF
--- a/operations/experimental/use-compiled-releases-windows.yml
+++ b/operations/experimental/use-compiled-releases-windows.yml
@@ -1,11 +1,4 @@
 - type: replace
-  path: /releases/name=binary-buildpack
-  value:
-    name: binary-buildpack
-    sha1: f0022e0632d31d5bbb0e0a5e424244bad83158a1
-    url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.27
-    version: 1.0.27
-- type: replace
   path: /releases/name=diego
   value:
     name: diego


### PR DESCRIPTION
### WHAT is this change about?

The binary buildpack does not need to be overridden as a source release if you are using Windows cells with compiled releases for Linux cells as the buildpack packages do not get compiled on Windows vms.

### WHY is this change being made (What problem is being addressed)?

It reduces the overhead in the `use-compiled-releases-windows.yml` opsfile and reduces the number of packages that need to be compiled from source if using compiled releases and Windows cells.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [ ] NO

This change should not affect CATs, it is a deploy time change.

### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
