### PR TITLE
Set prom_scrape interval to 60s

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -94,6 +94,7 @@ addons:
   - name: prom_scraper
     release: loggregator-agent
     properties:
+      scrape_interval: 60s
       scrape:
         tls:
           ca_cert: "((prom_scraper_scrape_tls.ca))"

--- a/operations/windows2019-cell.yml
+++ b/operations/windows2019-cell.yml
@@ -187,6 +187,7 @@
       release: loggregator-agent
     - name: prom_scraper_windows
       properties:
+        scrape_interval: 60s
         metrics:
           ca_cert: ((prom_scraper_metrics_tls.ca))
           cert: ((prom_scraper_metrics_tls.certificate))


### PR DESCRIPTION
Reduce default configuration log load by increasing `scrape_interval` from the default value of 15s to 60s.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

This reduces overall log volume by scraping ~1/4 as often.

### Please provide any contextual information.

https://pivotal-io.atlassian.net/browse/LOGG-44 

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Decrease log volume by increasing scrape_interval for system-wide prom_scraper component.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

`cf log-meta` should report longer cache duration for similar metrics counts.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cloudfoundry/cf-loggregator 
