### PR TITLE
feat(alibaba cloud): add a new oss blobstore manifest for multi bucket

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -26,6 +26,7 @@ This is the README for Ops-files. To learn more about `cf-deployment`, go to the
 | [`use-swift-blobstore.yml`](use-swift-blobstore.yml) | Replaces local WebDAV blobstore with OpenStack swift blobstore. Used for deploying Cloud Foundry on OpenStack with BOSH | Requires `use-external-blobstore.yml`. Introduces [new variables](example-vars-files/vars-use-swift-blobstore.yml) for OpenStack credentials and directory names. If you plan using the [Swift ops file](use-swift-blobstore.yml) to enable Swift as blobstore for the Cloud Controller, you should also run the [Swift extension](https://github.com/cloudfoundry-incubator/cf-openstack-validator/tree/master/extensions/object_storage). | **NO** |
 | **Alibaba Cloud** | | **\* Not validated or supported by the Release Integration team** | |
 | [`use-alicloud-oss-blobstore.yml`](use-alicloud-oss-blobstore.yml) | Configures external blobstore to use Alibaba Cloud OSS blobstore. | Requires `use-external-blobstore.yml`. Introduces [new variables](example-vars-files/vars-use-alicloud-oss-blobstore.yml) for oss credentials and bucket names.| **NO** |
+| [`use-alicloud-oss-blobstore-to-multi-bucket.yml`](use-alicloud-oss-blobstore-to-multi-bucket.yml) | Configures external blobstore to use Alibaba Cloud OSS blobstore. Each blobstore is in one alone OSS bucket. | Requires `use-external-blobstore.yml`. Introduces [new variables](example-vars-files/vars-use-alicloud-oss-blobstore.yml) for oss credentials and bucket names.| **NO** |
 
 
 ## Feature-based Ops-files

--- a/operations/example-vars-files/vars-use-alicloud-oss-blobstore-to-multi-bucket.yml
+++ b/operations/example-vars-files/vars-use-alicloud-oss-blobstore-to-multi-bucket.yml
@@ -1,0 +1,8 @@
+blobstore_region: cn-hangzhou
+blobstore_endpoint: oss-cn-hangzhou.aliyuncs.com
+blobstore_access_key_id: example-access-key-id
+blobstore_secret_access_key: example-secret-access-key
+app_package_directory_key: example-app-package-directory-key
+buildpack_directory_key: example-buildpack-directory-key
+droplet_directory_key: example-droplet-directory-key
+resource_directory_key: example-resource-directory-key

--- a/operations/use-alicloud-oss-blobstore-to-multi-bucket.yml
+++ b/operations/use-alicloud-oss-blobstore-to-multi-bucket.yml
@@ -1,0 +1,71 @@
+---
+# Note: Capi release version 1.61.0 or more is required to use Alibaba Cloud OSS as CF blobstore.
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/fog_connection
+  error: "Please apply 'use-external-blobstore.yml' before applying 'use-alicloud-oss-blobstore-to-multi-bucket.yml'."
+  value: &buildpacks-blobstore-properties
+    provider: aliyun
+    aliyun_accesskey_id: ((blobstore_access_key_id))
+    aliyun_accesskey_secret: ((blobstore_secret_access_key))
+    aliyun_region_id: ((blobstore_region))
+    aliyun_oss_bucket: ((buildpack_directory_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/fog_connection
+  value: &droplets-blobstore-properties
+    provider: aliyun
+    aliyun_accesskey_id: ((blobstore_access_key_id))
+    aliyun_accesskey_secret: ((blobstore_secret_access_key))
+    aliyun_region_id: ((blobstore_region))
+    aliyun_oss_bucket: ((droplet_directory_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/fog_connection
+  value: &packages-blobstore-properties
+    provider: aliyun
+    aliyun_accesskey_id: ((blobstore_access_key_id))
+    aliyun_accesskey_secret: ((blobstore_secret_access_key))
+    aliyun_region_id: ((blobstore_region))
+    aliyun_oss_bucket: ((app_package_directory_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/fog_connection
+  value: &resources-blobstore-properties
+    provider: aliyun
+    aliyun_accesskey_id: ((blobstore_access_key_id))
+    aliyun_accesskey_secret: ((blobstore_secret_access_key))
+    aliyun_region_id: ((blobstore_region))
+    aliyun_oss_bucket: ((resource_directory_key))
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/fog_connection
+  value: *buildpacks-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/fog_connection
+  value: *droplets-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/fog_connection
+  value: *packages-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/fog_connection
+  value: *resources-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/fog_connection
+  value: *buildpacks-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/fog_connection
+  value: *droplets-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/fog_connection
+  value: *packages-blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/fog_connection
+  value: *resources-blobstore-properties

--- a/scripts/test-operations.sh
+++ b/scripts/test-operations.sh
@@ -44,6 +44,7 @@ test_standard_ops() {
       check_interpolation "stop-skipping-tls-validation.yml"
 
       check_interpolation "name: use-alicloud-oss-blobstore.yml" "use-external-blobstore.yml -o use-alicloud-oss-blobstore.yml -l example-vars-files/vars-use-alicloud-oss-blobstore.yml"
+      check_interpolation "name: use-alicloud-oss-blobstore-to-multi-bucket.yml" "use-external-blobstore.yml -o use-alicloud-oss-blobstore-to-multi-bucket.yml -l example-vars-files/vars-use-alicloud-oss-blobstore-to-multi-bucket.yml"
       check_interpolation "name: use-azure-storage-blobstore.yml" "use-external-blobstore.yml -o use-azure-storage-blobstore.yml -l example-vars-files/vars-use-azure-storage-blobstore.yml"
       check_interpolation "use-blobstore-cdn.yml" "-l example-vars-files/vars-use-blobstore-cdn.yml"
       check_interpolation "use-compiled-releases.yml"

--- a/units/tests/standard_test/operations_test.go
+++ b/units/tests/standard_test/operations_test.go
@@ -50,6 +50,10 @@ var standardTests = map[string]helpers.OpsFileTestParams{
 		Ops:       []string{"use-external-blobstore.yml", "use-alicloud-oss-blobstore.yml"},
 		VarsFiles: []string{"example-vars-files/vars-use-alicloud-oss-blobstore.yml"},
 	},
+	"use-alicloud-oss-blobstore-to-multi-bucket.yml": {
+		Ops:       []string{"use-external-blobstore.yml", "use-alicloud-oss-blobstore-to-multi-bucket.yml"},
+		VarsFiles: []string{"example-vars-files/vars-use-alicloud-oss-blobstore-to-multi-bucket.yml"},
+	},
 	"use-azure-storage-blobstore.yml": {
 		Ops:       []string{"use-external-blobstore.yml", "use-azure-storage-blobstore.yml"},
 		VarsFiles: []string{"example-vars-files/vars-use-azure-storage-blobstore.yml"},


### PR DESCRIPTION
This PR aims to expand the alibaba cloud oss blobstore bucket to multiple.

### WHAT is this change about?

Enables fog aliyun to operate with multiple buckets as it has already done for bits aliyun.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Bits service for AliCloud utilizes multiple buckets to persist the files. This approach is totally different from fog configuration, which accepts a single bucket only to persist all kinds of resources. This PR aligns fog configuration with bits accepted configuration to enable a smooth transition from bits to fog adapter.
The reason for that is because the bits service is going to be in maintenance mode and deprecated from CF.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please see definition of breaking change below

- [ ] YES - please specify
- [x] NO

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

Alibaba Cloud
