### PR TITLE
Enable TLS to external policy server by default

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -909,7 +909,8 @@ instance_groups:
             script_path: "/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng_health_check"
             timeout: 6s
         - name: policy-server
-          port: 4002
+          tls_port: 4002
+          server_cert_domain_san: "api.((system_domain))"
           registration_interval: 20s
           uris:
           - api.((system_domain))/networking
@@ -964,6 +965,7 @@ instance_groups:
       uaa_client_secret: ((uaa_clients_network_policy_secret))
       uaa_ca: ((uaa_ssl.ca))
       enable_space_developer_self_service: true
+      enable_tls: true
       database:
         type: mysql
         username: network_policy
@@ -973,6 +975,8 @@ instance_groups:
         name: network_policy
         ca_cert: "((mysql_server_certificate.ca))"
         require_ssl: true
+      server_cert: ((network_policy_server_external.certificate))
+      server_key: ((network_policy_server_external.private_key))
   - name: policy-server-internal
     release: cf-networking
     properties:
@@ -1227,6 +1231,7 @@ instance_groups:
           ((diego_instance_identity_ca.ca))
           ((cc_tls.ca))
           ((uaa_ssl.ca))
+          ((network_policy_server_external.ca))
         backends:
           cert_chain: ((gorouter_backend_tls.certificate))
           private_key: ((gorouter_backend_tls.private_key))
@@ -1707,6 +1712,15 @@ variables:
   options:
     is_ca: true
     common_name: networkPolicyCA
+- name: network_policy_server_external
+  type: certificate
+  options:
+    ca: network_policy_ca
+    common_name: "api.((system_domain))"
+    alternative_names:
+    - "api.((system_domain))"
+    extended_key_usage:
+    - server_auth
 - name: network_policy_server
   type: certificate
   options:


### PR DESCRIPTION
### WHAT is this change about?

As part of the initiative to encrypt all platform traffic we're adding TLS for the external policy server API. See [#167305073](https://www.pivotaltracker.com/story/show/167305073) for more details.

### Please provide any contextual information.

Networking Story: [#167305073](https://www.pivotaltracker.com/story/show/167305073)

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

It has passed the relevant networking acceptance tests.

### Does this PR introduce a breaking change? Please see definition of breaking change below

- [ ] YES - please specify
- [x] NO

### How should this change be described in cf-deployment release notes?

Traffic between gorouter and the external policy server api is now over TLS by default

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@angelachin @KauzClay @adobley @keshav-pivotal
