### PR TITLE
Enable mTLS for routing api

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1003,6 +1003,12 @@ instance_groups:
     release: routing
     properties:
       routing_api:
+        enabled_api_endpoints: "both"
+        mtls_ca: "((routing_api_tls_client.ca))"
+        mtls_server_cert: "((routing_api_tls.certificate))"
+        mtls_server_key: "((routing_api_tls.private_key))"
+        mtls_client_cert: "((routing_api_tls_client.certificate))"
+        mtls_client_key: "((routing_api_tls_client.private_key))"
         skip_consul_lock: true
         system_domain: "((system_domain))"
         router_groups:
@@ -2171,6 +2177,25 @@ variables:
     alternative_names:
     - "((system_domain))"
     - "*.((system_domain))"
+- name: routing_api_ca
+  type: certificate
+  options:
+    common_name: routing_api
+    is_ca: true
+- name: routing_api_tls
+  type: certificate
+  options:
+    ca: routing_api_ca
+    common_name: routing-api.service.cf.internal
+    extended_key_usage:
+      - server_auth
+- name: routing_api_tls_client
+  type: certificate
+  options:
+    ca: routing_api_ca
+    common_name: routing-api-client
+    extended_key_usage:
+      - client_auth
 - name: uaa_ca
   type: certificate
   options:


### PR DESCRIPTION

Co-authored-by: Christopher Brown <cbrown@pivotal.io>

### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes

### WHAT is this change about?

Enabling mTLS for routing api endpoint. 

We need this PR to get merged first before we cut our next Routing Release that will use these properties. Hopefully this will avoid breaking your pipelines if you pull in our new Routing Release automatically :)

### WHY is this change being made (What problem is being addressed)?

One step in the effort to add mTLS everywhere in CF

### Please provide contextual information.

[#165404264](https://www.pivotaltracker.com/story/show/165404264) for more detail.

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### How should this change be described in cf-deployment release notes?

Enabled mTLS endpoint for routing api service component

### Does this PR introduce a breaking change?

No

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

Not on fire, but need to add this with corresponding new Routing-Release version in order it continue work on Route-Emitter mTLS to Routing-API with Diego

### Tag your pair, your PM, and/or team!
@adobley @xoebus 
