### PR TITLE
Bits-Service: Use new active_signing_key instead of deprecated secret

### DIFF
--- a/operations/bits-service/use-bits-service.yml
+++ b/operations/bits-service/use-bits-service.yml
@@ -73,7 +73,9 @@
               username: blobstore-user
           private_endpoint: https://bits.service.cf.internal
           public_endpoint: https://bits.((system_domain))
-          secret: ((bits_service_secret))
+          active_signing_key:
+            key_id: key1
+            secret: ((bits_service_secret))
           signing_users:
           - password: ((bits_service_signing_password))
             username: admin


### PR DESCRIPTION
### WHAT is this change about?

Don't use deprecated `secret` property in Bits-Service anymore. Instead, use new `active_signing_key`.

### WHY is this change being made (What problem is being addressed)?

The Bits-Service is switching from a non-rotatable secret to a rotatable list of signing keys. The first step is to migrate away from the deprecated `secret` property.

### Please provide contextual information.

Some context:
- https://docs.google.com/document/d/1jwDRdzJeLaDgJdqDdlI8f3X4Lr49uvUH5Zwa0tc9NJg/edit?disco=AAAACTZ8bqw
- https://www.pivotaltracker.com/story/show/161913277

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?

> Don't use deprecated `secret` property in Bits-Service anymore. Instead, use new `active_signing_key`.

### Does this PR introduce a breaking change? 

No.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@idev4u
