### PR TITLE
syslog_agent: fix ingress dropped and egress dropped metrics

### DIFF
--- a/operations/experimental/add-syslog-agent.yml
+++ b/operations/experimental/add-syslog-agent.yml
@@ -153,6 +153,7 @@
     template: "{{.SyslogAgent.IngressDropped}}"
     tags:
       direction: ingress
+      metric_version: "2.0"
       origin: syslog_agent
 
 - type: replace
@@ -229,5 +230,6 @@
     source_id: syslog_agent
     template: "{{.SyslogAgent.EgressDropped}}"
     tags:
+      direction: egress
       metric_version: "2.0"
       origin: syslog_agent


### PR DESCRIPTION
[#164346923]

Signed-off-by: Tom Chen <tochen@pivotal.io>

### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes.

### WHAT is this change about?

We noticed that our syslog_agent job had some incorrect metrics. The ingress dropped metric was missing `metric_version` tag and that egress dropped was missing `direction: egress` tag.

### WHY is this change being made (What problem is being addressed)?

To make the syslog_agent job metrics correct

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/164346923

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES 
- [ ] NO



### How should this change be described in cf-deployment release notes?

Currently the syslog_agent job has some incorrect metrics. This change will add to the ingress dropped metric a `metric_version` tag and to the egress dropped a `direction: egress` tag. 

### Does this PR introduce a breaking change? 

No


### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO


### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [ ] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!

@jtuchscherer, @johncornish, @chentom88 