### PR TITLE
Add windows stack to the list of runtime stacks

### DIFF
--- a/operations/windows1803-cell.yml
+++ b/operations/windows1803-cell.yml
@@ -55,6 +55,7 @@
             open_bindmounts_acl: true
             preloaded_rootfses:
             - windows2016:oci:///C:/var/vcap/packages/windows1803fs
+            - windows:oci:///C:/var/vcap/packages/windows1803fs
         enable_consul_service_registration: false
         enable_declarative_healthcheck: true
         logging:
@@ -121,6 +122,11 @@
   value:
     description: Windows Server 2016
     name: windows2016
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks/name=windows?
+  value:
+    description: Windows Server
+    name: windows
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/name=hwc_buildpack?
   value:

--- a/operations/windows2016-cell.yml
+++ b/operations/windows2016-cell.yml
@@ -55,6 +55,7 @@
             open_bindmounts_acl: true
             preloaded_rootfses:
             - windows2016:oci:///C:/var/vcap/packages/windows2016fs
+            - windows:oci:///C:/var/vcap/packages/windows2016fs
         enable_consul_service_registration: false
         enable_declarative_healthcheck: true
         logging:
@@ -121,6 +122,11 @@
   value:
     description: Windows Server 2016
     name: windows2016
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks/name=windows?
+  value:
+    description: Windows Server
+    name: windows
 - path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/name=hwc_buildpack?
   type: replace
   value:


### PR DESCRIPTION
### WHAT is this change about?

Add `-s windows` for pushing apps to windows server stack
 
### WHY is this change being made (What problem is being addressed)?

In an effort to deprecate `-s windows2016` and `-s windows2012R2` we are moving to a single runtime stack `-s windows` when users push their .NET apps to Windows Server. 

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/161817037

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES (https://github.com/cloudfoundry/cf-acceptance-tests/pull/350)
- [ ] NO


### How should this change be described in cf-deployment release notes?

- Add windows server runtime stack.

### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO


### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**


Dependent PRs:

- https://github.com/cloudfoundry/cf-acceptance-tests/pull/350
- https://github.com/cloudfoundry/capi-release/pull/109