### PR TITLE
Disable ssh-proxy HTTP healthcheck server

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1275,6 +1275,7 @@ instance_groups:
           uaa:
             ca_cert: "((uaa_ca.certificate))"
           bbs: *diego_bbs_client_properties
+          disable_healthcheck_server: true
       backends:
         tls:
           enabled: true

--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -42,6 +42,7 @@
             ca_cert: "((service_cf_internal_ca.certificate))"
             client_cert: "((diego_bbs_client.certificate))"
             client_key: "((diego_bbs_client.private_key))"
+          disable_healthcheck_server: true
           enable_cf_auth: true
           host_key: "((diego_ssh_proxy_host_key.private_key))"
           uaa_secret: "((uaa_clients_ssh-proxy_secret))"


### PR DESCRIPTION
This is a breaking change PR, intended for the next major release of cf-deployment

### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes

### WHAT is this change about?

 As a CF operator, I expect that cf-deployment disables the ssh-proxy HTTP healthcheck server by default. In the past, TCP load-balancers on GCP were requiring their backends to expose an HTTP health-check, so in order to be able to use one to load-balance across the Diego ssh-proxy instances we needed them to present such a health-check. TCP load-balancers on GCP haven't needed the HTTP healthcheck for a while now.
 
### WHY is this change being made (What problem is being addressed)?

We no longer need to expose an insecure HTTP healthcheck for ssh-proxy. This make the the ecosystem more robust and secure.

### Please provide contextual information.
Original Story to turn on HTTP Healthcheck: (https://www.pivotaltracker.com/story/show/130616967)
Removal of the HTTP healthcheck: (https://www.pivotaltracker.com/story/show/164091570)

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES 
- [ ] NO



### How should this change be described in cf-deployment release notes?

 As a CF operator, I expect that cf-deployment disables the ssh-proxy HTTP healthcheck server by default.

### Does this PR introduce a breaking change?  Yes

If you are an operator that uses CF-deployment for GCP and you are still using load-balancers that require HTTP Healtcheck, you are required to recreate your load-balancers to mitigate this change.

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [X] NO


### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**


@cloudfoundry/cf-diego 