### PR TITLE
Our licenses should state org correctly for copyright purposes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2017 CloudFoundry.org Foundation, Inc.
+
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Johanna Ratliff <josmith@pivotal.io>

### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment? Yes

### WHY is this change being made (What problem is being addressed)?

I was fixing the license for one of our sub projects and realized we don't state org, we just use template in a lot of these.
Year was chosen based off of original license add date.

### How should this change be described in cf-deployment release notes?

Fix org name in license

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**