### PR TITLE
Pull envoy-release from bosh.io

### DIFF
--- a/operations/experimental/enable-routing-integrity-windows1803.yml
+++ b/operations/experimental/enable-routing-integrity-windows1803.yml
@@ -24,6 +24,6 @@
   type: replace
   value:
     name: envoy
-    version: 0.1.0
-    url: https://github.com/cloudfoundry/envoy-release/releases/download/v0.1.0/envoy-0.1.0.tgz
-    sha1: dfff5adbc2696c25cd385a73bc39fff820a2df6c
+    version: 0.3.0
+    url: https://bosh.io/d/github.com/cloudfoundry/envoy-release?v=0.3.0
+    sha1: 82fb3f16b57f2665a00d22b429e0c71991c46947

--- a/operations/experimental/enable-routing-integrity-windows2016.yml
+++ b/operations/experimental/enable-routing-integrity-windows2016.yml
@@ -24,6 +24,6 @@
   type: replace
   value:
     name: envoy
-    version: 0.1.0
-    url: https://github.com/cloudfoundry/envoy-release/releases/download/v0.1.0/envoy-0.1.0.tgz
-    sha1: dfff5adbc2696c25cd385a73bc39fff820a2df6c
+    version: 0.3.0
+    url: https://bosh.io/d/github.com/cloudfoundry/envoy-release?v=0.3.0
+    sha1: 82fb3f16b57f2665a00d22b429e0c71991c46947


### PR DESCRIPTION
### WHAT is this change about?

Now that envoy-release is on bosh.io, we should pull it from there instead of a github release.

### WHY is this change being made (What problem is being addressed)?

bosh.io is the preferred place to pull releases from

### Please provide contextual information.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO

While we do have a CF deployed with Envoy on Windows in our pipelines, and push apps to it regularly, we do not technically run CATS against this CF


### How should this change be described in cf-deployment release notes?

N/A -- this feature is still very experimental

### Does this PR introduce a breaking change? 

No


### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
