### PR TITLE
allow api and worker instance groups to deploy in parallel

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -764,8 +764,6 @@ instance_groups:
   vm_extensions:
   - 50GB_ephemeral_disk
   stemcell: default
-  update:
-    serial: true
   networks:
   - name: default
   jobs:

--- a/operations/experimental/fast-deploy-with-downtime-and-danger.yml
+++ b/operations/experimental/fast-deploy-with-downtime-and-danger.yml
@@ -20,9 +20,6 @@
   path: /instance_groups/name=singleton-blobstore/update/serial
   value: false
 - type: replace
-  path: /instance_groups/name=api/update/serial
-  value: false
-- type: replace
   path: /instance_groups/name=router/update/serial
   value: false
 - type: replace


### PR DESCRIPTION
***please do not merge until capi-release 1.93.0*** (wait for https://bosh.io/releases/github.com/cloudfoundry/capi-release?version=1.93.0 to resolve)

### WHAT is this change about?

There was a bug in the ccng worker that made it not wait for migrations to finish running. We hotfixed that bug by setting the api to be serial: true in cfd, but have since made the worker block properly. 

properly fixes this issue:
https://github.com/cloudfoundry/capi-release/issues/165


[https://www.pivotaltracker.com/story/show/171394832]

Co-authored-by: Connor Braa <cbraa@pivotal.io>
Co-authored-by: Renee Chu <rchu@pivotal.io>

### What customer problem is being addressed? Use customer persona to define the problem 

This fixes the issue linked above and speeds up all cf-d deployments.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### How should this change be described in cf-deployment release notes?

allow api and worker instance groups to deploy in parallel

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Please provide Acceptance Criteria for this change?

When I deploy a CFD, I can see the cc-worker and api vms deploying simultaneously.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@reneighbor @aashah @selzoc 