### PR TITLE
Update use-alicloud-oss-blobstore.yml

### DIFF
--- a/operations/use-alicloud-oss-blobstore.yml
+++ b/operations/use-alicloud-oss-blobstore.yml
@@ -4,53 +4,68 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/fog_connection
   error: "Please apply 'use-external-blobstore.yml' before applying 'use-alicloud-oss-blobstore.yml'."
-  value: &blobstore-properties
+  value: &buildpacks-blobstore-properties
     provider: aliyun
     aliyun_accesskey_id: ((blobstore_access_key_id))
     aliyun_accesskey_secret: ((blobstore_secret_access_key))
     aliyun_region_id: ((blobstore_region))
-    aliyun_oss_bucket: ((blobstore_bucket_name))
+    aliyun_oss_bucket: ((buildpack_directory_key))
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/fog_connection
-  value: *blobstore-properties
+  value: &droplets-blobstore-properties
+    provider: aliyun
+    aliyun_accesskey_id: ((blobstore_access_key_id))
+    aliyun_accesskey_secret: ((blobstore_secret_access_key))
+    aliyun_region_id: ((blobstore_region))
+    aliyun_oss_bucket: ((droplet_directory_key))
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/fog_connection
-  value: *blobstore-properties
+  value: &packages-blobstore-properties
+    provider: aliyun
+    aliyun_accesskey_id: ((blobstore_access_key_id))
+    aliyun_accesskey_secret: ((blobstore_secret_access_key))
+    aliyun_region_id: ((blobstore_region))
+    aliyun_oss_bucket: ((app_package_directory_key))
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/fog_connection
-  value: *blobstore-properties
+  value: &resources-blobstore-properties
+    provider: aliyun
+    aliyun_accesskey_id: ((blobstore_access_key_id))
+    aliyun_accesskey_secret: ((blobstore_secret_access_key))
+    aliyun_region_id: ((blobstore_region))
+    aliyun_oss_bucket: ((resource_directory_key))
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/fog_connection
-  value: *blobstore-properties
+  value: *buildpacks-blobstore-properties
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/fog_connection
-  value: *blobstore-properties
+  value: *droplets-blobstore-properties
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/fog_connection
-  value: *blobstore-properties
+  value: *packages-blobstore-properties
 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/fog_connection
-  value: *blobstore-properties
+  value: *resources-blobstore-properties
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/fog_connection
-  value: *blobstore-properties
+  value: *buildpacks-blobstore-properties
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/fog_connection
-  value: *blobstore-properties
+  value: *droplets-blobstore-properties
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/fog_connection
-  value: *blobstore-properties
+  value: *packages-blobstore-properties
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/fog_connection
-  value: *blobstore-properties
+  value: *resources-blobstore-properties


### PR DESCRIPTION
Enable usage of multiple buckets for fog aliyun

### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes

### WHAT is this change about?

Enables fog aliyun to operate with multiple buckets as it has already done for bits aliyun.

### WHY is this change being made (What problem is being addressed)?

Bits service for AliCloud utilizes multiple buckets to persist the files. This approach is totally different from fog configuration, which accepts a single bucket only to persist all kinds of resources. This PR aligns fog configuration with bits accepted configuration to enable a smooth transition from bits to fog adapter.
The reason for that is because the bits service is going to be in maintenance mode and deprecated from CF.


### Please provide contextual information.

Fog configuration:
https://github.com/cloudfoundry/cf-deployment/blob/master/operations/use-alicloud-oss-blobstore.yml#L12

Bits cofiguration:
https://github.com/cloudfoundry/cf-deployment/blob/master/operations/bits-service/configure-bits-service-alicloud-oss.yml#L5


### Has a cf-deployment including this change passed our [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### How should this change be described in cf-deployment release notes?

_Something brief that conveys the change and is written with the Operator audience in mind.
See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

### Does this PR introduce a breaking change?

Yes, the old fog configuration may stop work.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!


