### PR TITLE
Switch to system-metrics-release and update the scraper and agent

### DIFF
--- a/operations/experimental/add-system-metrics-agent-windows1803.yml
+++ b/operations/experimental/add-system-metrics-agent-windows1803.yml
@@ -2,8 +2,9 @@
   path: /instance_groups/name=windows1803-cell/jobs/name=loggr-system-metrics-agent-windows?
   value:
     name: loggr-system-metrics-agent-windows
-    release: loggregator-agent
+    release: system-metrics
     properties:
+      metrics_port: 53035
       system_metrics:
           tls:
             ca_cert: "((system_metrics.ca))"

--- a/operations/experimental/add-system-metrics-agent.yml
+++ b/operations/experimental/add-system-metrics-agent.yml
@@ -11,19 +11,21 @@
     jobs:
     - name: loggr-system-metrics-agent
       properties:
+        metrics_port: 53035
         system_metrics:
           tls:
             ca_cert: ((system_metrics.ca))
             cert: ((system_metrics.certificate))
             key: ((system_metrics.private_key))
-      release: loggregator-agent
+      release: system-metrics
     name: loggr-system-metrics-agent
 
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=loggr-metric-scraper?
+  path: /instance_groups/name=scheduler/jobs/name=loggr-system-metric-scraper?
   value:
-    name: loggr-metric-scraper
+    name: loggr-system-metric-scraper
     properties:
+      scrape_port: 53035
       system_metrics:
         tls:
           ca_cert: ((system_metrics.ca))
@@ -38,7 +40,7 @@
         cert: "((loggr_metric_scraper_metrics_tls.certificate))"
         key: "((loggr_metric_scraper_metrics_tls.private_key))"
         server_name: loggr_metric_scraper_metrics
-    release: loggregator-agent
+    release: system-metrics
 
 - type: replace
   path: /instance_groups/name=scheduler/instances
@@ -59,7 +61,7 @@
         cert: "((leadership_election_metrics_tls.certificate))"
         key: "((leadership_election_metrics_tls.private_key))"
         server_name: leadership_election_metrics
-    release: leadership-election
+    release: system-metrics
 
 - type: replace
   path: /variables/name=system_metrics?
@@ -74,12 +76,12 @@
     type: certificate
 
 - type: replace
-  path: /releases/name=leadership-election?
+  path: /releases/name=system-metrics?
   value:
-    name: leadership-election
-    version: 2.0.0
-    url: https://bosh.io/d/github.com/cloudfoundry/leadership-election-release?v=2.0.0
-    sha1: f92817c3432f71ae3b99bec362711940ee6d179a
+    name: system-metrics
+    version: 1.0.0
+    url: https://bosh.io/d/github.com/cloudfoundry/system-metrics-release?v=1.0.0
+    sha1: 59c3ddf9a969e474be0c696a59bff2a8e40f3eb3
 
 - type: replace
   path: /variables/name=leadership_election_tls?


### PR DESCRIPTION
### WHAT is this change about?

System Metrics Scraper and Agent now comes from its own release and remove the Leadership Election release.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...
This is a refactor of the releases.

### Please provide any contextual information.

* https://www.pivotaltracker.com/story/show/169020450

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [x] YES - please choose the category from below. Feel free to provide additional details.
- [ ] NO

> **Types of breaking changes:**
This change removes a release and adds a new release to opsfiles in `operations/experimental`

### How should this change be described in cf-deployment release notes?

System metrics agent now comes from it's own release. Leadership Election release is removed.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [x] YES - please specify
- [ ] NO

This includes https://bosh.io/releases/github.com/cloudfoundry/system-metrics-release?all=1.

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

1. `bosh instances -p` and ensure that the `loggr-system-metrics-agent` is on all the VMs and that `loggr-system-metric-scraper` is on the Scheduler VMs. 

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@MasslessParticle @pianohacker @mjseaman 