### PR TITLE
Remove unneeded containerd job from manifest

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1481,8 +1481,6 @@ instance_groups:
           ((application_ca.certificate))
           ((credhub_ca.certificate))
           ((uaa_ca.certificate))
-  - name: containerd
-    release: garden-runc
   - name: garden
     release: garden-runc
     properties:

--- a/operations/experimental/use-native-garden-runc-runner.yml
+++ b/operations/experimental/use-native-garden-runc-runner.yml
@@ -1,6 +1,4 @@
 ---
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=containerd?
 
 - type: remove
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/containerd_mode?


### PR DESCRIPTION
### WHAT is this change about?

This change is removeing the unneeded containerd job form the main cf manifest.

### WHY is this change being made (What problem is being addressed)?

The containerd daemon is now part of the garden job. This is needed so that garden ca run with systemd.

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/162329293

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### How should this change be described in cf-deployment release notes?

This change depends on GRR release version greater than 1.17.2 that drops the containerd as a separate job

## Updated Ops Files:
- operations/experimental/use-native-garden-runc-runner.yml
  - no longer needs to remove the contianerd job

### Does this PR introduce a breaking change?

Yes it deletes the containerd job

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@julz @yulianedyalkova















