### PR TITLE
log-cache-expvar-forwarder -> prom_scraper

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1301,25 +1301,6 @@ instance_groups:
               cn: "cloud-controller-ng.service.cf.internal"
   - name: log-cache-scheduler
     release: log-cache
-  - name: log-cache-expvar-forwarder
-    release: log-cache
-    properties:
-      loggregator_agent:
-        tls:
-          ca_cert: "((loggregator_ca.certificate))"
-          cert: "((log_cache_to_loggregator_agent.certificate))"
-          key: "((log_cache_to_loggregator_agent.private_key))"
-      counters: []
-      gauges: []
-      maps:
-      - name: worker-assignments
-        source_id: log-cache-scheduler
-        addr: http://localhost:6064/debug/vars
-        template: "{{.WorkerAssignments | jsonMap}}"
-      - name: worker-health
-        source_id: log-cache-scheduler
-        addr: http://localhost:6064/debug/vars
-        template: "{{.WorkerHealth | jsonMap}}"
 - name: doppler
   azs:
   - z1
@@ -1366,107 +1347,12 @@ instance_groups:
           cert: ((logs_provider.certificate))
           key: ((logs_provider.private_key))
     release: log-cache
-  - name: log-cache-expvar-forwarder
+  - name: prom_scraper
+    consumes:
+      loggregator: {from: loggregator}
     properties:
-      loggregator_agent:
-        tls:
-          ca_cert: "((loggregator_ca.certificate))"
-          cert: "((log_cache_to_loggregator_agent.certificate))"
-          key: "((log_cache_to_loggregator_agent.private_key))"
-      maps: []
-      counters:
-        # Log Cache
-      - name: egress
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.Egress}}"
-      - name: ingress
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.Ingress}}"
-      - name: expired
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.Expired}}"
-      - name: dropped
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.Dropped}}"
-      - name: promql-timeout
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.PromQLTimeout}}"
-
-        # Nozzle
-      - name: egress
-        source_id: log-cache-nozzle
-        addr: http://localhost:6061/debug/vars
-        template: "{{.Nozzle.Egress}}"
-      - name: ingress
-        source_id: log-cache-nozzle
-        addr: http://localhost:6061/debug/vars
-        template: "{{.Nozzle.Ingress}}"
-      - name: err
-        source_id: log-cache-nozzle
-        addr: http://localhost:6061/debug/vars
-        template: "{{.Nozzle.Err}}"
-      - name: dropped
-        source_id: log-cache-nozzle
-        addr: http://localhost:6061/debug/vars
-        template: "{{.Nozzle.Dropped}}"
-      gauges:
-        # Log Cache
-      - name: cache-period
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.CachePeriod}}"
-      - name: store-size
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.StoreSize}}"
-      - name: total-system-memory
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.TotalSystemMemory}}"
-      - name: available-system-memory
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.AvailableSystemMemory}}"
-      - name: uptime
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.Uptime}}"
-      - name: promql-instant-query-time
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.PromQLInstantQueryTime}}"
-      - name: promql-range-query-time
-        source_id: log-cache
-        addr: http://localhost:6060/debug/vars
-        template: "{{.LogCache.PromQLRangeQueryTime}}"
-
-        # CF Auth Proxy
-      - name: last-uaa-latency
-        source_id: log-cache-cf-auth-proxy
-        addr: http://localhost:6065/debug/vars
-        template: "{{.CFAuthProxy.LastUAALatency}}"
-      - name: last-capi-v3-apps-latency
-        source_id: log-cache-cf-auth-proxy
-        addr: http://localhost:6065/debug/vars
-        template: "{{.CFAuthProxy.LastCAPIV3AppsLatency}}"
-      - name: last-capi-v2-list-service-instances-latency
-        source_id: log-cache-cf-auth-proxy
-        addr: http://localhost:6065/debug/vars
-        template: "{{.CFAuthProxy.LastCAPIV2ListServiceInstancesLatency}}"
-      - name: last-capi-v4-log-access-latency
-        source_id: log-cache-cf-auth-proxy
-        addr: http://localhost:6065/debug/vars
-        template: "{{.CFAuthProxy.LastCAPIV4LogAccessLatency}}"
-      - name: last-capi-v2-service-instances-latency
-        source_id: log-cache-cf-auth-proxy
-        addr: http://localhost:6065/debug/vars
-        template: "{{.CFAuthProxy.LastCAPIV2ServiceInstancesLatency}}"
-    release: log-cache
+      metrics_urls: "http://localhost:6060/metrics,http://localhost:6061/metrics,http://localhost:6065/metrics"
+    release: loggregator-agent
   - name: route_registrar
     properties:
       route_registrar:

--- a/operations/test/add-persistent-isolation-segment-logging-system.yml
+++ b/operations/test/add-persistent-isolation-segment-logging-system.yml
@@ -65,40 +65,12 @@
           client_secret: ((uaa_clients_doppler_secret))
           internal_addr: https://uaa.service.cf.internal:8443
       release: log-cache
-    - name: log-cache-expvar-forwarder
-      release: log-cache
+    - name: prom_scraper
       consumes:
-        log-cache: {from: isolated_log_cache}
         loggregator: {from: isolated_loggregator}
       properties:
-        loggregator_agent:
-          tls:
-            ca_cert: "((loggregator_ca.certificate))"
-            cert: "((log_cache_to_loggregator_agent.certificate))"
-            key: "((log_cache_to_loggregator_agent.private_key))"
-        maps: []
-        counters:
-        - {name: egress,         source_id: isolated-log-cache,        addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.Egress}}"}
-        - {name: ingress,        source_id: isolated-log-cache,        addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.Ingress}}"}
-        - {name: expired,        source_id: isolated-log-cache,        addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.Expired}}"}
-        - {name: dropped,        source_id: isolated-log-cache,        addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.Dropped}}"}
-        - {name: promql-timeout, source_id: isolated-log-cache,        addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.PromQLTimeout}}"}
-        - {name: egress,         source_id: isolated-log-cache-nozzle, addr: "http://localhost:6061/debug/vars", template: "{{.Nozzle.Egress}}"}
-        - {name: ingress,        source_id: isolated-log-cache-nozzle, addr: "http://localhost:6061/debug/vars", template: "{{.Nozzle.Ingress}}"}
-        - {name: err,            source_id: isolated-log-cache-nozzle, addr: "http://localhost:6061/debug/vars", template: "{{.Nozzle.Err}}"}
-        - {name: dropped,        source_id: isolated-log-cache-nozzle, addr: "http://localhost:6061/debug/vars", template: "{{.Nozzle.Dropped}}"}
-        gauges:
-        - {name: cache-period,                                source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.CachePeriod}}"}
-        - {name: store-size,                                  source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.StoreSize}}"}
-        - {name: total-system-memory,                         source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.TotalSystemMemory}}"}
-        - {name: available-system-memory,                     source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.AvailableSystemMemory}}"}
-        - {name: promql-instant-query-time,                   source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.PromQLInstantQueryTime}}"}
-        - {name: promql-range-query-time,                     source_id: isolated-log-cache,               addr: "http://localhost:6060/debug/vars", template: "{{.LogCache.PromQLRangeQueryTime}}"}
-        - {name: last-uaa-latency,                            source_id: isolated-log-cache-cf-auth-proxy, addr: "http://localhost:6065/debug/vars", template: "{{.CFAuthProxy.LastUAALatency}}"}
-        - {name: last-capi-v3-apps-latency,                   source_id: isolated-log-cache-cf-auth-proxy, addr: "http://localhost:6065/debug/vars", template: "{{.CFAuthProxy.LastCAPIV3AppsLatency}}"}
-        - {name: last-capi-v2-list-service-instances-latency, source_id: isolated-log-cache-cf-auth-proxy, addr: "http://localhost:6065/debug/vars", template: "{{.CFAuthProxy.LastCAPIV2ListServiceInstancesLatency}}"}
-        - {name: last-capi-v4-log-access-latency,             source_id: isolated-log-cache-cf-auth-proxy, addr: "http://localhost:6065/debug/vars", template: "{{.CFAuthProxy.LastCAPIV4LogAccessLatency}}"}
-        - {name: last-capi-v2-service-instances-latency,      source_id: isolated-log-cache-cf-auth-proxy, addr: "http://localhost:6065/debug/vars", template: "{{.CFAuthProxy.LastCAPIV2ServiceInstancesLatency}}"}
+        metrics_urls: "http://localhost:6060/metrics,http://localhost:6061/metrics,http://localhost:6065/metrics"
+      release: loggregator-agent
     - name: log-cache-gateway
       release: log-cache
       consumes:
@@ -378,22 +350,6 @@
       release: log-cache
       consumes:
         log-cache: {from: isolated_log_cache}
-    - name: log-cache-expvar-forwarder
-      release: log-cache
-      consumes:
-        log-cache: {from: isolated_log_cache}
-        loggregator: {from: isolated_loggregator}
-      properties:
-        loggregator_agent:
-          tls:
-            ca_cert: "((loggregator_ca.certificate))"
-            cert: "((log_cache_to_loggregator_agent.certificate))"
-            key: "((log_cache_to_loggregator_agent.private_key))"
-        counters: []
-        gauges: []
-        maps:
-        - {name: worker-assignments, source_id: isolated-log-cache-scheduler, addr: "http://localhost:6064/debug/vars", template: "{{.WorkerAssignments | jsonMap}}"}
-        - {name: worker-health,      source_id: isolated-log-cache-scheduler, addr: "http://localhost:6064/debug/vars", template: "{{.WorkerHealth | jsonMap}}"}
 
 - type: replace
   path: /variables/name=isolated_logs_provider?
@@ -474,12 +430,6 @@
     from: log_cache_gateway
 
 - type: replace
-  path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/consumes?
-  value:
-    log-cache: {from: log_cache}
-    loggregator: {from: loggregator}
-
-- type: replace
   path: /instance_groups/name=doppler/jobs/name=log-cache-gateway/consumes?
   value:
     log-cache: {from: log_cache}
@@ -499,12 +449,6 @@
   path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/consumes/log-cache?
   value:
     from: log_cache
-
-- type: replace
-  path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/consumes?
-  value:
-    log-cache: {from: log_cache}
-    loggregator: {from: loggregator}
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=log-cache-scheduler/consumes?


### PR DESCRIPTION
[#162397765]

Signed-off-by: Johanna Ratliff <josmith@pivotal.io>

### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes

### WHAT is this change about?

Removing hand rolled log-cache-expvar-forwarder job to be replaced by standardized `prom_scraper` job in loggregator-agent-release.

### WHY is this change being made (What problem is being addressed)?

Better to use a standardized scrape and dump to loggregator. Smaller manifest as a benefit.

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/162397765

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO



### How should this change be described in cf-deployment release notes?

_Something brief that conveys the change and is written with the Operator audience in mind. 
See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

Removing `log-cache-expvar-forwarder` job to be replaced by standardized `prom_scraper` job in `loggregator-agent-release`.

### Does this PR introduce a breaking change? 

No. Blackbox jobs against log-cache might see a blip between the addition of prom_scraper and the removal of expvar-forwarder. But the scraped metrics are only for health endpoint and log-cache meta information. 

This will require log-cache `v2.3` for jobs to serve the prometheus `/metrics` endpoint.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO


### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
/cc @rheaton @jtuchscherer 