### PR TITLE
add drain_ca_cert to use-logcache-syslog-ingress ops files

### DIFF
--- a/operations/experimental/use-logcache-syslog-ingress-windows1803.yml
+++ b/operations/experimental/use-logcache-syslog-ingress-windows1803.yml
@@ -2,3 +2,7 @@
 - type: replace
   path: /instance_groups/name=windows1803-cell/jobs/name=loggr-syslog-agent-windows/properties/non_app_drains?
   value: "syslog-tls://doppler.service.cf.internal:6067"
+
+- type: replace
+  path: /addons/name=loggr-syslog-agent/jobs/name=loggr-syslog-agent/properties/drain_ca_cert?
+  value: "((log_cache_syslog_tls.ca))"

--- a/operations/experimental/use-logcache-syslog-ingress.yml
+++ b/operations/experimental/use-logcache-syslog-ingress.yml
@@ -33,6 +33,10 @@
   value: "syslog-tls://doppler.service.cf.internal:6067"
 
 - type: replace
+  path: /addons/name=loggr-syslog-agent/jobs/name=loggr-syslog-agent/properties/drain_ca_cert?
+  value: "((log_cache_syslog_tls.ca))"
+
+- type: replace
   path: /variables/name=log_cache_syslog_server_metrics_tls?
   value:
     name: log_cache_syslog_server_metrics_tls


### PR DESCRIPTION
Signed-off-by: Caitlyn Yu <cyu@pivotal.io>

### WHAT is this change about?

This change allows the syslog agent to securely communicate with the log-cache syslog server.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

The user is now able to use syslog-log-cache without disabling tls validation

### Please provide any contextual information.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please see definition of breaking change below.

- [ ] YES - please specify
- [x] NO

### How should this change be described in cf-deployment release notes?

Update use-logcache-syslog-ingress ops files to enable secure communication between the syslog agent and the log cache syslog server.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Will this change increase the VM footprint of cf-deployment?

- [ ] YES - does it really have to?
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@MasslessParticle @pianohacker @mjseaman 