### PR TITLE
Restrict log-cache-cf-auth-proxy to TLS only

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1448,7 +1448,9 @@ instance_groups:
         routes:
         - name: log-cache-reverse-proxy
           port: 8083
+          tls_port: 8083
           registration_interval: 20s
+          server_cert_domain_san: log-cache.((system_domain))
           uris:
           - log-cache.((system_domain))
           - '*.log-cache.((system_domain))'
@@ -1459,6 +1461,8 @@ instance_groups:
         ca_cert: ((service_cf_internal_ca.certificate))
         common_name: cloud-controller-ng.service.cf.internal
       proxy_port: 8083
+      external_cert: ((logcache_ssl.certificate))
+      external_key: ((logcache_ssl.private_key))
       uaa:
         ca_cert: ((uaa_ca.certificate))
         client_id: doppler
@@ -2074,6 +2078,14 @@ variables:
     alternative_names:
     - "api.((system_domain))"
     - cloud-controller-ng.service.cf.internal
+- name: logcache_ssl
+  type: certificate
+  options:
+    ca: service_cf_internal_ca
+    common_name: log-cache
+    alternative_names:
+    - log-cache.((system_domain))
+    - "*.log-cache.((system_domain))"
 - name: router_ca
   type: certificate
   options:

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2356,9 +2356,9 @@ releases:
   version: "3.5"
   sha1: e1b9ec422c54ec6c947bb8befee0600b93ed7db6
 - name: log-cache
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.1.1
-  version: 2.1.1
-  sha1: 44ae08bc307bcfc82b755196331050939cb935a6
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.2.0
+  version: 2.2.0
+  sha1: 1ebecd0adbfc50fdd61309e129b0292deb7e7b24
 - name: bosh-dns-aliases
   url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
   version: 0.0.3


### PR DESCRIPTION
Support ServeTLS from auth proxy when log-cache-release is bumped.

Signed-off-by: Todd Persen <tpersen@pivotal.io>

### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment? 
Yes

### WHAT is this change about?
Support ServeTLS from auth proxy when log-cache-release is bumped.
Otherwise it will break - security fix, we did not phase it.

### WHY is this change being made (What problem is being addressed)?

Lock down log-cache-cf-auth-proxy to https

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/163887949

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO



### How should this change be described in cf-deployment release notes?

_Something brief that conveys the change and is written with the Operator audience in mind. 
See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

Restrict log-cache connections through gorouter to TLS only

### Does this PR introduce a breaking change? 

_Does this introduce changes that would require operators to take action in order to deploy without a failure?_
 
No. But it is a requirement to support upcoming LogCache `2.2.0`

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
/cc @toddboom @jtuchscherer 