### PR TITLE
Removing credhub.authentication.uaa.verification_key

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1598,7 +1598,6 @@ instance_groups:
             ca_certs:
             - ((uaa_ssl.ca))
             url: https://uaa.service.cf.internal:8443
-            verification_key: ((uaa_jwt_signing_key.public_key))
         authorization:
           acls:
             enabled: true


### PR DESCRIPTION
### WHAT is this change about?

Removing credhub.authentication.uaa.verification_key as it is obsolete and was removed over 1 year ago in credhub  https://github.com/pivotal-cf/credhub-release/commit/245fb799d137b170ffb45a04415e1351e56417ad

### Please provide any contextual information.

Cleanup for cf-deployment

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please see definition of breaking change below

- [ ] YES - please specify
- [x] NO

as it is unused by credhub and just a leftover to clean up.

### How should this change be described in cf-deployment release notes?

not needed

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component
- [x] None of above

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
- [x] **Not Urgent**

### Tag your pair, your PM, and/or team!

@philippthun 
