### PR TITLE
Add new certificate for Log Cache gateway <-> auth proxy

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1405,6 +1405,8 @@ instance_groups:
   - name: log-cache-gateway
     properties:
       gateway_addr: localhost:8081
+      proxy_cert: "((log_cache_proxy_tls.certificate))"
+      proxy_key: "((log_cache_proxy_tls.private_key))"
     release: log-cache
   - consumes:
       reverse_log_proxy: {from: reverse_log_proxy}
@@ -1535,6 +1537,7 @@ instance_groups:
       cc:
         ca_cert: ((service_cf_internal_ca.certificate))
         common_name: cloud-controller-ng.service.cf.internal
+      proxy_ca_cert: "((log_cache_ca.certificate))"
       proxy_port: 8083
       external_cert: ((logcache_ssl.certificate))
       external_key: ((logcache_ssl.private_key))
@@ -2163,6 +2166,11 @@ variables:
     alternative_names:
     - log-cache.((system_domain))
     - "*.log-cache.((system_domain))"
+- name: log_cache_proxy_tls
+  type: certificate
+  options:
+    ca: log_cache_ca
+    common_name: localhost
 - name: router_ca
   type: certificate
   options:


### PR DESCRIPTION
### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes!

### WHAT is this change about?

We wanted to make sure that traffic between the gateway and the auth proxy was encrypted, so we have added a new certificate for this communication path. Even though this traffic currently doesn't leave localhost on the doppler VM, we may find scenarios in the future where these components want to live on different hosts/containers.

### WHY is this change being made (What problem is being addressed)?

Security. Encryption. Always good, right?

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/165262353

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### How should this change be described in cf-deployment release notes?

Adds a TLS certificate for communication between the Log Cache gateway and auth proxy processes

### Does this PR introduce a breaking change?

No.

*However, this PR will need to be merged before we can cut Log Cache 2.3.0, which will expect the certificate to be available.*

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

/cc @colins @jtuchscherer @attack @rheaton @johannaratliff 
