### PR TITLE
Add experimental option to have a metric store in CF

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -19,6 +19,7 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 | [`add-deployment-updater-external-db.yml`](add-deployment-updater-external-db.yml) |  **"DEPRECATED because it is inlined in to `cf-deployment.yml`"** | Requires `add-deployment-updater.yml` and `use-external-dbs.yml` | **NO** |
 | [`add-deployment-updater-postgres.yml`](add-deployment-updater-postgres.yml) |  **"DEPRECATED because it is inlined in to `cf-deployment.yml`"** | Requires `add-deployment-updater.yml` | **NO** |
 | [`add-deployment-updater.yml`](add-deployment-updater.yml) |  **"DEPRECATED because it is inlined in to `cf-deployment.yml`"** | | **NO** |
+| [`add-metric-store.yml`](add-metric-store.yml) |  *Add Metric Store node for persistence of metrics from Loggregator** | | **NO** |
 | [`add-syslog-agent.yml`](add-syslog-agent.yml) |  Add agent to all vms for the purpose of egressing application logs to syslog | Requires `deploy-forwarder-agent.yml` | **YES** |
 | [`add-syslog-agent-windows1803.yml`](add-syslog-agent-windows1803.yml) |  Add agent to windows1803 Diego cells for the purpose of egressing application logs to syslog | Requires `../windows1803-cell.yml`, `add-syslog-agent.yml` and `deploy-forwarder-agent.yml` | **NO** |
 | [`add-system-metrics-agent.yml`](add-system-metrics-agent.yml) | Add agent to all vms with the purpose of egressing system metrics | | **NO** |

--- a/operations/experimental/add-metric-store.yml
+++ b/operations/experimental/add-metric-store.yml
@@ -1,0 +1,146 @@
+---
+- type: replace
+  path: /releases/-
+  value:
+    name: metric-store
+    version: latest
+    url: https://bosh.io/d/github.com/cloudfoundry/metric-store-release
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: metric-store
+    azs:
+    - z1
+    instances: 1
+    persistent_disk_type: 10GB
+    vm_type: minimal
+    stemcell: default
+    networks:
+    - name: default
+    jobs:
+    - name: metric-store
+      release: metric-store
+      provides:
+        metric-store: {shared: true, as: metric-store}
+      consumes:
+        metric-store: {from: metric-store}
+      properties:
+        egress_port: 8080
+        health_addr: localhost:6060
+        tls:
+          ca_cert: ((metric_store.ca))
+          cert: ((metric_store.certificate))
+          key: ((metric_store.private_key))
+    - name: metric-store-gateway
+      release: metric-store
+      provides:
+        metric-store-gateway: {as: metric-store-gateway}
+      consumes:
+        metric-store: {from: metric-store}
+      properties:
+        gateway_addr: localhost:8081
+    - name: metric-store-nozzle
+      release: metric-store
+      provides:
+        metric-store-nozzle: {as: metric-store-nozzle}
+      consumes:
+        reverse_log_proxy: {from: reverse_log_proxy}
+        metric-store-nozzle: {from: metric-store-nozzle}
+        metric-store: {from: metric-store}
+      properties:
+        shard_id: metric-store
+        logs_provider:
+          tls:
+            ca_cert: ((metric_store_to_logs_provider.ca))
+            cert: ((metric_store_to_logs_provider.certificate))
+            key: ((metric_store_to_logs_provider.private_key))
+    - name: route_registrar
+      release: routing
+      properties:
+        route_registrar:
+          routes:
+          - name: metric-store-reverse-proxy
+            port: 8083
+            tls_port: 8083
+            registration_interval: 20s
+            server_cert_domain_san: metric-store.((system_domain))
+            uris:
+            - metric-store.((system_domain))
+            - "*.metric-store.((system_domain))"
+    - name: prom_scraper
+      release: loggregator-agent
+      consumes:
+        loggregator: {from: loggregator}
+      properties:
+        metrics_urls: "http://localhost:6060/metrics,http://localhost:6061/metrics,http://localhost:6065/metrics"
+    - name: metric-store-cf-auth-proxy
+      release: metric-store
+      provides:
+        metric-store-cf-auth-proxy: {as: metric-store-cf-auth-proxy}
+      consumes:
+        cloud_controller: {from: cloud_controller}
+        metric-store-nozzle: {from: metric-store-nozzle}
+        metric-store-gateway: {from: metric-store-gateway}
+        metric-store: {from: metric-store}
+      properties:
+        cc:
+          ca_cert: ((service_cf_internal_ca.certificate))
+          common_name: cloud-controller-ng.service.cf.internal
+        proxy_port: 8083
+        external_cert: ((metricstore_ssl.certificate))
+        external_key: ((metricstore_ssl.private_key))
+        uaa:
+          ca_cert: ((uaa_ca.certificate))
+          client_id: doppler
+          client_secret: ((uaa_clients_doppler_secret))
+          internal_addr: https://uaa.service.cf.internal:8443
+
+- type: replace
+  path: /variables/-
+  value:
+    name: metric_store_to_logs_provider
+    type: certificate
+    options:
+      ca: loggregator_ca
+      common_name: metric-store
+      extended_key_usage:
+      - client_auth
+      - server_auth
+
+- type: replace
+  path: /variables/-
+  value:
+    name: metric_store_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: metric-store
+
+- type: replace
+  path: /variables/-
+  value:
+    name: metric_store
+    type: certificate
+    options:
+      ca: metric_store_ca
+      common_name: metric-store
+      alternative_names:
+      - ms
+      - metric-store
+      - metric-store
+      extended_key_usage:
+      - client_auth
+      - server_auth
+
+- type: replace
+  path: /variables/-
+  value:
+    name: metricstore_ssl
+    type: certificate
+    options:
+      ca: service_cf_internal_ca
+      common_name: metric-store
+      alternative_names:
+      - metric-store.((system_domain))
+      - "*.metric-store.((system_domain))"

--- a/scripts/test-experimental.sh
+++ b/scripts/test-experimental.sh
@@ -57,6 +57,8 @@ test_experimental_ops() {
       check_interpolation "add-system-metrics-agent.yml"
       check_interpolation "name: add-system-metrics-agent-windows1803.yml" "../windows1803-cell.yml" "-o add-system-metrics-agent.yml" "-o add-system-metrics-agent-windows1803.yml"
 
+      check_interpolation "add-metric-store.yml"
+
     popd > /dev/null # operations/experimental
   popd > /dev/null
   exit $exit_code


### PR DESCRIPTION
[#164122999]

Signed-off-by: Johanna Ratliff <josmith@pivotal.io>

### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment? Y

### WHAT is this change about?

Add Metric Store as an option within CF.

### WHY is this change being made (What problem is being addressed)?

Persistence and queryability (PromQL) of metrics downstream from Loggregator.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES 
- [ ] NO

### How should this change be described in cf-deployment release notes?

Add Metric Store - persistent storage for metrics downstream from Loggregator - as an experimental ops file.

### Does this PR introduce a breaking change? 

N

### Will this change increase the VM footprint of cf-deployment?

- [x] YES --- does it really have to? Yes. But it's an experimental ops file.
- [ ] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component


### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._

/cc @toddboom @jtuchscherer 