### PR TITLE
Add SAN to cc_tls certificate

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2201,6 +2201,7 @@ variables:
     common_name: uaa_login_saml
 - name: cc_tls
   type: certificate
+  update_mode: converge
   options:
     ca: service_cf_internal_ca
     common_name: cloud-controller-ng.service.cf.internal

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2204,6 +2204,8 @@ variables:
   options:
     ca: service_cf_internal_ca
     common_name: cloud-controller-ng.service.cf.internal
+    alternative_names:
+    - cloud-controller-ng.service.cf.internal
     extended_key_usage:
     - client_auth
     - server_auth


### PR DESCRIPTION
### WHAT is this change about?

We need to add a SAN to the `cc_tls` cert. This is so we can safely upgrade to Go 1.15 in `capi-release`. Without this, the cc_uploader will complain in Go 1.15 that CC's cert relies on the deprecated pattern of specifying a common name without a SAN.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

> _Understanding why this change is being made is fantastically helpful. Please do tell..._

This change allows `capi-release` developers to continue to auto-bump their Go dependency to 1.15+ (currently it is pinned at 1.14.x). If `capi-release` bumps Go without this change, the cc_uploader will fail to talk to CC, and `cf push`es will fail at the staging step (affecting Codys).

### Please provide any contextual information.

> _Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

- Golang release notes describing this change: https://golang.org/doc/go1.15#commonname
- Slack thread about this PR: https://cloudfoundry.slack.com/archives/C2U7KA7M4/p1599754038020000

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [X] YES - please choose the category from below. Feel free to provide additional details.
- [ ] NO -

Please see [this Slack thread](https://cloudfoundry.slack.com/archives/C2U7KA7M4/p1599754038020000). This PR on its own is not a breaking change. *However*, the bump to go 1.15 which this is in preparation for will cause a breaking change to `cf push`. We would like to use this PR to open a conversation about potential next steps:

a) Generate certificate property as-is and ask operators to delete the variable `cc_tls` prior to deploying so that the cert will be re-generated.
b) Add `update_mode: converge` to the `cc_tls` property to ensure the cert will be re-generated. (Potentially remove it in a future release).

Regardless of which mitigation we introduce, we may want to save the GoLang 1.15 upgrade to the next minor version.

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/master/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

> Add Subject Alternative Name (SAN) to `cc_tls` certificate in preparation for update to GoLang 1.15.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

This is the simplest varification but you can also provide additional commands to test that the variable holds the desired value.
* `bosh ssh api`
* `sudo su`
* `openssl s_client -connect cloud-controller-ng.service.cf.internal:9023  | openssl x509 -noout -text`
* View the output. Make sure that the following property is present:
```
X509v3 Subject Alternative Name: 
  DNS:cloud-controller-ng.service.cf.internal
```

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@cloudfoundry/v3-acceleration-team-vat 
