### PR TITLE
Consume smbbrokerpush bosh links from co-located errand

### DIFF
--- a/operations/backup-and-restore/enable-restore-smb-broker.yml
+++ b/operations/backup-and-restore/enable-restore-smb-broker.yml
@@ -3,7 +3,7 @@
   value:
     name: smbbrokerpush
     provides:
-      smbbrokerpush: {as: ignore-me}
+      smbbrokerpush: {as: smbbrokerpush-co-located}
     properties:
       app_domain: ((system_domain))
       cf:
@@ -28,5 +28,5 @@
     name: bbr-smbbroker
     release: smb-volume
     consumes:
-      smbbrokerpush: {from: smbbrokerpush}
+      smbbrokerpush: {from: smbbrokerpush-co-located}
 


### PR DESCRIPTION
BOSH does not support using bosh links provided from a non-co-located errand.

## Please take a moment to review the questions before submitting the PR
### WHAT is this change about?

Fix issue with consuming bosh links failing

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

As a Alana I can use the `enable-restore-smb-broker.yml` ops file to ensure my B+R solution works

### Please provide any contextual information.

It turns out that BOSH doesn't support consuming links from errands that ARENT co-located. So our current `enable-restore-smb-broker.yml` ops file is currently consuming bosh links from the non-co-located errand job. What this PR does is change it to consume from the co-located errand instead.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES
- [ ] NO

### Does this PR introduce a breaking change? Please see definition of breaking change below

- [ ] YES - please specify
- [X] NO

### How should this change be described in cf-deployment release notes?

Fix issue where `enable-restore-smb-broker.yml` fails to consume bosh links 

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
