### PR TITLE
Add a Ops-File to Remove the TCP Router Instance Group

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -44,6 +44,7 @@ and the ops-files will be removed.
 | [`migrate-nfsbroker-mysql-to-credhub.yml`](migrate-nfsbroker-mysql-to-credhub.yml) | Migrates existing NFS volume services state storage from MySQL to Credhub | Requires `enable-nfs-volume-service-credhub.yml` |
 | [`perm-service.yml`](perm-service.yml) | Deploy CF with [Perm Service](https://github.com/cloudfoundry-incubator/perm) | Requires `enable-mysql-tls.yml`. See the [deployment section of perm-release's README file](https://github.com/cloudfoundry-incubator/perm-release/blob/master/README.md#deploying-perm-with-cf-deployment) for more information|
 | [`perm-service-with-pxc-release.yml`](perm-service-with-pxc-release.yml) | Use [pxc-release](https://github.com/cloudfoundry-incubator/pxc-release) as data store for Perm Service. | Requires `perm-service.yml` and `use-pxc.yml`. |
+| [`remove-tcp-router.yml`](remove-tcp-router.yml) | Remove TCP router instance. | |
 | [`rootless-containers.yml`](rootless-containers.yml) | Enable rootless garden-runc containers. | Requires garden-runc 1.9.5 or later and grootfs 0.27.0 or later. This ops file **cannot** be deployed in conjunction with `enable-oci-phase-1.yml` or `use-garden-containerd.yml`. |
 | [`set-cpu-weight.yml`](set-cpu-weight.yml) | CPU shares for each garden container are proportional to its memory limits. | |
 | [`use-compiled-releases-windows.yml`](use-compiled-releases-windows.yml) | Reverts to source version of releases required for Windows cells | Intended for use with `use-compiled-releases.yml` and any of `windows*-cell.yml` |

--- a/operations/experimental/remove-tcp-router.yml
+++ b/operations/experimental/remove-tcp-router.yml
@@ -1,0 +1,8 @@
+- type: remove
+  path: /instance_groups/name=tcp-router
+
+- type: remove
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/tcp_router
+
+- type: remove
+  path: /variables/name=uaa_clients_tcp_router_secret

--- a/scripts/test-experimental.sh
+++ b/scripts/test-experimental.sh
@@ -39,6 +39,8 @@ test_experimental_ops() {
       check_interpolation "name: perm-service-with-pxc-release.yml" "perm-service.yml" "-o ${home}/operations/use-pxc.yml" "-o perm-service-with-pxc-release.yml -v perm_uaa_clients_cc_perm_secret=perm_secret -v perm_uaa_clients_perm_monitor_secret=perm_monitor_secret"
       check_interpolation "name: perm-service-with-tcp-routing.yml" "perm-service.yml" "-o ${home}/operations/use-pxc.yml" "-o perm-service-with-pxc-release.yml -v perm_uaa_clients_cc_perm_secret=perm_secret -v perm_uaa_clients_perm_monitor_secret=perm_monitor_secret" "-o perm-service-with-tcp-routing.yml"
 
+      check_interpolation "remove-tcp-router.yml"
+
       check_interpolation "rootless-containers.yml"
 
       check_interpolation "set-cpu-weight.yml"


### PR DESCRIPTION
### WHAT is this change about?

This is a new ops-file that removes the TCP router instance group and associated UAA client.

### WHY is this change being made (What problem is being addressed)?

Resources cost money. Since we don't test TCP routing in our environments, we didn't see the point in creating resources that we never use. It also takes time to create and destroy them.

### Please provide contextual information.

[#163074145](https://www.pivotaltracker.com/story/show/163074145)

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?

remove-tcp-router.yml
- This is a new ops-file that removes the TCP router instance group and associated UAA client.

### Does this PR introduce a breaking change? 

- [ ] YES 
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@paulcwarren @julian-hj 