### PR TITLE
Bump scheduler instances to 3 when using system-metrics-agent

### DIFF
--- a/operations/experimental/add-system-metrics-agent.yml
+++ b/operations/experimental/add-system-metrics-agent.yml
@@ -30,6 +30,9 @@
           key: ((system_metrics.private_key))
     release: loggregator-agent
 - type: replace
+  path: /instance_groups/name=scheduler/instances
+  value: 3
+- type: replace
   path: /instance_groups/name=scheduler/jobs/name=leadership-election?
   value:
     name: leadership-election


### PR DESCRIPTION
[#168061171]

## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

The system metrics scraper lives on the scheduler vm. To facilitate leadership election, there should be at least 3 scheduler vms.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

The leadership election used by System Metrics Scraper is implemented using the Raft algorithm. Using and odd number of vms >= 3 means that the system should not get into a split-brain state.

### Please provide any contextual information.

https://www.pivotaltracker.com/story/show/168061171

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please see definition of breaking change below.

- [ ] YES - please specify
- [x] NO

> **Types of breaking changes:**
> - **causes app or operator downtime**
> - modifies, deletes or moves the name of a job or instance group in the main manifest
> - modifies the name or deletes a property of a job or instance group in the main manifest
> - changes the name of credentials in the main manifest
> - requires out-of-band manual intervention on the part of the operator 
> - modifies the ops-file path, changes the type, changes the values or removes ops-files from the followning folders
>    - `./operations/` or `./operations/experimental` 
>    - `./addons`
>    - `./backup-and-restore/`
>    - `./bits-service/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/master/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test/`, `./workaround`

### How should this change be described in cf-deployment release notes?

> _Something brief that conveys the change and is written with the **persona (Alana, Cody...)** in mind. See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [x] YES - does it really have to?
- [ ] NO

yes -- fewer than three vms means that the leadership election may not be accurate and metrics might not be egressed

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._

@AllenDuet 