### PR TITLE
Log metric certs

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2040,6 +2040,7 @@ variables:
     common_name: loggregatorCA
 - name: loggregator_tls_statsdinjector
   type: certificate
+  update_mode: converge
   options:
     ca: loggregator_ca
     common_name: statsdinjector
@@ -2049,6 +2050,7 @@ variables:
     - statsdinjector
 - name: loggregator_tls_agent
   type: certificate
+  update_mode: converge
   options:
     ca: loggregator_ca
     common_name: metron
@@ -2059,6 +2061,7 @@ variables:
     - metron
 - name: loggregator_tls_doppler
   type: certificate
+  update_mode: converge
   options:
     ca: loggregator_ca
     common_name: doppler
@@ -2069,6 +2072,7 @@ variables:
     - doppler
 - name: loggregator_tls_tc
   type: certificate
+  update_mode: converge
   options:
     ca: loggregator_ca
     common_name: trafficcontroller
@@ -2079,6 +2083,7 @@ variables:
     - trafficcontroller
 - name: loggregator_tls_cc_tc
   type: certificate
+  update_mode: converge
   options:
     ca: service_cf_internal_ca
     common_name: trafficcontroller
@@ -2088,6 +2093,7 @@ variables:
     - trafficcontroller
 - name: loggregator_rlp_gateway_tls_cc
   type: certificate
+  update_mode: converge
   options:
     ca: service_cf_internal_ca
     common_name: rlp-gateway
@@ -2097,6 +2103,7 @@ variables:
     - rlp-gateway
 - name: loggregator_tls_rlp
   type: certificate
+  update_mode: converge
   options:
     ca: loggregator_ca
     common_name: reverselogproxy
@@ -2107,6 +2114,7 @@ variables:
     - reverselogproxy
 - name: loggregator_rlp_gateway
   type: certificate
+  update_mode: converge
   options:
     ca: loggregator_ca
     common_name: rlp_gateway
@@ -2121,7 +2129,10 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - log-cache
   type: certificate
+  update_mode: converge
 - name: log_cache_ca
   options:
     common_name: log-cache
@@ -2139,15 +2150,20 @@ variables:
     - client_auth
     - server_auth
   type: certificate
+  update_mode: converge
 - name: log_cache_to_loggregator_agent
   options:
     ca: loggregator_ca
     common_name: log-cache
+    alternative_names:
+    - log-cache
     extended_key_usage:
     - client_auth
   type: certificate
+  update_mode: converge
 - name: cc_logcache_tls
   type: certificate
+  update_mode: converge
   options:
     ca: log_cache_ca
     common_name: "api.((system_domain))"
@@ -2156,10 +2172,12 @@ variables:
     - cloud-controller-ng.service.cf.internal
 - name: logcache_ssl
   type: certificate
+  update_mode: converge
   options:
     ca: service_cf_internal_ca
     common_name: log-cache
     alternative_names:
+    - log-cache
     - log-cache.((system_domain))
     - "*.log-cache.((system_domain))"
 - name: log_cache_proxy_tls
@@ -2343,6 +2361,7 @@ variables:
 
 - name: loggregator_rlp_gateway_tls
   type: certificate
+  update_mode: converge
   options:
     alternative_names:
     - log-stream.((system_domain))
@@ -2352,6 +2371,7 @@ variables:
 
 - name: loggregator_trafficcontroller_tls
   type: certificate
+  update_mode: converge
   options:
     alternative_names:
     - doppler.((system_domain))
@@ -2374,6 +2394,7 @@ variables:
     alternative_names:
     - metrics_agent
   type: certificate
+  update_mode: converge
 - name: metrics_discovery_metrics_tls
   options:
     ca: metric_scraper_ca
@@ -2383,6 +2404,7 @@ variables:
     alternative_names:
     - metrics_discovery_metrics
   type: certificate
+  update_mode: converge
 - name: scrape_config_generator_metrics_tls
   options:
     ca: metric_scraper_ca
@@ -2390,9 +2412,11 @@ variables:
     extended_key_usage:
       - server_auth
   type: certificate
+  update_mode: converge
 
 - name: log_cache_metrics_tls
   type: certificate
+  update_mode: converge
   options:
     ca: metric_scraper_ca
     common_name: log_cache_metrics
@@ -2403,6 +2427,7 @@ variables:
 
 - name: log_cache_cf_auth_proxy_metrics_tls
   type: certificate
+  update_mode: converge
   options:
     ca: metric_scraper_ca
     common_name: log_cache_cf_auth_proxy_metrics
@@ -2413,6 +2438,7 @@ variables:
 
 - name: log_cache_gateway_metrics_tls
   type: certificate
+  update_mode: converge
   options:
     ca: metric_scraper_ca
     common_name: log_cache_gateway_metrics
@@ -2423,6 +2449,7 @@ variables:
 
 - name: forwarder_agent_metrics_tls
   type: certificate
+  update_mode: converge
   options:
     ca: metric_scraper_ca
     common_name: forwarder_agent_metrics
@@ -2433,6 +2460,7 @@ variables:
 
 - name: loggregator_agent_metrics_tls
   type: certificate
+  update_mode: converge
   options:
     ca: metric_scraper_ca
     common_name: loggregator_agent_metrics
@@ -2443,6 +2471,7 @@ variables:
 
 - name: loggr_udp_forwarder_tls
   type: certificate
+  update_mode: converge
   options:
     ca: metric_scraper_ca
     common_name: loggr_udp_forwarder_metrics
@@ -2453,30 +2482,40 @@ variables:
 
 - name: syslog_agent_api_tls
   type: certificate
+  update_mode: converge
   options:
     ca: loggregator_ca
     common_name: syslog-agent
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - syslog-agent
 
 - name: binding_cache_api_tls
   type: certificate
+  update_mode: converge
   options:
     ca: service_cf_internal_ca
     common_name: binding-cache
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - binding-cache
 
 - name: binding_cache_tls
   type: certificate
+  update_mode: converge
   options:
     ca: loggregator_ca
     common_name: binding-cache
     extended_key_usage:
     - server_auth
+    alternative_names:
+    - binding-cache
 
 - name: syslog_agent_metrics_tls
   type: certificate
+  update_mode: converge
   options:
     ca: metric_scraper_ca
     common_name: syslog_agent_metrics
@@ -2487,6 +2526,7 @@ variables:
 
 - name: loggr_syslog_binding_cache_metrics_tls
   type: certificate
+  update_mode: converge
   options:
     ca: metric_scraper_ca
     common_name: loggr_syslog_binding_cache_metrics
@@ -2498,6 +2538,7 @@ variables:
 
 - name: prom_scraper_scrape_tls
   type: certificate
+  update_mode: converge
   options:
     ca: metric_scraper_ca
     common_name: prom_scraper
@@ -2508,6 +2549,7 @@ variables:
 
 - name: prom_scraper_metrics_tls
   type: certificate
+  update_mode: converge
   options:
     ca: metric_scraper_ca
     common_name: prom_scraper_metrics
@@ -2518,6 +2560,7 @@ variables:
 
 - name: rlp_gateway_metrics_tls
   type: certificate
+  update_mode: converge
   options:
     ca: metric_scraper_ca
     common_name: rlp_gateway_metrics

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2045,6 +2045,8 @@ variables:
     common_name: statsdinjector
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - statsdinjector
 - name: loggregator_tls_agent
   type: certificate
   options:
@@ -2053,6 +2055,8 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - metron
 - name: loggregator_tls_doppler
   type: certificate
   options:
@@ -2061,6 +2065,8 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - doppler
 - name: loggregator_tls_tc
   type: certificate
   options:
@@ -2069,6 +2075,8 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - trafficcontroller
 - name: loggregator_tls_cc_tc
   type: certificate
   options:
@@ -2076,6 +2084,8 @@ variables:
     common_name: trafficcontroller
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - trafficcontroller
 - name: loggregator_rlp_gateway_tls_cc
   type: certificate
   options:
@@ -2083,6 +2093,8 @@ variables:
     common_name: rlp-gateway
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - rlp-gateway
 - name: loggregator_tls_rlp
   type: certificate
   options:
@@ -2091,6 +2103,8 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+    alternative_names:
+    - reverselogproxy
 - name: loggregator_rlp_gateway
   type: certificate
   options:
@@ -2098,6 +2112,8 @@ variables:
     common_name: rlp_gateway
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - rlp_gateway
 - name: logs_provider
   options:
     ca: loggregator_ca
@@ -2355,6 +2371,8 @@ variables:
     common_name: metrics_agent
     extended_key_usage:
       - server_auth
+    alternative_names:
+    - metrics_agent
   type: certificate
 - name: metrics_discovery_metrics_tls
   options:
@@ -2362,6 +2380,8 @@ variables:
     common_name: metrics_discovery_metrics
     extended_key_usage:
       - server_auth
+    alternative_names:
+    - metrics_discovery_metrics
   type: certificate
 - name: scrape_config_generator_metrics_tls
   options:
@@ -2378,6 +2398,8 @@ variables:
     common_name: log_cache_metrics
     extended_key_usage:
     - server_auth
+    alternative_names:
+    - log_cache_metrics
 
 - name: log_cache_cf_auth_proxy_metrics_tls
   type: certificate
@@ -2386,6 +2408,8 @@ variables:
     common_name: log_cache_cf_auth_proxy_metrics
     extended_key_usage:
     - server_auth
+    alternative_names:
+    - log_cache_cf_auth_proxy_metrics
 
 - name: log_cache_gateway_metrics_tls
   type: certificate
@@ -2394,6 +2418,8 @@ variables:
     common_name: log_cache_gateway_metrics
     extended_key_usage:
     - server_auth
+    alternative_names:
+    - log_cache_gateway_metrics
 
 - name: forwarder_agent_metrics_tls
   type: certificate
@@ -2402,6 +2428,8 @@ variables:
     common_name: forwarder_agent_metrics
     extended_key_usage:
     - server_auth
+    alternative_names:
+    - forwarder_agent_metrics
 
 - name: loggregator_agent_metrics_tls
   type: certificate
@@ -2410,6 +2438,8 @@ variables:
     common_name: loggregator_agent_metrics
     extended_key_usage:
     - server_auth
+    alternative_names:
+    - loggregator_agent_metrics
 
 - name: loggr_udp_forwarder_tls
   type: certificate
@@ -2418,6 +2448,8 @@ variables:
     common_name: loggr_udp_forwarder_metrics
     extended_key_usage:
     - server_auth
+    alternative_names:
+    - loggr_udp_forwarder_metrics
 
 - name: syslog_agent_api_tls
   type: certificate
@@ -2450,6 +2482,8 @@ variables:
     common_name: syslog_agent_metrics
     extended_key_usage:
     - server_auth
+    alternative_names:
+    - syslog_agent_metrics
 
 - name: loggr_syslog_binding_cache_metrics_tls
   type: certificate
@@ -2458,6 +2492,9 @@ variables:
     common_name: loggr_syslog_binding_cache_metrics
     extended_key_usage:
     - server_auth
+    alternative_names:
+    - loggr_syslog_binding_cache_metrics
+
 
 - name: prom_scraper_scrape_tls
   type: certificate
@@ -2466,6 +2503,8 @@ variables:
     common_name: prom_scraper
     extended_key_usage:
     - client_auth
+    alternative_names:
+    - prom_scraper
 
 - name: prom_scraper_metrics_tls
   type: certificate
@@ -2474,6 +2513,8 @@ variables:
     common_name: prom_scraper_metrics
     extended_key_usage:
     - server_auth
+    alternative_names:
+    - prom_scraper_metrics
 
 - name: rlp_gateway_metrics_tls
   type: certificate
@@ -2482,6 +2523,8 @@ variables:
     common_name: rlp_gateway_metrics
     extended_key_usage:
     - server_auth
+    alternative_names:
+    - rlp_gateway_metrics
 
 - name: nats_internal_ca
   type: certificate

--- a/operations/experimental/add-system-metrics-agent.yml
+++ b/operations/experimental/add-system-metrics-agent.yml
@@ -66,6 +66,7 @@
   path: /variables/name=system_metrics?
   value:
     name: system_metrics
+    update_mode: converge
     options:
       ca: loggregator_ca
       common_name: system-metrics
@@ -93,16 +94,20 @@
   path: /variables/name=leadership_election_tls?
   value:
     name: leadership_election_tls
+    update_mode: converge
     options:
       ca: loggregator_ca
       common_name: leadership_election
       extended_key_usage:
       - server_auth
+      alternative_names:
+      - leadership_election
     type: certificate
 - type: replace
   path: /variables/name=leadership_election_client_tls?
   value:
     name: leadership_election_client_tls
+    update_mode: converge
     options:
       ca: loggregator_ca
       common_name: leadership_election_client
@@ -115,6 +120,7 @@
   path: /variables/name=loggr_metric_scraper_metrics_tls?
   value:
     name: loggr_metric_scraper_metrics_tls
+    update_mode: converge
     options:
       ca: metric_scraper_ca
       common_name: loggr_metric_scraper_metrics
@@ -127,9 +133,12 @@
   path: /variables/name=leadership_election_metrics_tls?
   value:
     name: leadership_election_metrics_tls
+    update_mode: converge
     options:
       ca: metric_scraper_ca
       common_name: leadership_election_metrics
       extended_key_usage:
       - server_auth
+      alternative_names:
+      - leadership_election_metrics
     type: certificate

--- a/operations/experimental/add-system-metrics-agent.yml
+++ b/operations/experimental/add-system-metrics-agent.yml
@@ -72,6 +72,8 @@
       extended_key_usage:
       - client_auth
       - server_auth
+      alternative_names:
+      - system-metrics
     type: certificate
 - type: replace
   path: /releases/name=system-metrics?
@@ -106,6 +108,8 @@
       common_name: leadership_election_client
       extended_key_usage:
       - client_auth
+      alternative_names:
+      - leadership_election_client
     type: certificate
 - type: replace
   path: /variables/name=loggr_metric_scraper_metrics_tls?
@@ -116,6 +120,8 @@
       common_name: loggr_metric_scraper_metrics
       extended_key_usage:
       - server_auth
+      alternative_names:
+      - loggr_metric_scraper_metrics
     type: certificate
 - type: replace
   path: /variables/name=leadership_election_metrics_tls?


### PR DESCRIPTION
### WHAT is this change about?

Add alternatives names to all logging and metrics certificates. This is now required due to Golang 1.15. See similar changes from this PR: https://github.com/cloudfoundry/cf-deployment/pull/903

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

This will allow use of logging and metrics components that use Golang 1.15.

### Please provide any contextual information.

* https://cloudfoundry.slack.com/archives/C2U7KA7M4/p1600285368029400
* https://cloudfoundry.slack.com/archives/C2U7KA7M4/p1599754038020000

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

Add Subject Alternative Name (SAN) to all logging and metric certificates in preparation for update to Golang 1.15.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Pulled from linked PR:

This is the simplest varification but you can also provide additional commands to test that the variable holds the desired value.

`bosh ssh doppler`
`sudo su`
`openssl s_client -connect reverse-log-proxy.service.cf.internal:8082 | openssl x509 -noout -text`
View the output. Make sure that the following property is present:

```
            X509v3 Subject Alternative Name:
                DNS:reverselogproxy
```

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@dtimm 