### PR TITLE
Enhancement: NATS servers are now addressed with hostnames instead of IP addresses

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -260,6 +260,21 @@ addons:
           deployment: cf
           network: default
           domain: bosh
+      - domain: nats.service.cf.internal
+        targets:
+        - query: '*'
+          instance_group: nats
+          deployment: cf
+          network: default
+          domain: bosh
+      - domain: _.nats.service.cf.internal
+        targets:
+        - query: '_'
+          instance_group: nats
+          deployment: cf
+          network: default
+          domain: bosh
+
 
 instance_groups:
 - name: smoke-tests
@@ -308,6 +323,7 @@ instance_groups:
       nats:
         password: "((nats_password))"
         user: nats
+        hostname: nats.service.cf.internal
 - name: adapter
   azs:
   - z1


### PR DESCRIPTION
### WHAT is this change about?
Instead of using IPs as addresses for nats servers, use hostnames instead. This allows nats to take advantage of bosh dns, so that when instances roll, IP changes won't cause breaks in communication. This also lets us avoid nats split-brain problems by taking advantage of bosh dns to prefix hostnames with instance ids, so that each nats server can have a unique dns resolution.


### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...
Alana is able to roll NATS vms with minimal interruption to control plane communication.

This is more of an enhancement, though we did have a related inquiry recently that we happen to fix with this, we believe: https://cloudfoundry.slack.com/archives/CFX13JK7B/p1586368934041100

Mainly, this was done in response to a recent [failure](https://release-integration.ci.cf-app.com/teams/main/pipelines/update-releases/jobs/update-nats/builds/20) in RelInt pipelines for nats v34.

### Please provide any contextual information.
The story for this work is here: [#172315755](https://www.pivotaltracker.com/story/show/172315755)

More information on the split-brain solution that is the main feature for v34 can be found here: [#172137909](https://www.pivotaltracker.com/story/show/172137909)

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

NATS servers are now addressed with hostnames instead of IP addresses

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Given I have a cf-deployment with one or multiple NATs instances
When I ssh onto the NATS vm
And I `cat /var/vcap/jobs/nats/config/nats.conf`
Then I see that the `routes` section of the config contains addresses with `<instance-id>.nats.service.cf.internal` as the hostname.

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@kauana @ameowlia 
#networking in cf slack, use the @tiger-eyes alias.
