### PR TITLE
Remove syslog drain release in add-syslog-agent ops file

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -16,7 +16,7 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 |:---  |:---     |:---   |:---   |
 | [`add-credhub-lb.yml`](add-credhub-lb.yml) |  **[DEPRECATED]** Use load balancer to expose external address for CredHub. | | **NO** |
 | [`add-metric-store.yml`](add-metric-store.yml) |  **Add Metric Store node for persistence of metrics from Loggregator** | | **NO** |
-| [`add-syslog-agent.yml`](add-syslog-agent.yml) |  Add agent to all vms for the purpose of egressing application logs to syslog | | **YES** |
+| [`add-syslog-agent.yml`](add-syslog-agent.yml) |  Add agent to all vms for the purpose of egressing application logs to syslog and disable cf-syslog-drain release | | **YES** |
 | [`add-syslog-agent-windows1803.yml`](add-syslog-agent-windows1803.yml) |  Add agent to windows1803 Diego cells for the purpose of egressing application logs to syslog | Requires `../windows1803-cell.yml` and `add-syslog-agent.yml` | **NO** |
 | [`add-system-metrics-agent.yml`](add-system-metrics-agent.yml) | Add agent to all vms with the purpose of egressing system metrics | | **NO** |
 | [`add-system-metrics-agent-windows1803.yml`](add-system-metrics-agent-windows1803.yml) | Add agent to windows1803 Diego cells for the purpose of egressing system metrics | | **NO** |

--- a/operations/experimental/add-syslog-agent.yml
+++ b/operations/experimental/add-syslog-agent.yml
@@ -45,16 +45,6 @@
       extended_key_usage:
       - client_auth
 
-
-##################
-# Forwader Agent #
-##################
-- type: replace
-  path: /addons/name=forwarder_agent/jobs/name=loggr-forwarder-agent/properties/downstream_ingress_ports?
-  value:
-  - 3459
-  - 3460
-
 #################
 # Binding Cache #
 #################
@@ -125,3 +115,16 @@
       common_name: loggr_syslog_binding_cache_metrics
       extended_key_usage:
       - server_auth
+
+#################
+# Remove cf-syslog-drain-release #
+#################
+
+- type: remove
+  path: /releases/name=cf-syslog-drain
+
+- type: remove
+  path: /instance_groups/name=adapter
+
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=scheduler

--- a/operations/experimental/add-syslog-agent.yml
+++ b/operations/experimental/add-syslog-agent.yml
@@ -128,3 +128,15 @@
 
 - type: remove
   path: /instance_groups/name=scheduler/jobs/name=scheduler
+
+- type: remove
+  path: /variables/name=adapter_tls
+
+- type: remove
+  path: /variables/name=adapter_rlp_tls
+
+- type: remove
+  path: /variables/name=scheduler_client_tls
+
+- type: remove
+  path: /variables/name=scheduler_api_tls

--- a/operations/experimental/add-syslog-agent.yml
+++ b/operations/experimental/add-syslog-agent.yml
@@ -35,7 +35,7 @@
           server_name: syslog_agent_metrics
 
 - type: replace
-  path: /variables/name=syslog_agent_api_tls
+  path: /variables/name=syslog_agent_api_tls?
   value:
     name: syslog_agent_api_tls
     type: certificate

--- a/operations/experimental/add-syslog-agent.yml
+++ b/operations/experimental/add-syslog-agent.yml
@@ -2,7 +2,7 @@
 # Syslog Agent #
 ################
 - type: replace
-  path: /addons/-
+  path: /addons/name=loggr-syslog-agent?
   value:
     name: loggr-syslog-agent
     include:
@@ -35,7 +35,7 @@
           server_name: syslog_agent_metrics
 
 - type: replace
-  path: /variables/-
+  path: /variables/name=syslog_agent_api_tls
   value:
     name: syslog_agent_api_tls
     type: certificate
@@ -49,7 +49,7 @@
 # Binding Cache #
 #################
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/-
+  path: /instance_groups/name=scheduler/jobs/name=loggr-syslog-binding-cache?
   value:
     name: loggr-syslog-binding-cache
     release: loggregator-agent
@@ -73,7 +73,7 @@
         server_name: loggr_syslog_binding_cache_metrics
 
 - type: replace
-  path: /variables/-
+  path: /variables/name=binding_cache_api_tls?
   value:
     name: binding_cache_api_tls
     type: certificate
@@ -84,7 +84,7 @@
       - client_auth
 
 - type: replace
-  path: /variables/-
+  path: /variables/name=binding_cache_tls?
   value:
     name: binding_cache_tls
     type: certificate


### PR DESCRIPTION
### WHAT is this change about?

The add-syslog-agent ops file as it exists would lead to duplicate logs being sent to syslog drains. This changes that ops file to remove cf-syslog-drain release and its jobs so this doesn't happen.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Duplicated logs send to syslog drains

### Please provide any contextual information.

https://www.pivotaltracker.com/story/show/168468829

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please see definition of breaking change below.

- [x] YES - please specify
- [ ] NO

Changes the add-syslog-agent experimental ops file to do the following:
- remove the adapter instance group
- remove the scheduler job from the scheduler instance group
- remove the cf-syslog-drain release
- remove all variables associated with the removed jobs

### How should this change be described in cf-deployment release notes?

- add-syslog-agent experimental ops file now removes cf-syslog-drain release

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [x] NO - It will decrease it

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@MasslessParticle @pianohacker @mjseaman 
