### PR TITLE
Fix metric-store opsfile to be a usable opsfile

### DIFF
--- a/operations/use-metric-store.yml
+++ b/operations/use-metric-store.yml
@@ -17,8 +17,6 @@
     jobs:
     - name: metric-store
       properties:
-        egress_port: 8080
-        health_addr: localhost:6060
         metric_store_server:
           tls:
             ca_cert: ((metric_store_server.ca))


### PR DESCRIPTION
### WHAT is this change about?

The 2 properties described here are not valid in the metric-store
release and the intended values are the default values in metric-store
job. This causes the yaml parse failure when using this opsfile.

egress_port -> port
health_addr -> health_port

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

> Fix metric-store opsfile

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Using the opsfile in cf-deployment should succeed. 

### What is the level of urgency for publishing this change?

- [] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cf-diego 