### PR TITLE
Set deployment name tag in loggr-forwarder-agent

### DIFF
--- a/operations/community/change-metron-agent-deployment.yml
+++ b/operations/community/change-metron-agent-deployment.yml
@@ -4,3 +4,12 @@
 - type: replace
   path: /addons/name=loggregator_agent/jobs/name=loggregator_agent/properties/deployment?
   value: ((loggregator_agent_deployment))
+- type: replace
+  path: /addons/name=loggregator_agent/jobs/name=loggregator_agent/properties/tags?/deployment
+  value: ((loggregator_agent_deployment))
+- type: replace
+  path: /addons/name=forwarder_agent/jobs/name=loggr-forwarder-agent/properties/deployment?
+  value: ((loggregator_agent_deployment))
+- type: replace
+  path: /addons/name=forwarder_agent/jobs/name=loggr-forwarder-agent/properties/tags?/deployment
+  value: ((loggregator_agent_deployment))


### PR DESCRIPTION
### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes

### WHAT is this change about?

Since the loggregator forwarder_agent is now GA in cf-deployment,
in order to set a custom deployment name for metrics, we'll have to
set the deployment name deployment/tag property in the loggr-forwarder-agent properties.

### WHY is this change being made (What problem is being addressed)?

Without this change, customizing the deployment tag on envelopes emitted from your deployment is not possible.

### Please provide contextual information.

Slack thread: https://cloudfoundry.slack.com/archives/C02HCCXV5/p1556733079023100

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### How should this change be described in cf-deployment release notes?

Updates `operations/community/change-metron-agent-deployment.yml` to properly change the loggregator agent deployment name.

### Does this PR introduce a breaking change?

No

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cf-diego 
