### PR TITLE
Update skip droplets and packages ops files

### DIFF
--- a/operations/backup-and-restore/skip-backup-restore-droplets-and-packages.yml
+++ b/operations/backup-and-restore/skip-backup-restore-droplets-and-packages.yml
@@ -24,5 +24,5 @@
   path: /instance_groups/name=backup-restore/jobs/name=s3-versioned-blobstore-backup-restorer?/properties/buckets/packages
 
 - type: replace
-  path: /instance_groups/name=singleton-blobstore?/jobs/name=blobstore/properties/directories_to_backup
+  path: /instance_groups/name=singleton-blobstore?/jobs/name=blobstore/properties/select_directories_to_backup
   value: ["buildpacks"]

--- a/operations/backup-and-restore/skip-backup-restore-droplets.yml
+++ b/operations/backup-and-restore/skip-backup-restore-droplets.yml
@@ -12,5 +12,5 @@
   path: /instance_groups/name=backup-restore/jobs/name=s3-versioned-blobstore-backup-restorer?/properties/buckets/droplets
 
 - type: replace
-  path: /instance_groups/name=singleton-blobstore?/jobs/name=blobstore/properties/directories_to_backup
+  path: /instance_groups/name=singleton-blobstore?/jobs/name=blobstore/properties/select_directories_to_backup
   value: ["buildpacks", "packages"]


### PR DESCRIPTION
### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes

### WHAT is this change about?

This is a follow up PR from https://github.com/cloudfoundry/cf-deployment/pull/694, in the latest capi-release https://github.com/cloudfoundry/capi-release/releases/tag/1.79.0 the job properties `directories_to_backup` was renamed to `select_directories_to_backup`, this PR updated the ops-files that set these properties to respect the renames.

### WHY is this change being made (What problem is being addressed)?

Addressing property renames in the capi-release

### Please provide contextual information.

Previous PR for this feature: https://github.com/cloudfoundry/cf-deployment/pull/694

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### How should this change be described in cf-deployment release notes?

Update BBR selective backup ops-files to accommodate property changes in the capi-release.

### Does this PR introduce a breaking change?

No

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

cc @cloudfoundry/bosh-backup-and-restore-team 