### PR TITLE
Add an ops-file to add a test LDAP server

### DIFF
--- a/operations/test/README.md
+++ b/operations/test/README.md
@@ -18,5 +18,5 @@ They may change without notice.
 |:---  |:---     |:---   |
 | [`add-oidc-provider.yml `](add-oidc-provider.yml) | Allows testing of UAA with users authenticated via an OIDC provider | Creates a second UAA instance group that acts as the OIDC provider |
 | [`enable-nfs-test-server.yml`](enable-nfs-test-server.yml) | adds an NFS server to the deployment | nfstestserver can be reached at nfstestserver.service.cf.internal for acceptance testing purposes |
-| [`enable-nfs-test-ldapserver.yml`](enable-nfs-test-ldapserver.yml) | Adds an LDAP server to the deployment to allow testing of NFS volume services configured with LDAP authentication | nfstestldapserver can be reached at nfstestldapserver.service.cf.internal |
+| [`enable-nfs-test-ldapserver.yml`](enable-nfs-test-ldapserver.yml) | Adds an LDAP server to the deployment to allow testing of NFS volume services configured with LDAP authentication | Requires enable-nfs-volume-service.yml and enable-nfs-test-server.yml. nfstestldapserver can be reached at nfstestldapserver.service.cf.internal |
 | [`enable-smb-test-server.yml`](enable-smb-test-server.yml) | adds an SMB server to the deployment | smbtestserver can be reached at smbtestserver.service.cf.internal for acceptance testing purposes |

--- a/operations/test/README.md
+++ b/operations/test/README.md
@@ -18,4 +18,5 @@ They may change without notice.
 |:---  |:---     |:---   |
 | [`add-oidc-provider.yml `](add-oidc-provider.yml) | Allows testing of UAA with users authenticated via an OIDC provider | Creates a second UAA instance group that acts as the OIDC provider |
 | [`enable-nfs-test-server.yml`](enable-nfs-test-server.yml) | adds an NFS server to the deployment | nfstestserver can be reached at nfstestserver.service.cf.internal for acceptance testing purposes |
+| [`enable-nfs-test-ldapserver.yml`](enable-nfs-test-ldapserver.yml) | Adds an LDAP server to the deployment to allow testing of NFS volume services configured with LDAP authentication | nfstestldapserver can be reached at nfstestldapserver.service.cf.internal |
 | [`enable-smb-test-server.yml`](enable-smb-test-server.yml) | adds an SMB server to the deployment | smbtestserver can be reached at smbtestserver.service.cf.internal for acceptance testing purposes |

--- a/operations/test/enable-nfs-test-ldapserver.yml
+++ b/operations/test/enable-nfs-test-ldapserver.yml
@@ -1,22 +1,15 @@
 - type: replace
-  path: /instance_groups/-
+  path: /instance_groups/name=nfstestserver/jobs/-
   value:
     name: nfstestldapserver
-    azs: [z1]
-    instances: 1
-    stemcell: default
-    vm_type: small
-    networks: [ name: default ]
-    jobs:
-    - name: nfstestldapserver
-      release: nfs-volume
-      properties:
-        ldap:
-          ssl:
-            active: true
-            ca_cert: ((ldap_test_server_ca.certificate))
-            server_cert: ((ldap_test_server_ssl.certificate))
-            server_key: ((ldap_test_server_ssl.private_key))
+    release: nfs-volume
+    properties:
+      ldap:
+        ssl:
+          active: true
+          ca_cert: ((ldap_test_server_ca.certificate))
+          server_cert: ((ldap_test_server_ssl.certificate))
+          server_key: ((ldap_test_server_ssl.private_key))
 
 - type: replace
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=nfstestldapserver.service.cf.internal?
@@ -24,13 +17,13 @@
     domain: nfstestldapserver.service.cf.internal
     targets:
     - query: '*'
-      instance_group: nfstestldapserver
+      instance_group: nfstestserver
       deployment: cf
       network: default
       domain: bosh
 
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver/properties/nfsv3driver?/ldap_ca_cert?
+  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver/properties/nfsv3driver/ldap_ca_cert?
   value: ((ldap_test_server_ca.certificate))
 
 - type: replace

--- a/operations/test/enable-nfs-test-ldapserver.yml
+++ b/operations/test/enable-nfs-test-ldapserver.yml
@@ -1,0 +1,51 @@
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: nfstestldapserver
+    azs: [z1]
+    instances: 1
+    stemcell: default
+    vm_type: small
+    networks: [ name: default ]
+    jobs:
+    - name: nfstestldapserver
+      release: nfs-volume
+      properties:
+        ldap:
+          ssl:
+            active: true
+            ca_cert: ((ldap_test_server_ca.certificate))
+            server_cert: ((ldap_test_server_ssl.certificate))
+            server_key: ((ldap_test_server_ssl.private_key))
+
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=nfstestldapserver.service.cf.internal?
+  value:
+    domain: nfstestldapserver.service.cf.internal
+    targets:
+    - query: '*'
+      instance_group: nfstestldapserver
+      deployment: cf
+      network: default
+      domain: bosh
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=nfsv3driver/properties/nfsv3driver?/ldap_ca_cert?
+  value: ((ldap_test_server_ca.certificate))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: ldap_test_server_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: ldap_test_server_ca
+- type: replace
+  path: /variables/-
+  value:
+    name: ldap_test_server_ssl
+    type: certificate
+    options:
+      ca: ldap_test_server_ca
+      common_name: nfstestldapserver.service.cf.internal

--- a/scripts/test-test.sh
+++ b/scripts/test-test.sh
@@ -13,7 +13,7 @@ test_test_ops() {
       check_interpolation "add-persistent-isolation-segment-router.yml"
       check_interpolation "alter-ssh-proxy-redirect-uri.yml"
       check_interpolation "enable-nfs-test-server.yml"
-      check_interpolation "name: enable-nfs-test-ldapserver.yml" "${home}/operations/enable-nfs-volume-service.yml" "-o enable-nfs-test-ldapserver.yml"
+      check_interpolation "name: enable-nfs-test-ldapserver.yml" "${home}/operations/enable-nfs-volume-service.yml" "-o enable-nfs-test-server.yml" "-o enable-nfs-test-ldapserver.yml"
       check_interpolation "enable-smb-test-server.yml" "-v smb-password=FOO.PASS" "-v smb-username=BAR.USER"
       check_interpolation "name: add-persistent-isolation-segment-logging-system.yml" "add-persistent-isolation-segment-diego-cell.yml" "-o add-persistent-isolation-segment-logging-system.yml"
       check_interpolation "name: add-persistent-isolation-segment-syslog-drain.yml" "add-persistent-isolation-segment-diego-cell.yml" "-o add-persistent-isolation-segment-logging-system.yml" "-o add-persistent-isolation-segment-syslog-drain.yml"

--- a/scripts/test-test.sh
+++ b/scripts/test-test.sh
@@ -13,6 +13,7 @@ test_test_ops() {
       check_interpolation "add-persistent-isolation-segment-router.yml"
       check_interpolation "alter-ssh-proxy-redirect-uri.yml"
       check_interpolation "enable-nfs-test-server.yml"
+      check_interpolation "name: enable-nfs-test-ldapserver.yml" "${home}/operations/enable-nfs-volume-service.yml" "-o enable-nfs-test-ldapserver.yml"
       check_interpolation "enable-smb-test-server.yml" "-v smb-password=FOO.PASS" "-v smb-username=BAR.USER"
       check_interpolation "name: add-persistent-isolation-segment-logging-system.yml" "add-persistent-isolation-segment-diego-cell.yml" "-o add-persistent-isolation-segment-logging-system.yml"
       check_interpolation "name: add-persistent-isolation-segment-syslog-drain.yml" "add-persistent-isolation-segment-diego-cell.yml" "-o add-persistent-isolation-segment-logging-system.yml" "-o add-persistent-isolation-segment-syslog-drain.yml"


### PR DESCRIPTION
### WHAT is this change about?

This PR adds a new ops-file to add a test LDAP server for use when testing the NFS volume service.

### WHY is this change being made (What problem is being addressed)?

The Diego Persistence team decided that, since we have a GA'ed ops-file to enable LDAP support for the NFS volume service, we should "donate" the corresponding ops-file that allows us to test this integration in our CI.

### Please provide contextual information.

[#163926900](https://www.pivotaltracker.com/story/show/163926900)

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO, but it has passed our acceptance tests in our CI.

### How should this change be described in cf-deployment release notes?

New Ops-files
* `operations/test/enable-nfs-test-ldapserver.yml`

### Does this PR introduce a breaking change? 

No, this change is additive.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component
- [x] test infrastructure

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@paulcwarren @julian-hj 