### PR TITLE
set ssl-strict-internal to true for use-logcache ops files

### DIFF
--- a/operations/experimental/use-logcache-syslog-ingress-windows2019.yml
+++ b/operations/experimental/use-logcache-syslog-ingress-windows2019.yml
@@ -1,7 +1,7 @@
 ---
 - type: replace
   path: /instance_groups/name=windows2019-cell/jobs/name=loggr-syslog-agent-windows/properties/aggregate_drains?
-  value: "syslog-tls://doppler.service.cf.internal:6067?include-metrics-deprecated=true"
+  value: "syslog-tls://doppler.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true"
 
 - type: replace
   path: /instance_groups/name=windows2019-cell/jobs/name=loggr-syslog-agent-windows/properties/drain_ca_cert?

--- a/operations/experimental/use-logcache-syslog-ingress.yml
+++ b/operations/experimental/use-logcache-syslog-ingress.yml
@@ -33,7 +33,7 @@
 
 - type: replace
   path: /addons/name=loggr-syslog-agent/jobs/name=loggr-syslog-agent/properties/aggregate_drains?
-  value: "syslog-tls://doppler.service.cf.internal:6067?include-metrics-deprecated=true"
+  value: "syslog-tls://doppler.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true"
 
 - type: replace
   path: /addons/name=loggr-syslog-agent/jobs/name=loggr-syslog-agent/properties/drain_ca_cert?


### PR DESCRIPTION
### WHAT is this change about?

Update loggregator agent
- allow users to specify ssl ciphers for syslog and https drains
   * update opsfile for log-cache to still use internal ciphers
- allow users to remove structured data from drains
- allow users to specify doppler address for forwarder agent

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

- Requested because strict ssl requirements don't allow syslog agents to communicate with servers without up to date ciphers.
- requested because syslog data size(cost) reduction can happen when removing structured data
- requested to fit in with unusual deployment configurations. 

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

- ~bump loggregator agent release to 6.1.0~ Set ssl-strict-internal to true for use-logcache ops files

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [x] GA'd feature/component

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@pianohacker @MasslessParticle 