### PR TITLE
Add certs to allow internal tls for metric-store-gateway job

### DIFF
--- a/operations/experimental/add-metric-store.yml
+++ b/operations/experimental/add-metric-store.yml
@@ -34,6 +34,8 @@
       name: metric-store-gateway
       properties:
         gateway_addr: localhost:8081
+        proxy_cert: "((metric_store_proxy_tls.certificate))"
+        proxy_key: "((metric_store_proxy_tls.private_key))"
       provides:
         metric-store-gateway:
           as: metric-store-gateway
@@ -91,6 +93,7 @@
         cc:
           ca_cert: ((service_cf_internal_ca.certificate))
           common_name: cloud-controller-ng.service.cf.internal
+        proxy_ca_cert: "((metric_store_ca.certificate))"
         external_cert: ((metricstore_ssl.certificate))
         external_key: ((metricstore_ssl.private_key))
         proxy_port: 8083
@@ -154,3 +157,12 @@
       ca: service_cf_internal_ca
       common_name: metric-store
     type: certificate
+
+- type: replace
+  path: /variables/-
+  value:
+    name: metric_store_proxy_tls
+    type: certificate
+    options:
+      ca: metric_store_ca
+      common_name: localhost


### PR DESCRIPTION
### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment? Y

### WHAT is this change about?
Adding generation for new cert variables in the `add-metric-store.yml` ops file so that gateway can securely communicate with it's other localhost processes. 

### WHY is this change being made (What problem is being addressed)?

Locking down everything to TLS for security purposes. This will also help in the future if the processes are split out onto different containers.

_Helpful Links_
https://www.pivotaltracker.com/story/show/165422726

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### How should this change be described in cf-deployment release notes?

Metric Store Gateway now requires TLS.

### Does this PR introduce a breaking change?

No - once the new ops file is used, the new properties that were added for metric-store will be automatically generated. 
Breaking change for metric store, not for CF.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._

/cc @jtuchscherer @colins @attack 