### PR TITLE
Configure Gorouter to talk to NATS over mTLS

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1377,6 +1377,10 @@ instance_groups:
         route_services_secret: "((router_route_services_secret))"
         tracing:
           enable_zipkin: true
+      nats:
+        tls_enabled: true
+        cert_chain: "((nats_client_cert.certificate))"
+        private_key: "((nats_client_cert.private_key))"
       routing_api:
         enabled: true
       uaa:


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

✅ We only accept PRs to develop branch.

### WHAT is this change about?



### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

As a compliance and security specialist, Alana is unable to report that their corporate CF deployments are using TLS for all traffic. This fails something that is largely an industry standard.

This PR and its accompanying PRs go a long way to solving the problem. Gorouter will talk to NATS over mTLS by default. It is possible there is future work to do (e.g. disabling non-TLS NATS to solve issues like https://github.com/cloudfoundry/routing-release/issues/185.)

### Please provide any contextual information.

* The issue where Gorouter talking to NATS over plaintext was highlighted: https://github.com/cloudfoundry/cf-deployment/issues/906
* An accompanying PR adding this feature to Gorouter: https://github.com/cloudfoundry/gorouter/pull/283
* A supporting PR to routing-release: https://github.com/cloudfoundry/routing-release/pull/204

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [x] YES - category 4, this modifies the properties of the gorouter job.
- [] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

> _Something brief that conveys the change and is written with the **persona (Alana, Cody...)** in mind. See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

> _Please specify either bosh cli or cf cli commands for our team (and cf operators) to verify the changes._

> _Few examples_
> 1. For a PR with a new job in the manifest, `bosh instances` can verify the job is running after upgrade. You can provide additional commands to verify the job is running as specified.
> 2. For a PR with new variables, `bosh variables | grep <var-name>` command can verify the variable exists. This is the simplest varification but you can also provide additional commands to test that the variable holds the desired value.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

Worked on as part of SAP's CF Routing & Networking team.