### PR TITLE
Add uptime metric to log-cache

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1411,6 +1411,10 @@ instance_groups:
         source_id: log-cache
         addr: http://localhost:6060/debug/vars
         template: "{{.LogCache.AvailableSystemMemory}}"
+      - name: uptime
+        source_id: log-cache
+        addr: http://localhost:6060/debug/vars
+        template: "{{.LogCache.Uptime}}"
       - name: promql-instant-query-time
         source_id: log-cache
         addr: http://localhost:6060/debug/vars


### PR DESCRIPTION
[#164153522]

### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes

### WHAT is this change about?

Getting a uptime metric scraped from log-cache so that it is visible in `cf tail`
### WHY is this change being made (What problem is being addressed)?

Better blackbox testing against log cache an uptime metric that resets indicates it is restarting itself/dropping it's cache

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/164153522

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO


### How should this change be described in cf-deployment release notes?

Add scraping for log-cache uptime metric

### Does this PR introduce a breaking change? 
No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
/cc @toddboom @jtuchscherer 
