### PR TITLE
Add CN to SAN for logcache syslog-server

### DIFF
--- a/operations/experimental/use-logcache-syslog-ingress.yml
+++ b/operations/experimental/use-logcache-syslog-ingress.yml
@@ -24,6 +24,7 @@
       common_name: doppler.service.cf.internal
       alternative_names:
         - "q-s3.doppler.default.cf.bosh"
+        - "doppler.service.cf.internal"
       extended_key_usage:
         - server_auth
 


### PR DESCRIPTION
[#172918521]

### WHAT is this change about?

This is related to the previous PR here: https://github.com/cloudfoundry/cf-deployment/pull/887. 

We did some further testing and it appears we also have to add the Common Name to the Alternative Name list if you add the `alternative_names` field. This adds the original BOSH DNS alias as a SAN to continue to allow access to log-cache syslog server from within the CF deployment. 

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

In a world where Loggregator v1/v2 firehose is disabled and the shared-nothing loggregator architecture is in place, components still want to expose their metrics. To do this, logcache must be set up as a syslog server and include a SAN for the internal BOSH alias that is used to connect to the logcache syslog-server.

### Please provide any contextual information.

https://www.pivotaltracker.com/story/show/172918521

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

Service authors can send metrics to Logcache when Loggregator V1/V2 firehose is disabled. 

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Confirm `log_cache_syslog_tls` certificate includes `q-s3.doppler.default.cf.bosh` in the SAN.

1. `credhub find -n log_cache_syslog_tls` then `credhub get -n ... -j | jq -r .value.certificate > /tmp/cert.crt`
1. `openssl x509 -in /tmp/cert.crt -text -noout`

Confirm there are no errors connecting to logcache syslog server by review `bpm logs -af loggr-syslog-agent` logs on any doppler VM.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@dtimm 
@hev 
