### PR TITLE
Use the same healthy script for route_registrar in UAA

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -691,7 +691,7 @@ instance_groups:
         routes:
         - health_check:
             name: uaa-healthcheck
-            script_path: "/var/vcap/jobs/uaa/bin/health_check"
+            script_path: "/var/vcap/jobs/uaa/bin/dns/healthy"
           name: uaa
           tls_port: 8443
           server_cert_domain_san: "uaa.service.cf.internal"


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

This is to replace the old health_check script in the UAA release with the new path so both bosh_dns and route_registrar are using the same script.  In the future UAA will remove the bin/health_check script as they are identical

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

To make sure we have only a single script in sync between route_registrar and bosh_dns to ensure both paths to UAA is consistently applied as to the health of UAA.

### Please provide any contextual information.

https://github.com/cloudfoundry/uaa-release/pull/147

Was the PR to add the healthy script to UAA.  This "requires" UAA 74.11 where the new script exists.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO


### How should this change be described in cf-deployment release notes?

The healthy check script in UAA for route_registry is in a new path.  In the future the old script will be removed

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Ensure that the route_registrar health check is performing correctly and that UAA is registered correctly with gorouter.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

