### PR TITLE
add origin to logging metrics

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -38,35 +38,45 @@ addons:
       - addr: http://127.0.0.1:14824/debug/vars
         name: dropped
         template: "{{.Agent.Dropped}}"
+        tags:
+          origin: loggregator.metron
       - addr: http://127.0.0.1:14824/debug/vars
         name: dropped
         template: "{{.Agent.DroppedEgressV2}}"
         tags:
+          origin: loggregator.metron
           direction: egress
           metric_version: "2.0"
       - addr: http://127.0.0.1:14824/debug/vars
         name: dropped
         template: "{{.Agent.DroppedIngressV2}}"
         tags:
+          origin: loggregator.metron
           direction: ingress
           metric_version: "2.0"
 
       - addr: http://127.0.0.1:14824/debug/vars
         name: egress
         template: "{{.Agent.Egress}}"
+        tags:
+          origin: loggregator.metron
       - addr: http://127.0.0.1:14824/debug/vars
         name: egress
         template: "{{.Agent.EgressV2}}"
         tags:
+          origin: loggregator.metron
           metric_version: "2.0"
 
       - addr: http://127.0.0.1:14824/debug/vars
         name: ingress
         template: "{{.Agent.Ingress}}"
+        tags:
+          origin: loggregator.metron
       - addr: http://127.0.0.1:14824/debug/vars
         name: ingress
         template: "{{.Agent.IngressV2}}"
         tags:
+          origin: loggregator.metron
           metric_version: "2.0"
 
       gauges:
@@ -75,12 +85,14 @@ addons:
         unit: bytes/minute
         template: "{{.Agent.AverageEnvelope}}"
         tags:
+          origin: loggregator.metron
           loggregator: v1
       - addr: http://127.0.0.1:14824/debug/vars
         name: average_envelopes
         unit: bytes/minute
         template: "{{.Agent.AverageEnvelopeV2}}"
         tags:
+          origin: loggregator.metron
           metric_version: "2.0"
           loggregator: v2
 
@@ -89,6 +101,7 @@ addons:
         unit: bytes/minute
         template: "{{.Agent.OriginMappingsV2}}"
         tags:
+          origin: loggregator.metron
           metric_version: "2.0"
 
 - name: bpm


### PR DESCRIPTION
[#162317690]

### WHAT is this change about?

We broke our metrics when we went to the expvar forwarder by not attaching origin tags

### WHY is this change being made (What problem is being addressed)?

This ensures that the loggregator agent metrics don't change

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/162317690


### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO



### How should this change be described in cf-deployment release notes?

Emit loggregator agent logs with origin tag.

### Does this PR introduce a breaking change? 
No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@jtuchscherer 
