### PR TITLE
Add clients.read permissions to CF admin user

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -604,6 +604,7 @@ instance_groups:
           - name: admin
             password: "((cf_admin_password))"
             groups:
+            - clients.read
             - cloud_controller.admin
             - doppler.firehose
             - network.admin
@@ -638,7 +639,7 @@ instance_groups:
             authorized-grant-types: password,refresh_token
             override: true
             refresh-token-validity: 2592000
-            scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor,perm.admin
+            scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor,perm.admin,clients.read
             secret: ''
           cf_smoke_tests:
             authorities: cloud_controller.admin


### PR DESCRIPTION
### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes.

### WHAT is this change about?

This change adds the `clients.read` permission to the CF admin user.

### WHY is this change being made (What problem is being addressed)?

The CF CLI has implemented (but not released) changes to the set-org-role and set-space-role commands that allow setting roles on clients. These changes include validation that a provided client actually exists in the UAA, which requires the logged-in user to have one of a set of specific scopes (one option is `clients.read`).

### Please provide contextual information.

Relevant stories:
https://www.pivotaltracker.com/story/show/159967411
https://www.pivotaltracker.com/story/show/159969560


### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?

`clients.read` scope has been added to the CF Admin user's permissions. 

### Does this PR introduce a breaking change? 
 
No.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@cloudfoundry/cf-cli 
