### PR TITLE
Selective backups bug fix internal

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -707,6 +707,10 @@ instance_groups:
   - name: blobstore
     release: capi
     properties:
+      select_directories_to_backup:
+      - "buildpacks"
+      - "packages"
+      - "droplets"
       system_domain: "((system_domain))"
       blobstore:
         admin_users:

--- a/operations/backup-and-restore/skip-backup-restore-droplets-and-packages.yml
+++ b/operations/backup-and-restore/skip-backup-restore-droplets-and-packages.yml
@@ -23,6 +23,8 @@
 - type: remove
   path: /instance_groups/name=backup-restore/jobs/name=s3-versioned-blobstore-backup-restorer?/properties/buckets/packages
 
-- type: replace
-  path: /instance_groups/name=singleton-blobstore?/jobs/name=blobstore/properties/select_directories_to_backup
-  value: ["buildpacks"]
+- type: remove
+  path: /instance_groups/name=singleton-blobstore?/jobs/name=blobstore/properties/select_directories_to_backup/2
+
+- type: remove
+  path: /instance_groups/name=singleton-blobstore?/jobs/name=blobstore/properties/select_directories_to_backup/1

--- a/operations/backup-and-restore/skip-backup-restore-droplets.yml
+++ b/operations/backup-and-restore/skip-backup-restore-droplets.yml
@@ -11,6 +11,5 @@
 - type: remove
   path: /instance_groups/name=backup-restore/jobs/name=s3-versioned-blobstore-backup-restorer?/properties/buckets/droplets
 
-- type: replace
-  path: /instance_groups/name=singleton-blobstore?/jobs/name=blobstore/properties/select_directories_to_backup
-  value: ["buildpacks", "packages"]
+- type: remove
+  path: /instance_groups/name=singleton-blobstore?/jobs/name=blobstore/properties/select_directories_to_backup/2

--- a/scripts/test
+++ b/scripts/test
@@ -36,10 +36,18 @@ pass() {
 }
 
 interpolate() {
+  if [[ ${1} == output:* ]]; then
+    interpolation_output=$1
+    empty_string=""
+    interpolation_output="${interpolation_output/output: /$empty_string}"; shift
+  else
+    interpolation_output=/dev/null
+  fi
+
   local vars_store=$(mktemp)
   cp ${home}/scripts/fixtures/unit-test-vars-store.yml $vars_store
 
-  bosh interpolate --vars-store $vars_store --var-errs -v system_domain=foo.bar.com ${home}/cf-deployment.yml $@ > /dev/null
+  bosh interpolate --vars-store $vars_store --var-errs -v system_domain=foo.bar.com ${home}/cf-deployment.yml $@ > $interpolation_output
   local exit_code=$?
 
   rm $vars_store

--- a/scripts/test-backup-and-restore.sh
+++ b/scripts/test-backup-and-restore.sh
@@ -6,26 +6,39 @@ test_backup_and_restore_ops() {
 
   pushd ${home} > /dev/null
     pushd operations/backup-and-restore > /dev/null
+
+      # internal
       check_interpolation "name: enable-backup-restore.yml" "enable-backup-restore.yml"
+
+      # internal skip-droplets & skip-droplets-and-packages
+      check_interpolation "name: skip-backup-restore-droplets.yml" "enable-backup-restore.yml" "-o skip-backup-restore-droplets.yml"
+      check_interpolation "name: skip-backup-restore-droplets-and-packages.yml" "enable-backup-restore.yml" "-o skip-backup-restore-droplets-and-packages.yml"
+
+      check_internal_blobstore_properties "$(echo -e '- buildpacks\n- packages\n- droplets')" ""
+      check_internal_blobstore_properties "$(echo -e '- buildpacks\n- packages')" "-o skip-backup-restore-droplets.yml"
+      check_internal_blobstore_properties "$(echo -e '- buildpacks')" "-o skip-backup-restore-droplets-and-packages.yml"
+
+      ensure_singleton_blobstore_not_templated "skip-backup-restore-droplets.yml"
+      ensure_singleton_blobstore_not_templated "skip-backup-restore-droplets-and-packages.yml"
 
       # s3 versioned & unversioned
       check_interpolation "name: enable-backup-restore-s3-versioned.yml"   "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-s3-blobstore.yml" "-o enable-backup-restore-s3-versioned.yml"   "-l ${home}/operations/example-vars-files/vars-use-s3-blobstore.yml"
       check_interpolation "name: enable-backup-restore-s3-unversioned.yml" "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-s3-blobstore.yml" "-o enable-backup-restore-s3-unversioned.yml" "-l ${home}/operations/example-vars-files/vars-use-s3-blobstore.yml" "-l example-vars-files/vars-enable-backup-restore-s3-unversioned.yml"
 
       # s3 versioned & unversioned, skip-droplets & skip-droplets-and-packages
-      check_interpolation "name: skip-backup-restore-droplets.yml"   "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-s3-blobstore.yml" "-o enable-backup-restore-s3-versioned.yml" "-o skip-backup-restore-droplets.yml"  "-l ${home}/operations/example-vars-files/vars-use-s3-blobstore.yml"
-      check_interpolation "name: skip-backup-restore-droplets-and-packages.yml"   "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-s3-blobstore.yml" "-o enable-backup-restore-s3-versioned.yml" "-o skip-backup-restore-droplets-and-packages.yml"  "-l ${home}/operations/example-vars-files/vars-use-s3-blobstore.yml"
+      check_interpolation "name: skip-backup-restore-droplets.yml (with s3 ver)"   "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-s3-blobstore.yml" "-o enable-backup-restore-s3-versioned.yml" "-o skip-backup-restore-droplets.yml"  "-l ${home}/operations/example-vars-files/vars-use-s3-blobstore.yml"
+      check_interpolation "name: skip-backup-restore-droplets-and-packages.yml (with s3 ver)"   "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-s3-blobstore.yml" "-o enable-backup-restore-s3-versioned.yml" "-o skip-backup-restore-droplets-and-packages.yml"  "-l ${home}/operations/example-vars-files/vars-use-s3-blobstore.yml"
 
-      check_interpolation "name: skip-backup-restore-droplets.yml"   "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-s3-blobstore.yml" "-o enable-backup-restore-s3-unversioned.yml" "-o skip-backup-restore-droplets.yml"  "-l ${home}/operations/example-vars-files/vars-use-s3-blobstore.yml" "-l example-vars-files/vars-enable-backup-restore-s3-unversioned.yml"
-      check_interpolation "name: skip-backup-restore-droplets-and-packages.yml"   "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-s3-blobstore.yml" "-o enable-backup-restore-s3-unversioned.yml" "-o skip-backup-restore-droplets-and-packages.yml"  "-l ${home}/operations/example-vars-files/vars-use-s3-blobstore.yml" "-l example-vars-files/vars-enable-backup-restore-s3-unversioned.yml"
+      check_interpolation "name: skip-backup-restore-droplets.yml (with s3 unver)"   "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-s3-blobstore.yml" "-o enable-backup-restore-s3-unversioned.yml" "-o skip-backup-restore-droplets.yml"  "-l ${home}/operations/example-vars-files/vars-use-s3-blobstore.yml" "-l example-vars-files/vars-enable-backup-restore-s3-unversioned.yml"
+      check_interpolation "name: skip-backup-restore-droplets-and-packages.yml (with s3 unver)"   "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-s3-blobstore.yml" "-o enable-backup-restore-s3-unversioned.yml" "-o skip-backup-restore-droplets-and-packages.yml"  "-l ${home}/operations/example-vars-files/vars-use-s3-blobstore.yml" "-l example-vars-files/vars-enable-backup-restore-s3-unversioned.yml"
 
       # azure
       check_interpolation "name: enable-backup-restore-azure.yml" "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-azure-storage-blobstore.yml" "-o enable-backup-restore-azure.yml" "-l ${home}/operations/example-vars-files/vars-use-azure-storage-blobstore.yml"
       check_interpolation "name: enable-restore-azure-clone.yml"  "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-azure-storage-blobstore.yml" "-o enable-restore-azure-clone.yml"  "-l ${home}/operations/example-vars-files/vars-use-azure-storage-blobstore.yml" "-l example-vars-files/vars-enable-restore-azure-clone.yml"
 
       # azure skip-droplets & skip-droplets-and-packages
-      check_interpolation "name: skip-backup-restore-droplets.yml" "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-azure-storage-blobstore.yml" "-o enable-backup-restore-azure.yml" "-o skip-backup-restore-droplets.yml" "-l ${home}/operations/example-vars-files/vars-use-azure-storage-blobstore.yml"
-      check_interpolation "name: skip-backup-restore-droplets-and-packages.yml" "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-azure-storage-blobstore.yml" "-o enable-backup-restore-azure.yml" "-o skip-backup-restore-droplets-and-packages.yml" "-l ${home}/operations/example-vars-files/vars-use-azure-storage-blobstore.yml"
+      check_interpolation "name: skip-backup-restore-droplets.yml (with azure)" "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-azure-storage-blobstore.yml" "-o enable-backup-restore-azure.yml" "-o skip-backup-restore-droplets.yml" "-l ${home}/operations/example-vars-files/vars-use-azure-storage-blobstore.yml"
+      check_interpolation "name: skip-backup-restore-droplets-and-packages.yml (with azure)" "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-azure-storage-blobstore.yml" "-o enable-backup-restore-azure.yml" "-o skip-backup-restore-droplets-and-packages.yml" "-l ${home}/operations/example-vars-files/vars-use-azure-storage-blobstore.yml"
 
       check_interpolation "name: skip-backup-restore-droplets.yml"  "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-azure-storage-blobstore.yml" "-o enable-restore-azure-clone.yml" "-o skip-backup-restore-droplets.yml" "-l ${home}/operations/example-vars-files/vars-use-azure-storage-blobstore.yml" "-l example-vars-files/vars-enable-restore-azure-clone.yml"
       check_interpolation "name: skip-backup-restore-droplets-and-packages.yml"  "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-azure-storage-blobstore.yml" "-o enable-restore-azure-clone.yml" "-o skip-backup-restore-droplets-and-packages.yml" "-l ${home}/operations/example-vars-files/vars-use-azure-storage-blobstore.yml" "-l example-vars-files/vars-enable-restore-azure-clone.yml"
@@ -34,8 +47,8 @@ test_backup_and_restore_ops() {
       check_interpolation "name: enable-backup-restore-gcs.yml" "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-gcs-blobstore-service-account.yml" "-o enable-backup-restore-gcs.yml" "-l ${home}/operations/example-vars-files/vars-use-gcs-blobstore-service-account.yml" "-l ${home}/operations/backup-and-restore/example-vars-files/vars-enable-backup-restore-gcs.yml"
 
       # gcs skip-droplets & skip-droplets-and-packages
-      check_interpolation "name: skip-backup-restore-droplets.yml" "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-gcs-blobstore-service-account.yml" "-o enable-backup-restore-gcs.yml" "-o skip-backup-restore-droplets.yml" "-l ${home}/operations/example-vars-files/vars-use-gcs-blobstore-service-account.yml" "-l ${home}/operations/backup-and-restore/example-vars-files/vars-enable-backup-restore-gcs.yml"
-      check_interpolation "name: skip-backup-restore-droplets-and-packages.yml" "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-gcs-blobstore-service-account.yml" "-o enable-backup-restore-gcs.yml" "-o skip-backup-restore-droplets-and-packages.yml" "-l ${home}/operations/example-vars-files/vars-use-gcs-blobstore-service-account.yml" "-l ${home}/operations/backup-and-restore/example-vars-files/vars-enable-backup-restore-gcs.yml"
+      check_interpolation "name: skip-backup-restore-droplets.yml (with gcs)" "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-gcs-blobstore-service-account.yml" "-o enable-backup-restore-gcs.yml" "-o skip-backup-restore-droplets.yml" "-l ${home}/operations/example-vars-files/vars-use-gcs-blobstore-service-account.yml" "-l ${home}/operations/backup-and-restore/example-vars-files/vars-enable-backup-restore-gcs.yml"
+      check_interpolation "name: skip-backup-restore-droplets-and-packages.yml (with gcs)" "enable-backup-restore.yml" "-o ${home}/operations/use-external-blobstore.yml" "-o ${home}/operations/use-gcs-blobstore-service-account.yml" "-o enable-backup-restore-gcs.yml" "-o skip-backup-restore-droplets-and-packages.yml" "-l ${home}/operations/example-vars-files/vars-use-gcs-blobstore-service-account.yml" "-l ${home}/operations/backup-and-restore/example-vars-files/vars-enable-backup-restore-gcs.yml"
 
       # nfs
       check_interpolation "name: enable-backup-restore-nfs-broker.yml" "enable-backup-restore.yml" "-o enable-backup-restore-nfs-broker.yml" "-v nfs-broker-database-password=i_am_a_password"
@@ -43,4 +56,75 @@ test_backup_and_restore_ops() {
     popd > /dev/null
   popd > /dev/null
   exit $exit_code
+}
+
+ensure_properties_are_in_sync() {
+  local component=$1
+  local jobname=$2
+  local manifest="$(mktemp)"
+  local operations="${home}/operations"
+
+  set +e
+  interpolate "output: ${manifest}" "-o ${operations}/enable-${component}-volume-service.yml" "-o ${operations}/backup-and-restore/enable-backup-restore.yml" "-o ${home}/operations/backup-and-restore/enable-restore-${component}-broker.yml"
+
+  diff <(bosh int $manifest --path /instance_groups/name=${component}-broker-push/jobs/name=${jobname}/properties) <(bosh int $manifest --path /instance_groups/name=backup-restore/jobs/name=${jobname}/properties)
+  exit_code=$?
+  set -e
+
+  if [ "${exit_code}" == "0" ]; then
+      pass "${jobname} properties in enable ops file and backup-restore ops file are in sync"
+  else
+      fail "${jobname} properties in enable ops file and backup-restore ops file have diverged"
+  fi
+
+  rm $manifest
+  return $exit_code
+}
+
+check_internal_blobstore_properties() {
+  local expected="$1"
+  local selective_opsfile="$2"
+  local output; output="$(mktemp)"
+
+  interpolate "output: ${output}" "-o ${home}/operations/backup-and-restore/enable-backup-restore.yml" "${selective_opsfile}"
+
+  set +e
+  directories_to_backup="$(bosh int "$output" --path /instance_groups/name=singleton-blobstore/jobs/name=blobstore/properties/select_directories_to_backup)"
+  exit_code=$?
+  set -e
+
+  local selective_opsfile="${2:-full blobstore}"
+  if [ "${exit_code}" == "0" ] && [ "$directories_to_backup" == "$expected"  ]; then
+      pass "${selective_opsfile#'-o '}"
+  else
+      fail "${selective_opsfile#'-o '}"
+  fi
+  rm "$output"
+}
+
+ensure_singleton_blobstore_not_templated() {
+  local selective_opsfile="$1"
+  local output; output=$(mktemp)
+  local operations="${home}/operations"
+
+  interpolate "output: ${output}" \
+    "-o ${operations}/use-external-blobstore.yml" \
+    "-o ${operations}/backup-and-restore/enable-backup-restore.yml" \
+    "-o ${operations}/use-s3-blobstore.yml" \
+    "-o ${operations}/backup-and-restore/enable-backup-restore-s3-versioned.yml" \
+    "-l ${operations}/example-vars-files/vars-use-s3-blobstore.yml" \
+    "-o ${operations}/backup-and-restore/${selective_opsfile}"
+
+  set +e
+  bosh int "$output" --path /instance_groups/name=singleton-blobstore &> /dev/null
+  code=$?
+  set -e
+
+  if [ "${code}" != "0" ]; then
+      exit_code=0
+      pass "${selective_opsfile} does not render 'singleton-blobstore' instance_group"
+  else
+      fail "${selective_opsfile} does render 'singleton-blobstore' instance_group"
+  fi
+  rm "$output"
 }

--- a/units/tests/backup_and_restore_test/operations_test.go
+++ b/units/tests/backup_and_restore_test/operations_test.go
@@ -1,10 +1,25 @@
 package backupandrestore_test
 
 import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"path/filepath"
 	"testing"
 
 	"github.com/cf-deployment/units/helpers"
 )
+
+type manifest struct {
+	InstanceGroups []struct {
+		Name string
+		Jobs []struct {
+			Name       string
+			Properties struct {
+				SelectDirectoriesToBackup []string `yaml:"select_directories_to_backup"`
+			}
+		}
+	} `yaml:"instance_groups"`
+}
 
 const testDirectory = "operations/backup-and-restore"
 
@@ -107,4 +122,70 @@ func TestBackupAndRestore(t *testing.T) {
 	suite.EnsureTestCoverage(t)
 	suite.ReadmeTest(t)
 	suite.InterpolateTest(t)
+
+	operationsSubDirectory := filepath.Join(cfDeploymentHome, "operations")
+	manifestPath := filepath.Join(cfDeploymentHome, "cf-deployment.yml")
+
+	t.Run("skip droplets", func(t *testing.T) {
+		manifest, err := boshInterpolateAndUnmarshal(
+			operationsSubDirectory,
+			manifestPath,
+			"-o", "backup-and-restore/enable-backup-restore.yml", "-o", "backup-and-restore/skip-backup-restore-droplets.yml",
+		)
+
+		if err != nil {
+			t.Errorf("failed to bosh interpolate: %v", err)
+		}
+
+		dirs := findDirectoriesToBackup(manifest)
+		if !(len(dirs) == 2 && dirs[0] == "buildpacks" && dirs[1] == "packages") {
+			t.Error("Ops file skip-backup-restore-droplets.yml is failing to remove droplets directories from select_directories_to_backup")
+		}
+	})
+
+	t.Run("skip droplets and packages", func(t *testing.T) {
+		manifest, err := boshInterpolateAndUnmarshal(
+			operationsSubDirectory,
+			manifestPath,
+			"-o", "backup-and-restore/enable-backup-restore.yml", "-o", "backup-and-restore/skip-backup-restore-droplets-and-packages.yml",
+		)
+
+		if err != nil {
+			t.Errorf("failed to bosh interpolate: %v", err)
+		}
+
+		dirs := findDirectoriesToBackup(manifest)
+		if !(len(dirs) == 1 && dirs[0] == "buildpacks") {
+			t.Error("Ops file skip-backup-restore-droplets-and-packages.yml is failing to remove droplets and packages directories from select_directories_to_backup")
+		}
+	})
+}
+
+func boshInterpolateAndUnmarshal(opsSubDir, manifestPath string, args ...string) (manifest, error) {
+	boshInterpolateOutput, err := helpers.BoshInterpolate(opsSubDir, manifestPath, "", args...)
+
+	if err != nil {
+		return manifest{}, fmt.Errorf("bosh interpolate error: %v", err)
+	}
+
+	var m manifest
+	err = yaml.Unmarshal(boshInterpolateOutput, &m)
+	if err != nil {
+		return manifest{}, fmt.Errorf("failed to unmarshal bosh interpolate output: %v", err)
+	}
+
+	return m, nil
+}
+
+func findDirectoriesToBackup(manifest manifest) []string {
+	for _, instanceGroup := range manifest.InstanceGroups {
+		if instanceGroup.Name == "singleton-blobstore" {
+			for _, job := range instanceGroup.Jobs {
+				if job.Name == "blobstore" {
+					return job.Properties.SelectDirectoriesToBackup
+				}
+			}
+		}
+	}
+	return []string{}
 }

--- a/units/tests/backup_and_restore_test/operations_test.go
+++ b/units/tests/backup_and_restore_test/operations_test.go
@@ -9,28 +9,9 @@ import (
 const testDirectory = "operations/backup-and-restore"
 
 var backupAndRestoreTests = map[string]helpers.OpsFileTestParams{
+	//internal
 	"enable-backup-restore.yml": {
 		Ops: []string{"enable-backup-restore.yml"},
-	},
-	"enable-backup-restore-azure.yml": {
-		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-azure-storage-blobstore.yml", "enable-backup-restore-azure.yml"},
-		VarsFiles: []string{"../example-vars-files/vars-use-azure-storage-blobstore.yml"},
-	},
-	"enable-restore-azure-clone.yml": {
-		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-azure-storage-blobstore.yml", "enable-restore-azure-clone.yml"},
-		VarsFiles: []string{"../example-vars-files/vars-use-azure-storage-blobstore.yml", "example-vars-files/vars-enable-restore-azure-clone.yml"},
-	},
-	"enable-backup-restore-gcs.yml": {
-		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-gcs-blobstore-service-account.yml", "enable-backup-restore-gcs.yml"},
-		VarsFiles: []string{"../example-vars-files/vars-use-gcs-blobstore-service-account.yml", "example-vars-files/vars-enable-backup-restore-gcs.yml"},
-	},
-	"enable-backup-restore-s3-unversioned.yml": {
-		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-s3-blobstore.yml", "enable-backup-restore-s3-unversioned.yml"},
-		VarsFiles: []string{"../example-vars-files/vars-use-s3-blobstore.yml", "example-vars-files/vars-enable-backup-restore-s3-unversioned.yml"},
-	},
-	"enable-backup-restore-s3-versioned.yml": {
-		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-s3-blobstore.yml", "enable-backup-restore-s3-versioned.yml"},
-		VarsFiles: []string{"../example-vars-files/vars-use-s3-blobstore.yml"},
 	},
 	"skip-backup-restore-droplets.yml": {
 		Ops: []string{"enable-backup-restore.yml", "skip-backup-restore-droplets.yml"},
@@ -38,6 +19,78 @@ var backupAndRestoreTests = map[string]helpers.OpsFileTestParams{
 	"skip-backup-restore-droplets-and-packages.yml": {
 		Ops: []string{"enable-backup-restore.yml", "skip-backup-restore-droplets-and-packages.yml"},
 	},
+
+	//azure
+	"enable-backup-restore-azure.yml": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-azure-storage-blobstore.yml", "enable-backup-restore-azure.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-azure-storage-blobstore.yml"},
+	},
+	"enable-backup-restore-azure.yml with skip droplets": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-azure-storage-blobstore.yml", "enable-backup-restore-azure.yml", "skip-backup-restore-droplets.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-azure-storage-blobstore.yml"},
+	},
+	"enable-backup-restore-azure.yml with skip droplets and packages": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-azure-storage-blobstore.yml", "enable-backup-restore-azure.yml", "skip-backup-restore-droplets-and-packages.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-azure-storage-blobstore.yml"},
+	},
+
+	//azure-clone
+	"enable-restore-azure-clone.yml": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-azure-storage-blobstore.yml", "enable-restore-azure-clone.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-azure-storage-blobstore.yml", "example-vars-files/vars-enable-restore-azure-clone.yml"},
+	},
+	"enable-restore-azure-clone.yml with skip droplets": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-azure-storage-blobstore.yml", "enable-restore-azure-clone.yml", "skip-backup-restore-droplets.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-azure-storage-blobstore.yml", "example-vars-files/vars-enable-restore-azure-clone.yml"},
+	},
+	"enable-restore-azure-clone.yml with skip droplets and packages": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-azure-storage-blobstore.yml", "enable-restore-azure-clone.yml", "skip-backup-restore-droplets-and-packages.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-azure-storage-blobstore.yml", "example-vars-files/vars-enable-restore-azure-clone.yml"},
+	},
+
+	//gcs
+	"enable-backup-restore-gcs.yml": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-gcs-blobstore-service-account.yml", "enable-backup-restore-gcs.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-gcs-blobstore-service-account.yml", "example-vars-files/vars-enable-backup-restore-gcs.yml"},
+	},
+	"enable-backup-restore-gcs.yml with skip droplets": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-gcs-blobstore-service-account.yml", "enable-backup-restore-gcs.yml", "skip-backup-restore-droplets.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-gcs-blobstore-service-account.yml", "example-vars-files/vars-enable-backup-restore-gcs.yml"},
+	},
+	"enable-backup-restore-gcs.yml with skip droplets and packages": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-gcs-blobstore-service-account.yml", "enable-backup-restore-gcs.yml", "skip-backup-restore-droplets-and-packages.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-gcs-blobstore-service-account.yml", "example-vars-files/vars-enable-backup-restore-gcs.yml"},
+	},
+
+	//s3-unversioned
+	"enable-backup-restore-s3-unversioned.yml": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-s3-blobstore.yml", "enable-backup-restore-s3-unversioned.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-s3-blobstore.yml", "example-vars-files/vars-enable-backup-restore-s3-unversioned.yml"},
+	},
+	"enable-backup-restore-s3-unversioned.yml with skip droplets": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-s3-blobstore.yml", "enable-backup-restore-s3-unversioned.yml", "skip-backup-restore-droplets.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-s3-blobstore.yml", "example-vars-files/vars-enable-backup-restore-s3-unversioned.yml"},
+	},
+	"enable-backup-restore-s3-unversioned.yml with skip droplets and packages": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-s3-blobstore.yml", "enable-backup-restore-s3-unversioned.yml", "skip-backup-restore-droplets-and-packages.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-s3-blobstore.yml", "example-vars-files/vars-enable-backup-restore-s3-unversioned.yml"},
+	},
+
+	//s3-versioned
+	"enable-backup-restore-s3-versioned.yml": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-s3-blobstore.yml", "enable-backup-restore-s3-versioned.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-s3-blobstore.yml"},
+	},
+	"enable-backup-restore-s3-versioned.yml with skip droplets": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-s3-blobstore.yml", "enable-backup-restore-s3-versioned.yml", "skip-backup-restore-droplets.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-s3-blobstore.yml"},
+	},
+	"enable-backup-restore-s3-versioned.yml with skip droplets and packages": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-s3-blobstore.yml", "enable-backup-restore-s3-versioned.yml", "skip-backup-restore-droplets-and-packages.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-s3-blobstore.yml"},
+	},
+
+	//nfs-broker
 	"enable-backup-restore-nfs-broker.yml": {
 		Ops:  []string{"enable-backup-restore.yml", "enable-backup-restore-nfs-broker.yml"},
 		Vars: []string{"nfs-broker-database-password=i_am_a_password"},

--- a/units/tests/backup_and_restore_test/operations_test.go
+++ b/units/tests/backup_and_restore_test/operations_test.go
@@ -9,17 +9,20 @@ import (
 const testDirectory = "operations/backup-and-restore"
 
 var backupAndRestoreTests = map[string]helpers.OpsFileTestParams{
+	"enable-backup-restore.yml": {
+		Ops: []string{"enable-backup-restore.yml"},
+	},
 	"enable-backup-restore-azure.yml": {
 		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-azure-storage-blobstore.yml", "enable-backup-restore-azure.yml"},
 		VarsFiles: []string{"../example-vars-files/vars-use-azure-storage-blobstore.yml"},
 	},
+	"enable-restore-azure-clone.yml": {
+		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-azure-storage-blobstore.yml", "enable-restore-azure-clone.yml"},
+		VarsFiles: []string{"../example-vars-files/vars-use-azure-storage-blobstore.yml", "example-vars-files/vars-enable-restore-azure-clone.yml"},
+	},
 	"enable-backup-restore-gcs.yml": {
 		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-gcs-blobstore-service-account.yml", "enable-backup-restore-gcs.yml"},
 		VarsFiles: []string{"../example-vars-files/vars-use-gcs-blobstore-service-account.yml", "example-vars-files/vars-enable-backup-restore-gcs.yml"},
-	},
-	"enable-backup-restore-nfs-broker.yml": {
-		Ops:  []string{"enable-backup-restore.yml", "enable-backup-restore-nfs-broker.yml"},
-		Vars: []string{"nfs-broker-database-password=i_am_a_password"},
 	},
 	"enable-backup-restore-s3-unversioned.yml": {
 		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-s3-blobstore.yml", "enable-backup-restore-s3-unversioned.yml"},
@@ -29,16 +32,15 @@ var backupAndRestoreTests = map[string]helpers.OpsFileTestParams{
 		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-s3-blobstore.yml", "enable-backup-restore-s3-versioned.yml"},
 		VarsFiles: []string{"../example-vars-files/vars-use-s3-blobstore.yml"},
 	},
-	"enable-backup-restore.yml": {},
-	"enable-restore-azure-clone.yml": {
-		Ops:       []string{"enable-backup-restore.yml", "../use-external-blobstore.yml", "../use-azure-storage-blobstore.yml", "enable-restore-azure-clone.yml"},
-		VarsFiles: []string{"../example-vars-files/vars-use-azure-storage-blobstore.yml", "example-vars-files/vars-enable-restore-azure-clone.yml"},
-	},
 	"skip-backup-restore-droplets.yml": {
 		Ops: []string{"enable-backup-restore.yml", "skip-backup-restore-droplets.yml"},
 	},
 	"skip-backup-restore-droplets-and-packages.yml": {
 		Ops: []string{"enable-backup-restore.yml", "skip-backup-restore-droplets-and-packages.yml"},
+	},
+	"enable-backup-restore-nfs-broker.yml": {
+		Ops:  []string{"enable-backup-restore.yml", "enable-backup-restore-nfs-broker.yml"},
+		Vars: []string{"nfs-broker-database-password=i_am_a_password"},
 	},
 }
 


### PR DESCRIPTION
### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes

### WHAT is this change about?

Fixing bug on our skipping droplets/packages ops file that template the `singleton-blobstore` instance group even when external blobstore is enabled. 

### WHY is this change being made (What problem is being addressed)?

Will create extra VMs unnecessarily for user when using skip droplets/packages ops files

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/164664190

### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### How should this change be described in cf-deployment release notes?

Fix bug that skipping droplets/packages for backup will always template singleton blobstore.

### Does this PR introduce a breaking change?

Nope

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [x] NO, decreases

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@gmrodgers
@glestaris 
@cloudfoundry/bosh-backup-and-restore-team 
