### PR TITLE
Volume Services TLS Config

### DIFF
--- a/operations/enable-nfs-ldap.yml
+++ b/operations/enable-nfs-ldap.yml
@@ -1,15 +1,25 @@
 ---
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver/properties
-  value:
-    nfsv3driver:
-      ldap_svc_user: ((nfs-ldap-service-user))
-      ldap_svc_password: ((nfs-ldap-service-password))
-      ldap_host: ((nfs-ldap-host))
-      ldap_port: ((nfs-ldap-port))
-      ldap_proto: ((nfs-ldap-proto))
-      ldap_user_fqdn: ((nfs-ldap-fqdn))
-      allowed-in-source: ""
+  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver/properties/nfsv3driver/ldap_svc_user?
+  value: ((nfs-ldap-service-user))
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver/properties/nfsv3driver/ldap_svc_password?
+  value: ((nfs-ldap-service-password))
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver/properties/nfsv3driver/ldap_host?
+  value: ((nfs-ldap-host))
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver/properties/nfsv3driver/ldap_port?
+  value: ((nfs-ldap-port))
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver/properties/nfsv3driver/ldap_proto?
+  value: ((nfs-ldap-proto))
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver/properties/nfsv3driver/ldap_user_fqdn?
+  value: ((nfs-ldap-fqdn))
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver/properties/nfsv3driver/allowed-in-source?
+  value: ""
 - type: replace
   path: /instance_groups/name=nfs-broker-push/jobs/name=nfsbrokerpush/properties/nfsbrokerpush/ldap_enabled?
   value: true

--- a/operations/enable-nfs-volume-service.yml
+++ b/operations/enable-nfs-volume-service.yml
@@ -60,7 +60,14 @@
   path: /instance_groups/name=diego-cell/jobs/-
   value:
     name: nfsv3driver
-    properties: {}
+    properties:
+      nfsv3driver:
+        tls:
+          ca_cert: ((nfs_ca.certificate))
+          server_cert: ((nfsv3driver_cert.certificate))
+          server_key: ((nfsv3driver_cert.private_key))
+          client_cert: ((nfsv3driver_client_cert.certificate))
+          client_key: ((nfsv3driver_client_cert.private_key))
     release: nfs-volume
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=mapfs?
@@ -82,6 +89,36 @@
   value:
     name: nfs-broker-push-uaa-client-secret
     type: password
+- type: replace
+  path: /variables/-
+  value:
+    name: nfs_ca
+    options:
+      common_name: nfs-ca
+      is_ca: true
+    type: certificate
+- type: replace
+  path: /variables/-
+  value:
+    name: nfsv3driver_cert
+    options:
+      ca: nfs_ca
+      common_name: 127.0.0.1
+      alternative_names:
+      - 127.0.0.1
+      extended_key_usage:
+      - server_auth
+    type: certificate
+- type: replace
+  path: /variables/-
+  value:
+    name: nfsv3driver_client_cert
+    options:
+      ca: nfs_ca
+      common_name: nfs-client
+      extended_key_usage:
+      - client_auth
+    type: certificate
 - type: replace
   path: /releases/-
   value:

--- a/operations/experimental/enable-nfs-volume-service-credhub.yml
+++ b/operations/experimental/enable-nfs-volume-service-credhub.yml
@@ -1,13 +1,4 @@
 - type: replace
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/volume_services_enabled?
-  value: true
-- type: replace
-  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/volume_services_enabled?
-  value: true
-- type: replace
-  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/volume_services_enabled?
-  value: true
-- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/nfs-broker-credhub-client?
   value:
     authorities: credhub.read,credhub.write
@@ -93,17 +84,6 @@
     stemcell: default
     vm_type: minimal
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver?
-  value:
-    name: nfsv3driver
-    properties: {}
-    release: nfs-volume
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=mapfs?
-  value:
-    name: mapfs
-    release: mapfs
-- type: replace
   path: /variables/-
   value:
     name: nfs-broker-credhub-password
@@ -113,17 +93,3 @@
   value:
     name: nfs-broker-credhub-uaa-client-secret
     type: password
-- type: replace
-  path: /releases/name=nfs-volume?
-  value:
-    name: nfs-volume
-    sha1: 8e92355c8f83f2c3ff1496f55fb7e04294e03baa
-    url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=1.7.5
-    version: 1.7.5
-- type: replace
-  path: /releases/name=mapfs?
-  value:
-    name: mapfs
-    sha1: 604b646eb6de8448dc3d7124702537e13ecf31f1
-    url: https://bosh.io/d/github.com/cloudfoundry/mapfs-release?v=1.1.2
-    version: 1.1.2

--- a/operations/experimental/enable-smb-volume-service.yml
+++ b/operations/experimental/enable-smb-volume-service.yml
@@ -69,7 +69,13 @@
   path: /instance_groups/name=diego-cell/jobs/name=smbdriver?
   value:
     name: smbdriver
-    properties: {}
+    properties: 
+      tls:
+        ca_cert: ((smb_ca.certificate))
+        server_cert: ((smbdriver_cert.certificate))
+        server_key: ((smbdriver_cert.private_key))
+        client_cert: ((smbdriver_client_cert.certificate))
+        client_key: ((smbdriver_client_cert.private_key))
     release: smb-volume
 - type: replace
   path: /variables/-
@@ -86,6 +92,36 @@
   value:
     name: smb-broker-credhub-uaa-client-secret
     type: password
+- type: replace
+  path: /variables/-
+  value:
+    name: smb_ca
+    options:
+      common_name: smb-ca
+      is_ca: true
+    type: certificate
+- type: replace
+  path: /variables/-
+  value:
+    name: smbdriver_cert
+    options:
+      ca: smb_ca
+      common_name: 127.0.0.1
+      alternative_names:
+      - 127.0.0.1
+      extended_key_usage:
+      - server_auth
+    type: certificate
+- type: replace
+  path: /variables/-
+  value:
+    name: smbdriver_client_cert
+    options:
+      ca: smb_ca
+      common_name: smb-client
+      extended_key_usage:
+      - client_auth
+    type: certificate
 - type: replace
   path: /releases/-
   value:


### PR DESCRIPTION
### WHAT is this change about?

This change configures TLS for NFS and SMB volume services.

### WHY is this change being made (What problem is being addressed)?

As part of the `secure by default` policy, we have exposed the ability to configure the NFS and SMB drivers that run on the Diego cells to use mutual TLS when communicating with the rep process.

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/160036094

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO, but it has passed through our CI, including our acceptance tests

### How should this change be described in cf-deployment release notes?

NFS and SMB volume services
- Communication between the `rep` and the NFS and SMB drivers is now secured  through mutual TLS.

### Does this PR introduce a breaking change? 

- [ ] YES --- does it really have to?
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@paulcwarren @julian-hj 