### PR TITLE
Update metric store release 1.3.0

### DIFF
--- a/operations/use-metric-store.yml
+++ b/operations/use-metric-store.yml
@@ -19,7 +19,6 @@
         metric-store: {from: metric-store}
         metric-store-nozzle: {from: metric-store-nozzle}
         metric-store-cf-auth-proxy: {from: metric-store-cf-auth-proxy}
-        metric-store-blackbox: {from: metric-store-blackbox, deployment: metric-store-blackbox, optional: true}
       properties:
         metric_store_server:
           tls:

--- a/operations/use-metric-store.yml
+++ b/operations/use-metric-store.yml
@@ -1,27 +1,46 @@
 - type: replace
-  path: /addons/name=prom_scraper/exclude?/instance_groups/-
-  value: metric-store
-- type: replace
-  path: /releases/-
+  path: /releases/name=metric-store?
   value:
     name: metric-store
     sha1: 0c340e8fec7230b0243bf4321fa92906ab6fc8f3
     url: https://bosh.io/d/github.com/cloudfoundry/metric-store-release?v=1.3.0
     version: 1.3.0
 - type: replace
-  path: /instance_groups/-
+  path: /instance_groups/name=metric-store?
   value:
     azs:
     - z1
     instances: 1
     jobs:
     - name: metric-store
+      provides:
+        metric-store: {shared: true, as: metric-store}
+      consumes:
+        metric-store: {from: metric-store}
+        metric-store-nozzle: {from: metric-store-nozzle}
+        metric-store-cf-auth-proxy: {from: metric-store-cf-auth-proxy}
+        metric-store-blackbox: {from: metric-store-blackbox, deployment: metric-store-blackbox, optional: true}
       properties:
         metric_store_server:
           tls:
             ca_cert: ((metric_store_server.ca))
             cert: ((metric_store_server.certificate))
             key: ((metric_store_server.private_key))
+        metric_store_internode:
+          tls:
+            ca_cert: ((metric_store_internode.ca))
+            cert: ((metric_store_internode.certificate))
+            key: ((metric_store_internode.private_key))
+        metric_store_metrics_server:
+          tls:
+            ca_cert: ((metric_store_metrics_server.ca))
+            cert: ((metric_store_metrics_server.certificate))
+            key: ((metric_store_metrics_server.private_key))
+        metric_store_metrics_client:
+          tls:
+            ca_cert: ((metric_store_metrics_client.ca))
+            cert: ((metric_store_metrics_client.certificate))
+            key: ((metric_store_metrics_client.private_key))
         tls:
           ca_cert: ((metric_store.ca))
           cert: ((metric_store.certificate))
@@ -39,7 +58,18 @@
             ca_cert: ((nozzle_to_metric_store_client.ca))
             cert: ((nozzle_to_metric_store_client.certificate))
             key: ((nozzle_to_metric_store_client.private_key))
+        metric_store_metrics:
+          tls:
+            ca_cert: ((metric_store_metrics_server.ca))
+            cert: ((metric_store_metrics_server.certificate))
+            key: ((metric_store_metrics_server.private_key))
       release: metric-store
+      provides:
+        metric-store-nozzle: {as: metric-store-nozzle}
+      consumes:
+        reverse_log_proxy: {from: reverse_log_proxy, deployment: cf}
+        metric-store-nozzle: {from: metric-store-nozzle}
+        metric-store: {from: metric-store}
     - name: route_registrar
       properties:
         route_registrar:
@@ -54,7 +84,22 @@
             - '*.metric-store.((system_domain))'
       release: routing
     - name: metric-store-cf-auth-proxy
+      provides:
+        metric-store-cf-auth-proxy: {as: metric-store-cf-auth-proxy}
+      consumes:
+        cloud_controller: {from: cloud_controller, deployment: cf}
+        metric-store-nozzle: {from: metric-store-nozzle}
+        metric-store: {from: metric-store}
       properties:
+        metric_store_metrics:
+          tls:
+            ca_cert: ((metric_store_metrics_server.ca))
+            cert: ((metric_store_metrics_server.certificate))
+            key: ((metric_store_metrics_server.private_key))
+        metric_store_client:
+          tls:
+            cert: ((metric_store.certificate))
+            key: ((metric_store.private_key))
         cc:
           ca_cert: ((cc_tls.ca))
           common_name: cloud-controller-ng.service.cf.internal
@@ -74,8 +119,9 @@
     persistent_disk_type: 5GB
     stemcell: default
     vm_type: minimal
+
 - type: replace
-  path: /variables/-
+  path: /variables/name=metric_store_to_logs_provider?
   value:
     name: metric_store_to_logs_provider
     options:
@@ -85,16 +131,18 @@
       - client_auth
       - server_auth
     type: certificate
+
 - type: replace
-  path: /variables/-
+  path: /variables/name=metric_store_ca?
   value:
     name: metric_store_ca
     options:
       common_name: metric-store
       is_ca: true
     type: certificate
+
 - type: replace
-  path: /variables/-
+  path: /variables/name=metric_store?
   value:
     name: metric_store
     options:
@@ -107,8 +155,9 @@
       - client_auth
       - server_auth
     type: certificate
+
 - type: replace
-  path: /variables/-
+  path: /variables/name=metric_store_server?
   value:
     name: metric_store_server
     options:
@@ -119,8 +168,9 @@
       extended_key_usage:
       - server_auth
     type: certificate
+
 - type: replace
-  path: /variables/-
+  path: /variables/name=nozzle_to_metric_store_client?
   value:
     name: nozzle_to_metric_store_client
     options:
@@ -131,8 +181,9 @@
       extended_key_usage:
       - client_auth
     type: certificate
+
 - type: replace
-  path: /variables/-
+  path: /variables/name=metricstore_ssl?
   value:
     name: metricstore_ssl
     options:
@@ -142,3 +193,44 @@
       ca: service_cf_internal_ca
       common_name: metric-store
     type: certificate
+
+- type: replace
+  path: /variables/name=metric_store_internode?
+  value:
+    name: metric_store_internode
+    type: certificate
+    options:
+      ca: metric_store_ca
+      common_name: metric-store
+      alternative_names:
+      - metric-store
+      extended_key_usage:
+      - server_auth
+      - client_auth
+
+- type: replace
+  path: /variables/name=metric_store_proxy_tls?
+  value:
+    name: metric_store_proxy_tls
+    type: certificate
+    options:
+      ca: metric_store_ca
+      common_name: localhost
+
+- type: replace
+  path: /variables/name=metric_store_metrics_server?
+  value:
+    name: metric_store_metrics_server
+    type: certificate
+    options:
+      ca: metric_scraper_ca
+      common_name: metric-store
+
+- type: replace
+  path: /variables/name=metric_store_metrics_client?
+  value:
+    name: metric_store_metrics_client
+    type: certificate
+    options:
+      ca: metric_scraper_ca
+      common_name: metric-store-client

--- a/operations/use-metric-store.yml
+++ b/operations/use-metric-store.yml
@@ -5,9 +5,9 @@
   path: /releases/-
   value:
     name: metric-store
-    sha1: 0c67ab7b06095771d4f9e460b83dde2b499b38b0
-    url: https://bosh.io/d/github.com/cloudfoundry/metric-store-release?v=1.2.2
-    version: 1.2.2
+    sha1: 0c340e8fec7230b0243bf4321fa92906ab6fc8f3
+    url: https://bosh.io/d/github.com/cloudfoundry/metric-store-release?v=1.3.0
+    version: 1.3.0
 - type: replace
   path: /instance_groups/-
   value:


### PR DESCRIPTION
### WHAT is this change about?

Add new certs and properties required by metric-store 1.3.0

### Please provide any contextual information.

https://cloudfoundry.slack.com/archives/CHB7BCZS8/p1582670875000300

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Bump metric-store-release to v1.3.0

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

As CF admin user, this command:

```
curl -H "Authorization: $(cf oauth-token)" -sS -G https://metric-store.$SYSTEM_DOMAIN/api/v1/query --data-urlencode 'query=up'
```

should return json-encoded metrics (and not an error)


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@heidmotron @attack @thepeterstone @josephgee 
