### PR TITLE
remove unnecessary config

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -378,8 +378,6 @@ instance_groups:
             cert: "((adapter_tls.certificate))"
             key: "((adapter_tls.private_key))"
             cn: ss-adapter
-          logs:
-            addr: reverse-log-proxy.service.cf.internal:8082
         adapter_rlp:
           tls:
             ca: "((loggregator_ca.certificate))"


### PR DESCRIPTION
### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Remove logging configuration that's no longer necessary

### WHY is this change being made (What problem is being addressed)?

There is some logging config that's still in cf-deployment.yml that's not used by the release anymore.

### Please provide contextual information.

This issue is related to this post https://www.pivotalk.io/t/voodoo-cf-deployments-shrinking-heads-with-bosh-interpolate/29085. This config created confusion about where the address comes from

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES
- [ ] NO

### How should this change be described in cf-deployment release notes?

Remove unnecessary logging configuration

### Does this PR introduce a breaking change?

NO

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@hev 