### PR TITLE
Scheduler instance group deploys immediately after api

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1087,70 +1087,6 @@ instance_groups:
             secret: "((uaa_clients_cc-service-dashboards_secret))"
           cc_routing:
             secret: "((uaa_clients_cc-routing_secret))"
-- name: router
-  azs:
-  - z1
-  - z2
-  instances: 2
-  vm_type: minimal
-  vm_extensions:
-  - cf-router-network-properties
-  stemcell: default
-  update:
-    serial: true
-  networks:
-  - name: default
-  jobs:
-  - name: gorouter
-    release: routing
-    properties:
-      router:
-        enable_ssl: true
-        tls_pem:
-        - cert_chain: "((router_ssl.certificate))"
-          private_key: "((router_ssl.private_key))"
-        ca_certs: |
-          ((application_ca.certificate))
-          ((service_cf_internal_ca.certificate))
-        backends:
-          cert_chain: ((gorouter_backend_tls.certificate))
-          private_key: ((gorouter_backend_tls.private_key))
-        status:
-          password: "((router_status_password))"
-          user: router-status
-        route_services_secret: "((router_route_services_secret))"
-        tracing:
-          enable_zipkin: true
-      routing_api:
-        enabled: true
-      uaa:
-        clients:
-          gorouter:
-            secret: "((uaa_clients_gorouter_secret))"
-        ca_cert: "((uaa_ca.certificate))"
-        ssl:
-          port: 8443
-- name: tcp-router
-  azs:
-  - z1
-  - z2
-  instances: 2
-  vm_type: minimal
-  stemcell: default
-  vm_extensions:
-  - cf-tcp-router-network-properties
-  networks:
-  - name: default
-  jobs:
-  - name: tcp_router
-    release: routing
-    properties:
-      tcp_router:
-        oauth_secret: "((uaa_clients_tcp_router_secret))"
-        router_group: default-tcp
-      uaa:
-        ca_cert: "((uaa_ca.certificate))"
-        tls_port: 8443
 - name: scheduler
   azs:
   - z1
@@ -1326,6 +1262,70 @@ instance_groups:
         source_id: log-cache-scheduler
         addr: http://localhost:6064/debug/vars
         template: "{{.WorkerHealth | jsonMap}}"
+- name: router
+  azs:
+  - z1
+  - z2
+  instances: 2
+  vm_type: minimal
+  vm_extensions:
+  - cf-router-network-properties
+  stemcell: default
+  update:
+    serial: true
+  networks:
+  - name: default
+  jobs:
+  - name: gorouter
+    release: routing
+    properties:
+      router:
+        enable_ssl: true
+        tls_pem:
+        - cert_chain: "((router_ssl.certificate))"
+          private_key: "((router_ssl.private_key))"
+        ca_certs: |
+          ((application_ca.certificate))
+          ((service_cf_internal_ca.certificate))
+        backends:
+          cert_chain: ((gorouter_backend_tls.certificate))
+          private_key: ((gorouter_backend_tls.private_key))
+        status:
+          password: "((router_status_password))"
+          user: router-status
+        route_services_secret: "((router_route_services_secret))"
+        tracing:
+          enable_zipkin: true
+      routing_api:
+        enabled: true
+      uaa:
+        clients:
+          gorouter:
+            secret: "((uaa_clients_gorouter_secret))"
+        ca_cert: "((uaa_ca.certificate))"
+        ssl:
+          port: 8443
+- name: tcp-router
+  azs:
+  - z1
+  - z2
+  instances: 2
+  vm_type: minimal
+  stemcell: default
+  vm_extensions:
+  - cf-tcp-router-network-properties
+  networks:
+  - name: default
+  jobs:
+  - name: tcp_router
+    release: routing
+    properties:
+      tcp_router:
+        oauth_secret: "((uaa_clients_tcp_router_secret))"
+        router_group: default-tcp
+      uaa:
+        ca_cert: "((uaa_ca.certificate))"
+        tls_port: 8443
 - name: doppler
   azs:
   - z1


### PR DESCRIPTION
### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

yup

### WHAT is this change about?

Moving the `scheduler` instance group to immediately after the `cc-worker` instance group

### WHY is this change being made (What problem is being addressed)?

The cloud_controller_ng job may run migrations against ccdb when it is deployed. This means that for a time the cloud_controller_clock and cloud_controller_worker are running older code against this newly migrated ccdb. This is typically fine, but if those jobs are stopped and restarted for any reason (monit restarts, someone inadvertently running bbr during the deploy), then they cannot come up successfully because their older code is out of date with the db.

To minimize the time between the cloud_controller_ng job deploying and the scheduler (with cloud_controller_clock job) deploying we should have them deploy immediately after cloud_controller.

### Please provide contextual information.


### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES 
- [x] NO


### How should this change be described in cf-deployment release notes?

Change deploy order of scheduler instance group to minimize time between deploys of `cloud_controller_ng` and `cloud_controller_clock` jobs.

### Does this PR introduce a breaking change? 

We don't believe so

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES --- does it really have to?
- [x] NO



### Does this PR make a change to an experimental or GA'd feature/component?

no


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

@tcdowney @Gerg @coreyti 
