### PR TITLE
Bump metric store version to 1.2.1

### DIFF
--- a/operations/use-metric-store.yml
+++ b/operations/use-metric-store.yml
@@ -13,7 +13,7 @@
 - type: replace
   path: /instance_groups/-
   value:
-  - name: metric-store
+    name: metric-store
     azs:
     - z1
     instances: 1

--- a/operations/use-metric-store.yml
+++ b/operations/use-metric-store.yml
@@ -6,9 +6,9 @@
   path: /releases/-
   value:
     name: metric-store
-    sha1: d97c03afaef0667e65ada31b4d3372c0c5578a80
-    url: https://bosh.io/d/github.com/cloudfoundry/metric-store-release?v=1.1.2
-    version: 1.1.2
+    sha1: 2dfd3b305480b2aea11697a7c633f35083176cdb
+    url: https://bosh.io/d/github.com/cloudfoundry/metric-store-release?v=1.2.1
+    version: 1.2.1
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Updating the version of metric store.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana can now make recording/alerting rules. We improved performance, error messages, and emite more metrics, making Metric Store easier to operate. We also updated some dependencies.

### Please provide any contextual information.

https://github.com/cloudfoundry/metric-store-release/releases/tag/v1.2.1

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

"Bump metric store version to 1.2.1"

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [ ] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

An admin user should be able to run the following curl command: 
```
$ curl -H "Authorization: $(cf oauth-token)" -sS -G https://metric-store-route.my.foundation.pivotal.io/health
```
and see it return `{"version":"1.2.1"}`.

### What is the level of urgency for publishing this change?
- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
/cc @attack @heidmotron @toddboom 
