### PR TITLE
Add ops-file for enabling route integrity with nginx on windows 2019.

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -18,7 +18,7 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 | [`add-deployment-updater-external-db.yml`](add-deployment-updater-external-db.yml) |  **"DEPRECATED because it is inlined in to `cf-deployment.yml`"** | Requires `add-deployment-updater.yml` and `use-external-dbs.yml` | **NO** |
 | [`add-deployment-updater-postgres.yml`](add-deployment-updater-postgres.yml) |  **"DEPRECATED because it is inlined in to `cf-deployment.yml`"** | Requires `add-deployment-updater.yml` | **NO** |
 | [`add-deployment-updater.yml`](add-deployment-updater.yml) |  **"DEPRECATED because it is inlined in to `cf-deployment.yml`"** | | **NO** |
-| [`add-metric-store.yml`](add-metric-store.yml) |  *Add Metric Store node for persistence of metrics from Loggregator** | | **NO** |
+| [`add-metric-store.yml`](add-metric-store.yml) |  **Add Metric Store node for persistence of metrics from Loggregator** | | **NO** |
 | [`add-syslog-agent.yml`](add-syslog-agent.yml) |  Add agent to all vms for the purpose of egressing application logs to syslog | | **YES** |
 | [`add-syslog-agent-windows1803.yml`](add-syslog-agent-windows1803.yml) |  Add agent to windows1803 Diego cells for the purpose of egressing application logs to syslog | Requires `../windows1803-cell.yml`, `add-syslog-agent.yml` and `deploy-forwarder-agent.yml` | **NO** |
 | [`add-system-metrics-agent.yml`](add-system-metrics-agent.yml) | Add agent to all vms with the purpose of egressing system metrics | | **NO** |
@@ -29,6 +29,7 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 | [`enable-iptables-logger.yml`](enable-iptables-logger.yml) | Enables iptables logger. | | **YES** |
 | [`enable-mysql-tls.yml`](enable-mysql-tls.yml) | **DEPRECATED because PXC is now the default database in cf-deployment** Enables TLS on the database job, and secures all client database connections. | | **NO** |
 | [`enable-nfs-volume-service-credhub.yml`](enable-nfs-volume-service-credhub.yml) | **DEPRECATED because it is inlined into `enable-nfs-volume-service.yml`** Enables credhub integration for NFS volume services | | **NO** |
+| [`enable-nginx-routing-integrity-windows2019.yml`](enable-nginx-routing-integrity-windows2019.yml) | Enables container proxy on the Windows 2019 Diego Cell `rep` and configures gorouter to opt into TLS-enabled connections to the backend. | **Warning: this is very experimental** Requires `../windows1803-cell.yml` | **NO** |
 | [`enable-oci-phase-1.yml`](enable-oci-phase-1.yml) | Configure CC, Diego, and Garden to create app and task containers more efficiently via OCI image specs. | This ops file **cannot** be deployed in conjunction with `rootless-containers.yml`. | **NO** |
 | [`enable-routing-integrity-windows1803.yml`](enable-routing-integrity-windows1803.yml) | Enables container proxy on the Windows 1803 Diego Cell `rep` and configures gorouter to opt into TLS-enabled connections to the backend. | **Warning: this is very experimental** Requires `../windows1803-cell.yml` | **NO** |
 | [`enable-routing-integrity-windows2016.yml`](enable-routing-integrity-windows2016.yml) | Enables container proxy on the Windows 2016 Diego Cell `rep` and configures gorouter to opt into TLS-enabled connections to the backend. | **Warning: this is very experimental** Requires `../windows2016-cell.yml` | **NO** |

--- a/operations/experimental/enable-nginx-routing-integrity-windows2019.yml
+++ b/operations/experimental/enable-nginx-routing-integrity-windows2019.yml
@@ -28,5 +28,5 @@
 - path: /releases/name=envoy-nginx?
   type: replace
   value:
-    name: envoy
+    name: envoy-nginx
     version: latest

--- a/operations/experimental/enable-nginx-routing-integrity-windows2019.yml
+++ b/operations/experimental/enable-nginx-routing-integrity-windows2019.yml
@@ -29,4 +29,6 @@
   type: replace
   value:
     name: envoy-nginx
-    version: latest
+    version: 0.3.0
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/envoy-nginx-release?v=0.3.0
+    sha1: 4b11ceb0e575e77d7cfcea755c456f888579641a

--- a/operations/experimental/enable-nginx-routing-integrity-windows2019.yml
+++ b/operations/experimental/enable-nginx-routing-integrity-windows2019.yml
@@ -1,0 +1,32 @@
+---
+- type: replace
+  path: /instance_groups/name=windows2019-cell/jobs/name=rep_windows/properties/containers?/proxy/enabled
+  value: true
+
+- type: replace
+  path: /instance_groups/name=windows2019-cell/jobs/name=rep_windows/properties/containers?/proxy/require_and_verify_client_certificates
+  value: true
+
+- type: replace
+  path: /instance_groups/name=windows2019-cell/jobs/name=rep_windows/properties/containers?/proxy/trusted_ca_certificates
+  value:
+  - ((gorouter_backend_tls.ca))
+  - ((ssh_proxy_backends_tls.ca))
+
+- type: replace
+  path: /instance_groups/name=windows2019-cell/jobs/name=rep_windows/properties/containers?/proxy/verify_subject_alt_name
+  value:
+  - gorouter.service.cf.internal
+  - ssh-proxy.service.cf.internal
+
+- type: replace
+  path: /instance_groups/name=windows2019-cell/jobs/-
+  value:
+    name: envoy_windows
+    release: envoy-nginx
+
+- path: /releases/name=envoy-nginx?
+  type: replace
+  value:
+    name: envoy
+    version: latest

--- a/scripts/test-experimental.sh
+++ b/scripts/test-experimental.sh
@@ -46,6 +46,7 @@ test_experimental_ops() {
 
       check_interpolation "name: windows-component-syslog-ca.yml" "windows-enable-component-syslog.yml" "-o windows-component-syslog-ca.yml" "-l ${home}/operations/addons/example-vars-files/vars-enable-component-syslog.yml"
       check_interpolation "name: windows-enable-component-syslog.yml" "windows-enable-component-syslog.yml" "-l ${home}/operations/addons/example-vars-files/vars-enable-component-syslog.yml"
+      check_interpolation "name: enable-nginx-routing-integrity-windows2019.yml" "../windows2019-cell.yml" "-o enable-nginx-routing-integrity-windows2019.yml"
       check_interpolation "name: enable-routing-integrity-windows1803.yml" "../windows1803-cell.yml" "-o enable-routing-integrity-windows1803.yml"
       check_interpolation "name: enable-routing-integrity-windows2016.yml" "../windows2016-cell.yml" "-o enable-routing-integrity-windows2016.yml"
 

--- a/units/tests/experimental_test/operations_test.go
+++ b/units/tests/experimental_test/operations_test.go
@@ -34,6 +34,9 @@ var experimentalTests = map[string]helpers.OpsFileTestParams{
 	"enable-mysql-tls.yml":                     {},
 	"enable-nfs-volume-service-credhub.yml":    {},
 	"enable-oci-phase-1.yml":                   {},
+	"enable-nginx-routing-integrity-windows2019.yml": {
+		Ops: []string{"../windows2019-cell.yml", "enable-nginx-routing-integrity-windows2019.yml"},
+	},
 	"enable-routing-integrity-windows1803.yml": {
 		Ops: []string{"../windows1803-cell.yml", "enable-routing-integrity-windows1803.yml"},
 	},


### PR DESCRIPTION
### Is this a PR to [the develop branch](https://github.com/cloudfoundry/cf-deployment/tree/develop) of cf-deployment?

Yes

### WHAT is this change about?

Experimental ops-file to enable route integrity using nginx on Windows 2019 cells.

### WHY is this change being made (What problem is being addressed)?

Users want route integrity.

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/167029192


### How should this change be described in cf-deployment release notes?

New experimental ops-file. Enable route integrity using nginx in place of envoy on Windows 2019 diego cells.

### Does this PR introduce a breaking change?

No


### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

https://bosh.io/releases/github.com/cloudfoundry-incubator/envoy-nginx-release?all=1 

- [x] YES - please specify
- [ ] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [x] NO

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

