### PR TITLE
Update datadog release to latest (v77)

### DIFF
--- a/operations/test/add-datadog-firehose-nozzle.yml
+++ b/operations/test/add-datadog-firehose-nozzle.yml
@@ -50,6 +50,6 @@
   path: /releases/-
   value:
     name: datadog-firehose-nozzle
-    url: https://bosh.io/d/github.com/DataDog/datadog-firehose-nozzle-release?v=74
-    version: "74"
-    sha1: 574a275a644f9496be7d1d77cb9a50d5a344b477
+    url: https://bosh.io/d/github.com/DataDog/datadog-firehose-nozzle-release?v=77
+    version: "77"
+    sha1: c47fe351b361aecbfa7c05674b079e32a859f6a7


### PR DESCRIPTION
This fixes an issue where deploying metric-store along with older
versions of datadog-firehose-nozzle-release doesn't work. The issue has
been fixed in later versions.

### WHAT is this change about?

Bump datadog-firehose-nozzle release to 77 which has a fix for metric store to work.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

No customer. We are seeing an issue with metric store not working because it is not compatible with old datadog-firehose-nozzle release.

### Please provide any contextual information.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

Update datadog-firehose-nozzle release to v77

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Deploy metric-store with datadog using ops-files:

- operations/test/add-datadog-firehose-nozzle.yml
- operations/use-metric-store.yml

Metrics should appear in datadog.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cf-diego 
