### PR TITLE
Add general BOSH dns query as SAN to logcache syslog server

### DIFF
--- a/operations/experimental/use-logcache-syslog-ingress.yml
+++ b/operations/experimental/use-logcache-syslog-ingress.yml
@@ -22,6 +22,8 @@
     options:
       ca: loggregator_ca
       common_name: doppler.service.cf.internal
+      alternative_names:
+        - "q-s3.doppler.default.cf.bosh"
       extended_key_usage:
         - server_auth
 


### PR DESCRIPTION
[#172918521]

### WHAT is this change about?

This adds a more general BOSH DNS alternative name to allow access to logcache syslog server from service instances.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

In a world where Loggregator v1/v2 firehose is disabled and the shared-nothing loggregator architecture is in place, service authors still want to expose metrics about their services. To do this, logcache must be set up as a syslog server and include a SAN for the BOSH dns query that is used to connect to the logcache syslog-server.

### Please provide any contextual information.

https://www.pivotaltracker.com/story/show/172918521


### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

Service authors can send metrics to Logcache when Loggregator V1/V2 firehose is disabled. 

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Confirm `log_cache_syslog_tls` certificate includes `q-s3.doppler.default.cf.bosh` in the SAN.

1. `credhub find -n log_cache_syslog_tls` then `credhub get -n ... -j | jq -r .value.certificate > /tmp/cert.crt`
1. `openssl x509 -in /tmp/cert.crt -text -noout`

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@dtimm 
@hev 
