### PR TITLE
Enable TLS between route_registrar and NATS

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -479,6 +479,11 @@ instance_groups:
   - name: route_registrar
     release: routing
     properties:
+      nats:
+        tls:
+          enabled: true
+          client_cert: "((nats_client_cert.certificate))"
+          client_key: "((nats_client_cert.private_key))"
       route_registrar:
         routes:
         - name: cf-mysql-proxy
@@ -757,6 +762,11 @@ instance_groups:
   - name: route_registrar
     release: routing
     properties:
+      nats:
+        tls:
+          enabled: true
+          client_cert: "((nats_client_cert.certificate))"
+          client_key: "((nats_client_cert.private_key))"
       route_registrar:
         routes:
         - health_check:
@@ -816,6 +826,11 @@ instance_groups:
   - name: route_registrar
     release: routing
     properties:
+      nats:
+        tls:
+          enabled: true
+          client_cert: "((nats_client_cert.certificate))"
+          client_key: "((nats_client_cert.private_key))"
       route_registrar:
         routes:
         - name: blobstore
@@ -996,6 +1011,11 @@ instance_groups:
   - name: route_registrar
     release: routing
     properties:
+      nats:
+        tls:
+          enabled: true
+          client_cert: "((nats_client_cert.certificate))"
+          client_key: "((nats_client_cert.private_key))"
       route_registrar:
         routes:
         - name: api
@@ -1733,6 +1753,11 @@ instance_groups:
   - name: route_registrar
     release: routing
     properties:
+      nats:
+        tls:
+          enabled: true
+          client_cert: "((nats_client_cert.certificate))"
+          client_key: "((nats_client_cert.private_key))"
       route_registrar:
         routes:
         - name: doppler

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1486,6 +1486,11 @@ instance_groups:
     release: log-cache
   - name: route_registrar
     properties:
+      nats:
+        tls:
+          enabled: true
+          client_cert: "((nats_client_cert.certificate))"
+          client_key: "((nats_client_cert.private_key))"
       route_registrar:
         routes:
         - name: log-cache-reverse-proxy


### PR DESCRIPTION
### WHAT is this change about?

Enable mTLS between route_registrar (which publishes the route information about cf components) and NATS Server as default.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Securing the CF traffic with TLS

### Please provide any contextual information.

TLS for everything -> https://github.com/cloudfoundry/cf-deployment/issues/906

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

Manifest Update: Enables TLS between route_registrar (running as a job on api, singleton-blobstore, database, log-api, doppler and uaa instance_groups) and NATS.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?
After update the instance_groups like doppler, singleton-blobstore, uaa, log-api, database should be not failing as the route_registrar job can connect to the NATS TLS Server. 
Also the "login.((system_domain))" is available.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**


