### PR TITLE
Fix cc_deployment_updater always refers to only one mysql instance even if ccdb is scaled out

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1232,16 +1232,7 @@ instance_groups:
           ca_cert: "((cc_tls.ca))"
           private_key: "((cc_tls.private_key))"
           public_cert: "((cc_tls.certificate))"
-      ccdb:
-        databases:
-        - name: cloud_controller
-          tag: cc
-        db_scheme: mysql
-        port: 3306
-        roles:
-        - name: cloud_controller
-          password: ((cc_database_password))
-          tag: admin
+      ccdb: *ccdb
   - name: service-discovery-controller
     properties:
       dnshttps:


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

Even if you scale out CCDB with `operations/scale-database-cluster.yml`, cc_deployment_updater will always reference only CCDB with `index: 0`.
Therefore, cc_deployment_updater becomes down just by the appearance of `index: 0` in Percona XtraDB Cluster is down (Percona XtraDB Cluster is in a healthy state at this time).

This is due to the code below.
https://github.com/cloudfoundry/capi-release/blob/4899333c053273e8a24036c1f803adb70c67218f/jobs/cc_deployment_updater/templates/cloud_controller_ng.yml.erb#L49-L65

### WHAT is this change about?

Changed cc_deployment_updater to refer to CCDB by ip address to use BOSH DNS record ( `sql-db.service.cf.internal` ).

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana is now able to use cf even if `index: 0` of CCDB cluster goes down.

### Please provide any contextual information.

N/A

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Fix cc_deployment_updater always refers to only one mysql instance even if ccdb is scaled out

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

After building CF with `operations/scale-database-cluster.yml`, `bosh stop database/0` is possible  `cc_deployment_updater` job in scheduler vm must be started.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

I'm an individual :)
