### PR TITLE
Update datadog-firehose-nozzle-release to latest

### DIFF
--- a/operations/test/add-datadog-firehose-nozzle.yml
+++ b/operations/test/add-datadog-firehose-nozzle.yml
@@ -50,6 +50,6 @@
   path: /releases/-
   value:
     name: datadog-firehose-nozzle
-    url: https://bosh.io/d/github.com/DataDog/datadog-firehose-nozzle-release?v=68
-    version: 68
-    sha1: 88f4d0d66a6e792c486ed26237b15b0ec4c95150
+    url: https://bosh.io/d/github.com/DataDog/datadog-firehose-nozzle-release?v=74
+    version: 74
+    sha1: 574a275a644f9496be7d1d77cb9a50d5a344b477


### PR DESCRIPTION
### WHAT is this change about?

Update `datadog-firehose-nozzle-release` to latest (version `74`). We saw metrics not being sent to DataDog with the `develop` and `release-candidate` branches of `cf-deployment.

### Please provide any contextual information.

- Diego backlog story: https://www.pivotaltracker.com/story/show/167622640

### Does this PR introduce a breaking change? Please see definition of breaking change below

- [ ] YES - please specify
- [x] NO

### How should this change be described in cf-deployment release notes?

This change should be documented in the section of the release notes that notes down updated releases/stemcells.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cloudfoundry/cf-diego 
