### PR TITLE
Remove unused variable cf_bosh_password

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1824,8 +1824,6 @@ variables:
   type: password
 - name: cf_admin_password
   type: password
-- name: cf_bosh_password
-  type: password
 - name: router_route_services_secret
   type: password
 - name: uaa_admin_client_secret

--- a/scripts/fixtures/unit-test-vars-store.yml
+++ b/scripts/fixtures/unit-test-vars-store.yml
@@ -1364,7 +1364,6 @@ cf_app_sd_server_tls:
     3s14wglLDiyFRtfchzKcr9VnpxE3pAaAXX+uXw32F+4HS+zvF8idG0s7ziGAUvVn
     NFNee/mpvwEoEzYksUoy6F1mVmq44GplfnH0V/tRB8q26i3cIyrq
     -----END RSA PRIVATE KEY-----
-cf_bosh_password: er1dx8l09nq5gazqk49f
 cf_mysql_mysql_admin_password: t73b5xhpqks9eyc4enof
 cf_mysql_mysql_cluster_health_password: 43kp9am9e30oxelv7dab
 cf_mysql_mysql_galera_healthcheck_endpoint_password: eanikhee369xz7p76hq2


### PR DESCRIPTION
### WHAT is this change about?

found that there is an unused variable called "cf_bosh_password".  This is just removing that from the manifests.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Nothing really just cleaning up the manifest so there are no unused variables.

### Please provide any contextual information.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

removed unused variable cf_bosh_password

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

`bosh variables | grep cf_bosh_password`  will return no variables.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**