### PR TITLE
Update cf-deployment.yml

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1481,18 +1481,18 @@ instance_groups:
     release: cflinuxfs2
     properties:
       cflinuxfs2-rootfs:
-        trusted_certs: |
-          ((application_ca.certificate))
-          ((credhub_ca.certificate))
-          ((uaa_ca.certificate))
+        trusted_certs:
+          - ((application_ca.certificate))
+          - ((credhub_ca.certificate))
+          - ((uaa_ca.certificate))
   - name: cflinuxfs3-rootfs-setup
     release: cflinuxfs3
     properties:
       cflinuxfs3-rootfs:
-        trusted_certs: |
-          ((application_ca.certificate))
-          ((credhub_ca.certificate))
-          ((uaa_ca.certificate))
+        trusted_certs:
+          - ((application_ca.certificate))
+          - ((credhub_ca.certificate))
+          - ((uaa_ca.certificate))
   - name: garden
     release: garden-runc
     properties:


### PR DESCRIPTION
- `cflinuxfs2-rootfs.trusted_certs` now supports arrays
- `cflinuxfs3-rootfs.trusted_certs` now supports arrays

### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

_Only PR's to develop are accepted._

### WHAT is this change about?

Property now accepts arrays

### WHY is this change being made (What problem is being addressed)?

We are completing this PR. https://github.com/cloudfoundry/cflinuxfs2-release/issues/3

### Please provide contextual information.




### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [ ] NO



### How should this change be described in cf-deployment release notes?

`cflinuxfs2-rootfs.trusted_certs` now supports arrays
`cflinuxfs3-rootfs.trusted_certs` now supports arrays



### Does this PR introduce a breaking change? 

No


### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@tylerphelan @sclevine 
