### PR TITLE
Populate the credhub link properties

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1713,7 +1713,6 @@ instance_groups:
             operations: [read]
         ca_certificate: |
           ((credhub_ca.certificate))
-          ((uaa_ca.certificate))
         data_storage:
           database: credhub
           host: sql-db.service.cf.internal

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1711,6 +1711,9 @@ instance_groups:
           - path: /*
             actors: ["uaa-client:cc_service_key_client"]
             operations: [read]
+        ca_certificate: |
+          ((credhub_ca.certificate))
+          ((uaa_ca.certificate))
         data_storage:
           database: credhub
           host: sql-db.service.cf.internal
@@ -1728,6 +1731,7 @@ instance_groups:
           providers:
           - name: internal-provider
             type: internal
+        internal_url: https://credhub.service.cf.internal
         tls: ((credhub_tls))
     release: credhub
 - name: rotate-cc-database-key


### PR DESCRIPTION

### WHAT is this change about?

These properties need to be specified otherwise the credhub link is unusable.

Note, in case you are wondering, because it is required by both the credhub-cli and the credhub Go library to authenticate with UAA, we included the UAA CA certificate.  

### WHY is this change being made (What problem is being addressed)?

As credhub is becoming our default store, we now want to consume the credhub link to populate our brokers (and migrator). 

### Please provide contextual information.

[#161974894](https://www.pivotaltracker.com/story/show/161974894)

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO

No existing component (including credhub itself) currently uses the link so running CATS would be a no-op so we didn't do it.

### How should this change be described in cf-deployment release notes?

Credhub link properties updated to make bosh link consumable.

### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@davewalter @julian-hj 