### PR TITLE
Add windows stack-associated hwc-buildpack and binary-buildpacks

### DIFF
--- a/operations/windows1803-cell.yml
+++ b/operations/windows1803-cell.yml
@@ -133,6 +133,11 @@
     name: hwc_buildpack
     package: hwc-buildpack-windows2016
 - type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=hwc-buildpack-windows?
+  value:
+    name: hwc_buildpack
+    package: hwc-buildpack-windows
+- type: replace
   path: /instance_groups/name=api/jobs/name=hwc-buildpack?
   value:
     name: hwc-buildpack
@@ -142,6 +147,11 @@
   value:
     name: binary_buildpack
     package: binary-buildpack-windows2016
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=binary-buildpack-windows?
+  value:
+    name: binary_buildpack
+    package: binary-buildpack-windows
 - type: replace
   path: /releases/name=hwc-buildpack?
   value:

--- a/operations/windows2016-cell.yml
+++ b/operations/windows2016-cell.yml
@@ -133,6 +133,11 @@
     name: hwc_buildpack
     package: hwc-buildpack-windows2016
 - type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=hwc-buildpack-windows?
+  value:
+    name: hwc_buildpack
+    package: hwc-buildpack-windows
+- type: replace
   path: /instance_groups/name=api/jobs/name=hwc-buildpack?
   value:
     name: hwc-buildpack
@@ -142,6 +147,11 @@
   value:
     name: binary_buildpack
     package: binary-buildpack-windows2016
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=binary-buildpack-windows?
+  value:
+    name: binary_buildpack
+    package: binary-buildpack-windows
 - type: replace
   path: /releases/name=hwc-buildpack?
   value:


### PR DESCRIPTION
[#162249894](https://www.pivotaltracker.com/story/show/162249894)

Co-authored-by: Ben Fickes <bfickes@pivotal.io>

### WHAT is this change about?

Adds the new 'windows' stack associated binary-buildpack and hwc-buildpack

### WHY is this change being made (What problem is being addressed)?

To install the 'windows' stack associated buildpack on windows by default.

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._



### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO



### How should this change be described in cf-deployment release notes?

Installs the 'windows' stack associated binary-buildpack and hwc-buildpack

### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

