### PR TITLE
Use correct containerd flag

### DIFF
--- a/operations/test/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/test/add-persistent-isolation-segment-diego-cell.yml
@@ -33,7 +33,7 @@
       release: garden-runc
       properties:
         garden:
-          experimental_containerd_mode: true
+          containerd_mode: true
           cleanup_process_dirs_on_wait: true
           default_container_grace_time: 0
           destroy_containers_on_start: true


### PR DESCRIPTION
### WHAT is this change about?

The experimental flag is deprecated and soon to be removed, I am not sure
how we missed this one when the others were PRed a while ago.

The changed file is under a `test` directory, so it is possible that nobody will notice this change, unless `test` means something else here.

### WHY is this change being made (What problem is being addressed)?

Ensuring everything still works when we retire the old flag shortly.

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/163145141
https://github.com/cloudfoundry/cf-deployment/pull/680

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO

### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

