### PR TITLE
Remove experimental ops file that is unused by UAA.

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -25,7 +25,6 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 | [`add-system-metrics-agent-windows1803.yml`](add-system-metrics-agent-windows1803.yml) | Add agent to windows1803 Diego cells for the purpose of egressing system metrics | | **NO** |
 | [`add-system-metrics-agent-windows2019.yml`](add-system-metrics-agent-windows2019.yml) | Add agent to windows2019 Diego cells for the purpose of egressing system metrics | | **NO** |
 | [`disable-interpolate-service-bindings.yml`](disable-interpolate-service-bindings.yml) | Disables the interpolation of CredHub service credentials by Cloud Controller. | | **NO** |
-| [`disable-uaa-client-redirect-uri-legacy-matching-mode.yml`](disable-uaa-client-redirect-uri-legacy-matching-mode.yml) | Disables legacy (non-exact) matching of redirect URIs in the UAA. | | **NO** |
 | [`enable-bpm-garden.yml`](enable-bpm-garden.yml) | Enables the [BOSH Process Manager](https://github.com/cloudfoundry-incubator/bpm-release) for Garden. | This ops file **cannot** be deployed in conjunction with `enable-oci-phase-1.yml`. | **NO** |
 | [`enable-containerd-for-processes.yml`](enable-containerd-for-processes.yml) | Configure Garden to run processes via containerd. | This ops file **cannot** be deployed in conjunction with `rootless-containers.yml`. | **NO** |
 | [`enable-iptables-logger.yml`](enable-iptables-logger.yml) | Enables iptables logger. | | **YES** |

--- a/operations/experimental/disable-uaa-client-redirect-uri-legacy-matching-mode.yml
+++ b/operations/experimental/disable-uaa-client-redirect-uri-legacy-matching-mode.yml
@@ -1,5 +1,0 @@
----
-
-- type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/client?/redirect_uri/matching_mode
-  value: "exact"

--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -30,7 +30,6 @@ add-system-metrics-agent-windows2019.yml:
   - add-system-metrics-agent-windows2019.yml
 add-system-metrics-agent.yml: {}
 disable-interpolate-service-bindings.yml: {}
-disable-uaa-client-redirect-uri-legacy-matching-mode.yml: {}
 enable-bpm-garden.yml: {}
 enable-containerd-for-processes.yml: {}
 enable-iptables-logger.yml: {}


### PR DESCRIPTION
This is an ops file we added to cf-deployment but it is
unlikely to ever be turned on.

[#167764897]

Signed-off-by: Joshua Casey <jcasey@pivotal.io>

### WHAT is this change about?

Remove experimental ops file that is unused by UAA.

### What customer problem is being addressed? Use customer persona to define the problem 
This is an ops file we added to cf-deployment but it is
unlikely to ever be turned on.

### Please provide any contextual information.

https://www.pivotaltracker.com/story/show/167764897

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

  
### How should this change be described in cf-deployment release notes?

This is an ops file we added to cf-deployment but it is
unlikely to ever be turned on.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO


### Please provide Acceptance Criteria for this change?

file is gone.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@joshuatcasey
@dbeneke

