### PR TITLE
Upgrade Log Cache to v2.0.2 and fix certificates

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1209,6 +1209,11 @@ instance_groups:
   - name: log-cache-expvar-forwarder
     release: log-cache
     properties:
+      loggregator_agent:
+        tls:
+          ca_cert: "((loggregator_ca.certificate))"
+          cert: "((log_cache_to_loggregator_agent.certificate))"
+          key: "((log_cache_to_loggregator_agent.private_key))"
       counters: []
       gauges: []
       maps:
@@ -1268,6 +1273,11 @@ instance_groups:
     release: log-cache
   - name: log-cache-expvar-forwarder
     properties:
+      loggregator_agent:
+        tls:
+          ca_cert: "((loggregator_ca.certificate))"
+          cert: "((log_cache_to_loggregator_agent.certificate))"
+          key: "((log_cache_to_loggregator_agent.private_key))"
       maps: []
       counters:
         # Log Cache
@@ -1373,10 +1383,7 @@ instance_groups:
     properties:
       cc:
         ca_cert: ((service_cf_internal_ca.certificate))
-        capi_internal_addr: https://cloud-controller-ng.service.cf.internal:9023
-        cert: ((log_cache_tls_cc_auth_proxy.certificate))
         common_name: cloud-controller-ng.service.cf.internal
-        key: ((log_cache_tls_cc_auth_proxy.private_key))
       proxy_port: 8083
       uaa:
         ca_cert: ((uaa_ca.certificate))
@@ -1978,9 +1985,9 @@ variables:
     - client_auth
     - server_auth
   type: certificate
-- name: log_cache_tls_cc_auth_proxy
+- name: log_cache_to_loggregator_agent
   options:
-    ca: service_cf_internal_ca
+    ca: loggregator_ca
     common_name: log-cache
     extended_key_usage:
     - client_auth
@@ -2215,9 +2222,9 @@ releases:
   version: "3.1"
   sha1: c915a59373e986ae1d98cfb96b09c805664e2550
 - name: log-cache
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.0.1
-  version: 2.0.1
-  sha1: 23f9c4767109293b5f8b8a6a07ca31f065bcf88b
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.0.2
+  version: 2.0.2
+  sha1: 1f52248096ce2263405f3c82278e4f2aaddf1599
 - name: bosh-dns-aliases
   url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
   version: 0.0.3


### PR DESCRIPTION
[#162127063]

Signed-off-by: Todd Persen <tpersen@pivotal.io>

### WHAT is this change about?

Log Cache v2.0.2 has a metrics forwarder that no longer writes directly back into Log Cache, but writes to the local Loggregator Agent instead. This change is necessary to make generated metrics pick up the same system-level tags as all other components.

### WHY is this change being made (What problem is being addressed)?

This change creates a new certificate to be used when communicating to the local Loggregator Agent.

### Please provide contextual information.

This feature was added in this story:
https://www.pivotaltracker.com/story/show/157580025

And the breaking change was discussed here:
https://pivotal.slack.com/archives/CBF2AU6A0/p1542756218138100

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?

Adds Loggregator Agent certificate for Log Cache metrics forwarder

### Does this PR introduce a breaking change?

No.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

/cc @jtuchscherer @pianohacker