### PR TITLE
Update cf smoke tests release 41.0.0

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2550,9 +2550,9 @@ releases:
   version: 2.31.0
   sha1: f27406853aee40c38615d61cf648936c0ef63d2f
 - name: cf-smoke-tests
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=40.0.134
-  version: 40.0.134
-  sha1: 0dd5720a87878cac9bb7c1f903f8cbf7ef0124ce
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.0
+  version: 41.0.0
+  sha1: a61430335a44d27c1d7273659fd2848503c70ee2
 - name: cflinuxfs3
   url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.200.0
   version: 0.200.0

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -358,7 +358,7 @@ instance_groups:
         space: cf_smoke_tests_space
         cf_dial_timeout_in_seconds: 300
         skip_ssl_validation: true
-  - name: cf-cli-6-linux
+  - name: cf-cli-7-linux
     release: cf-cli
 - name: nats
   azs:


### PR DESCRIPTION
### WHAT is this change about?
Reconcile a new requirement of the cf-smoke-tests instance group for the new major release of cf-smoke-tests. 

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...
Alana is now able to run cf-smoke-tests with the latest supported cf cli.

### Please provide any contextual information.


### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?
N.A. this only affects the cf-smoke-tests instance group, which only tests a small base set of functionality.

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.
- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?
cf-smoke-tests now runs with cf cli v7


### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?
- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?
cf-deployment continues to successfully deploy and `bosh run-errand smoke-tests` succeeds after the deploy

### What is the level of urgency for publishing this change?
- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
cc @jamespollard8 @cloudfoundry/cf-release-integration 
