### PR TITLE
Volume services ops files use cf-cli v7, bump releases

### DIFF
--- a/operations/enable-nfs-volume-service.yml
+++ b/operations/enable-nfs-volume-service.yml
@@ -64,7 +64,7 @@
         nfsbrokerpush:
           as: ignore-me
       release: nfs-volume
-    - name: cf-cli-6-linux
+    - name: cf-cli-7-linux
       release: cf-cli
     lifecycle: errand
     name: nfs-broker-push

--- a/operations/enable-smb-volume-service.yml
+++ b/operations/enable-smb-volume-service.yml
@@ -57,7 +57,7 @@
         syslog_url: ""
         username: smb-broker
       release: smb-volume
-    - name: cf-cli-6-linux
+    - name: cf-cli-7-linux
       release: cf-cli
     lifecycle: errand
     name: smb-broker-push


### PR DESCRIPTION
### WHAT is this change about?
Switches the volume services ops files to use cf-cli-v7

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...
Alana is able to deploy volume services without using v6 cli (in the bosh errand script)

### Please provide any contextual information.
https://www.pivotaltracker.com/story/show/173993501
https://www.pivotaltracker.com/story/show/173993537
release notes:
https://github.com/cloudfoundry/nfs-volume-release/releases/tag/v7.1.0
https://github.com/cloudfoundry/smb-volume-release/releases/tag/v3.1.0

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?
Optional ops files for volume services use cf cli v7

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?
1. Deploy cf-deployment with each of these ops files.
Run `bosh run-errand nfsbrokerpush` and `bosh run-errand smbbrokerpush`.
Verify from the errand logs that the errand is using cf cli v7.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@paulcwarren @julian-hj