### PR TITLE
Add SAN to nats_server_cert

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2520,8 +2520,12 @@ variables:
   options:
     ca: nats_ca
     common_name: nats.service.cf.internal
+    alternative_names:
+    - "*.nats.service.cf.internal"
+    - nats.service.cf.internal
     extended_key_usage:
     - server_auth
+  update_mode: converge
   consumes:
     alternative_name:
       from: nats-tls-address


### PR DESCRIPTION
### WHAT is this change about?

Update the nats_server_cert to include a subject alternate name definition. Also add `update_mode: converge` to force recreation of the cert on upgrade.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

This is required for Golang 1.15 clients to be able to validate the server certificate that is presented by the NATS server.

### Please provide any contextual information.

[#174887105](https://www.pivotaltracker.com/story/show/174887105)

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

This should be transparent to users.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Deploy and verify that the nats_server_cert has the correct SAN defined.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@ameowlia @jrussett 