### PR TITLE
Add the nfs-broker seeded database back into the base nfs ops file

### DIFF
--- a/operations/enable-nfs-volume-service.yml
+++ b/operations/enable-nfs-volume-service.yml
@@ -8,6 +8,12 @@
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/volume_services_enabled?
   value: true
 - type: replace
+  path: /instance_groups/name=database/jobs/name=pxc-mysql/properties/seeded_databases/-
+  value:
+    name: nfs-broker
+    password: ((nfs-broker-database-password))
+    username: nfs-broker
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/nfs-broker-push-client?
   value:
     authorities: cloud_controller.admin


### PR DESCRIPTION
### WHAT is this change about?

Adds the seeded database back into the base enable-nfs-volume ops file.

### WHY is this change being made (What problem is being addressed)?

Fixes [this issue](https://github.com/cloudfoundry/nfs-volume-release/issues/47). 

### Please provide contextual information.

[#164438618](https://www.pivotaltracker.com/story/show/164438618)

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [X] NO

No, but it has passed through the persi "heleus" pipeline that tests "first product install" (of the base nfs ops file) and also migration of service instances and bindings from a sql store to a credhub store. 

### How should this change be described in cf-deployment release notes?

n/a

### Does this PR introduce a breaking change? 

No

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component



### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@davewalter @julian-hj 
