### PR TITLE
Capi remove internal api pw

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -860,7 +860,6 @@ instance_groups:
           keys:
             encryption_key_0: "((cc_db_encryption_key))"
         bulk_api_password: "((cc_bulk_api_password))"
-        internal_api_password: "((cc_internal_api_password))"
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"
         temporary_use_logcache: true
@@ -1056,7 +1055,6 @@ instance_groups:
       cc:
         db_encryption_key: "((cc_db_encryption_key))"
         database_encryption: *cc-database-encryption
-        internal_api_password: "((cc_internal_api_password))"
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"
         resource_pool: *blobstore-properties
@@ -1129,7 +1127,6 @@ instance_groups:
       cc:
         db_encryption_key: "((cc_db_encryption_key))"
         database_encryption: *cc-database-encryption
-        internal_api_password: "((cc_internal_api_password))"
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"
         resource_pool: *blobstore-properties
@@ -1734,8 +1731,6 @@ variables:
 - name: cc_bulk_api_password
   type: password
 - name: cc_db_encryption_key
-  type: password
-- name: cc_internal_api_password
   type: password
 - name: cc_staging_upload_password
   type: password


### PR DESCRIPTION
> _Please describe the change._

Removing a vestigal password

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana is confused why this unused property is generated.

### Please provide any contextual information.

> _Include any links to other PRs, stories, slack discussions, etc... that will help establish context._
Closing out old issues on the capi-release repo, we found this one: https://github.com/cloudfoundry/capi-release/issues/59

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO



### How should this change be described in cf-deployment release notes?

Remove `cc_internal_api_password` as mTLS is now used in its stead.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

CATs is fine

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
- [x] Not at all urgent

### Tag your pair, your PM, and/or team!

@cloudfoundry/cf-capi 