### PR TITLE
Revert "Remove unused variable cf_bosh_password"

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1824,6 +1824,8 @@ variables:
   type: password
 - name: cf_admin_password
   type: password
+- name: cf_bosh_password
+  type: password
 - name: router_route_services_secret
   type: password
 - name: uaa_admin_client_secret

--- a/scripts/fixtures/unit-test-vars-store.yml
+++ b/scripts/fixtures/unit-test-vars-store.yml
@@ -1364,6 +1364,7 @@ cf_app_sd_server_tls:
     3s14wglLDiyFRtfchzKcr9VnpxE3pAaAXX+uXw32F+4HS+zvF8idG0s7ziGAUvVn
     NFNee/mpvwEoEzYksUoy6F1mVmq44GplfnH0V/tRB8q26i3cIyrq
     -----END RSA PRIVATE KEY-----
+cf_bosh_password: er1dx8l09nq5gazqk49f
 cf_mysql_mysql_admin_password: t73b5xhpqks9eyc4enof
 cf_mysql_mysql_cluster_health_password: 43kp9am9e30oxelv7dab
 cf_mysql_mysql_galera_healthcheck_endpoint_password: eanikhee369xz7p76hq2


### PR DESCRIPTION
Reverts cloudfoundry/cf-deployment#872

The change is a breaking change to the main manifest. We can put this in v13 backlog.