### PR TITLE
Adds NGINX-buildpack-release and R-buildpack-release for cflinuxfs3

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -849,6 +849,8 @@ instance_groups:
           package: php-buildpack-cflinuxfs3
         - name: nginx_buildpack
           package: nginx-buildpack-cflinuxfs3
+        - name: r_buildpack
+          package: r-buildpack-cflinuxfs3
         - name: binary_buildpack
           package: binary-buildpack-cflinuxfs3
         db_encryption_key: "((cc_db_encryption_key))"
@@ -902,6 +904,8 @@ instance_groups:
     release: nodejs-buildpack
   - name: nginx-buildpack
     release: nginx-buildpack
+  - name: r-buildpack
+    release: r-buildpack
   - name: php-buildpack
     release: php-buildpack
   - name: python-buildpack
@@ -2224,10 +2228,14 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=26
   version: "26"
   sha1: 2f2c27acdfff81f3519968921686522518ab5783
-- name: "nginx-buildpack"
-  version: "1.0.4"
-  url: "https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.0.4"
-  sha1: "95c53b9697a3c7544130227563a1c9a62957fc8f"
+- name: nginx-buildpack
+  version: 1.0.4
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.0.4
+  sha1: 95c53b9697a3c7544130227563a1c9a62957fc8f
+- name: r-buildpack
+  version: 1.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.0.3
+  sha1: 830ff36aa05f4ea20c46c27abbcff9b233acd5fe
 - name: nodejs-buildpack
   url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.6.38
   version: 1.6.38

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -847,6 +847,8 @@ instance_groups:
           package: python-buildpack-cflinuxfs3
         - name: php_buildpack
           package: php-buildpack-cflinuxfs3
+        - name: nginx_buildpack
+          package: nginx-buildpack-cflinuxfs3
         - name: binary_buildpack
           package: binary-buildpack-cflinuxfs3
         db_encryption_key: "((cc_db_encryption_key))"
@@ -898,6 +900,8 @@ instance_groups:
     release: java-buildpack
   - name: nodejs-buildpack
     release: nodejs-buildpack
+  - name: nginx-buildpack
+    release: nginx-buildpack
   - name: php-buildpack
     release: php-buildpack
   - name: python-buildpack
@@ -2224,6 +2228,10 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.6.34
   version: 1.6.34
   sha1: 8fa43dabde22135cfa9c09321d815303251d1186
+- name: nginx-buildpack
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack?v=1.0.4
+  version: 1.0.4
+  sha1: "TBD"
 - name: php-buildpack
   url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.3.64
   version: 4.3.64

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2228,10 +2228,10 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.6.34
   version: 1.6.34
   sha1: 8fa43dabde22135cfa9c09321d815303251d1186
-- name: nginx-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack?v=1.0.4
-  version: 1.0.4
-  sha1: "TBD"
+- name: "nginx-buildpack"
+  version: "1.0.4"
+  url: "https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.0.4"
+  sha1: "95c53b9697a3c7544130227563a1c9a62957fc8f"
 - name: php-buildpack
   url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.3.64
   version: 4.3.64


### PR DESCRIPTION
~~**NOTE**: The release configuration will need be modified when 
https://github.com/bosh-io/releases/pull/71 is accepted to properly index this release~~(Merged)

### WHAT is this change about?
Adds NGINX-buildpack-release for cflinuxfs3

_Describe the change._

### WHY is this change being made (What problem is being addressed)?
To install NGINX-buildpack-release for cflinuxfs3 by default

_Understanding why this change is being made is fantastically helpful. Please do tell..._

### Please provide contextual information.
https://www.pivotaltracker.com/story/show/159444595

~~Currently blocked waiting for bosh.io indexing 
https://github.com/bosh-io/releases/pull/71~~(This has been merged)

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._



### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO



### How should this change be described in cf-deployment release notes?

_Something brief that conveys the change and is written with the Operator audience in mind. 
See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

Installs new `nginx-buildpack` for cflinuxfs3

### Does this PR introduce a breaking change? 

_Does this introduce changes that would require operators to take action in order to deploy without a failure?_

- If operators have installed null-stack buildpacks, those will have to be removed before install can proceed successfully.

**Examples of breaking changes:**
- changes the name of a job or instance group
- moves a job to a different instance group
- deletes a job or instance group
- changes the name of a credential
- requires out-of-band manual intervention on the part of the operator



### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
@djoyahoy @eshanks @sclevine @tylerphelan 