### PR TITLE
The use-postgres.yml should remove route_registrar from database job …

### DIFF
--- a/operations/use-postgres.yml
+++ b/operations/use-postgres.yml
@@ -6,6 +6,8 @@
     url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=39
     version: "39"
 - type: remove
+  path: /instance_groups/name=database/jobs/name=route_registrar
+- type: remove
   path: /instance_groups/name=database/jobs/name=pxc-mysql
 - type: remove
   path: /instance_groups/name=database/jobs/name=proxy


### PR DESCRIPTION
The route_registrar job on database can be removed when use-postgres is used since this is only registering mysql proxy job endpoints

## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Remove the extra route_registrar jobs that is not used when using postgres.

### What customer problem is being addressed? Use customer persona to define the problem e.g. 

The operator will have extra routes registered in the gorouter with no listeners on the database instance_group

### Please provide any contextual information.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please see definition of breaking change below.

- [ ] YES - please specify
- [X] NO

### How should this change be described in cf-deployment release notes?

Not required

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
