### PR TITLE
Update syslog agent property name to aggregate_drains

### DIFF
--- a/operations/experimental/use-logcache-syslog-ingress-windows1803.yml
+++ b/operations/experimental/use-logcache-syslog-ingress-windows1803.yml
@@ -1,6 +1,6 @@
 ---
 - type: replace
-  path: /instance_groups/name=windows1803-cell/jobs/name=loggr-syslog-agent-windows/properties/non_app_drains?
+  path: /instance_groups/name=windows1803-cell/jobs/name=loggr-syslog-agent-windows/properties/aggregate_drains?
   value: "syslog-tls://doppler.service.cf.internal:6067"
 
 - type: replace

--- a/operations/experimental/use-logcache-syslog-ingress.yml
+++ b/operations/experimental/use-logcache-syslog-ingress.yml
@@ -29,7 +29,7 @@
   path: /instance_groups/name=doppler/jobs/name=log-cache-nozzle?
 
 - type: replace
-  path: /addons/name=loggr-syslog-agent/jobs/name=loggr-syslog-agent/properties/non_app_drains?
+  path: /addons/name=loggr-syslog-agent/jobs/name=loggr-syslog-agent/properties/aggregate_drains?
   value: "syslog-tls://doppler.service.cf.internal:6067"
 
 - type: replace


### PR DESCRIPTION
[#168526399]

### WHAT is this change about?

Update property name for aggregate drains in Syslog Agent

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana is unclear what the `non_app_drains` property in Syslog Agent is.

### Please provide any contextual information.

https://www.pivotaltracker.com/story/show/169017178

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [x] YES - please choose the category from below. Feel free to provide additional details.
- [ ] NO

### How should this change be described in cf-deployment release notes?

`non_app_drains` property is now `aggregate_drains`. This is a name change to remove any confusion about what this property is, which is a single drain destination for all metrics and app logs. 

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

`bosh -d cf manifest` and see the new property name in Syslog Agent

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

slack: loggregator