### PR TITLE
Add Pass/Fail Indicator to "test" Script

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -237,6 +237,14 @@ main() {
     semantic_tests
   fi
 
+  echo
+
+  if [[ ${exit_code} = 0 ]]; then
+    echo -e "${GREEN}All tests passed.${NOCOLOR}"
+  else
+    echo -e "${RED}At least one test failed.${NOCOLOR}"
+  fi
+
   exit $exit_code
 }
 


### PR DESCRIPTION
### WHAT is this change about?

This PR adds a simple pass/fail message to the bottom of the script that runs the ops-file tests.

### WHY is this change being made (What problem is being addressed)?

It is extremely annoying to have to scroll back through pages of output to verify that all tests have passed when working on a change to an ops-file. It is even more annoying to submit a PR, only to receive an automated response a few minutes later to tell you that one of the tests failed and asking you to fix the problem. Given that the script runs the tests in the background in parallel, failing instantly is out of the question. However, we do know whether all of the tests passed or not via the `$exit_code` variable. This PR simply checks that variable and outputs a simple pass/fail message.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO - Not applicable.

### How should this change be described in cf-deployment release notes?

The test script now outputs a simple pass/fail message at the bottom of its output to inform the user as to the overall state of the test run.

### Does this PR introduce a breaking change? 

- [ ] YES --- does it really have to?
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component
- [x] Test infrastructure

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
