### PR TITLE
move aggregate drains to the loggr-syslog-binding-cache job

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2812,9 +2812,9 @@ releases:
   version: 75.1.0
   sha1: d23e29e8e16c127e640ea992aa5e7ac4184000c7
 - name: loggregator-agent
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.0
+  version: 6.3.0
+  sha1: 240a3b3f1e5678eeee24b54e282cf7168209689f
 - name: log-cache
   url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
   version: 2.10.0

--- a/operations/experimental/use-logcache-syslog-ingress-windows2019.yml
+++ b/operations/experimental/use-logcache-syslog-ingress-windows2019.yml
@@ -1,8 +1,4 @@
 ---
 - type: replace
-  path: /instance_groups/name=windows2019-cell/jobs/name=loggr-syslog-agent-windows/properties/aggregate_drains?
-  value: "syslog-tls://doppler.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true"
-
-- type: replace
   path: /instance_groups/name=windows2019-cell/jobs/name=loggr-syslog-agent-windows/properties/drain_ca_cert?
   value: "((log_cache_syslog_tls.ca))"

--- a/operations/experimental/use-logcache-syslog-ingress.yml
+++ b/operations/experimental/use-logcache-syslog-ingress.yml
@@ -32,7 +32,7 @@
   path: /instance_groups/name=doppler/jobs/name=log-cache-nozzle?
 
 - type: replace
-  path: /addons/name=loggr-syslog-agent/jobs/name=loggr-syslog-agent/properties/aggregate_drains?
+  path: /instance_groups/name=scheduler/jobs/name=loggr-syslog-binding-cache/properties/aggregate_drains?
   value: "syslog-tls://doppler.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true"
 
 - type: replace

--- a/operations/test/remove-logging-pipeline-with-danger-windows2019.yml
+++ b/operations/test/remove-logging-pipeline-with-danger-windows2019.yml
@@ -11,9 +11,5 @@
 
 # update syslog agents
 - type: replace
-  path:  /addons/name=loggr-syslog-agent-windows2019/jobs/name=loggr-syslog-agent-windows/properties/aggregate_drains?
-  value: "syslog-tls://q-s3.log-cache.default.cf.bosh:6067"
-
-- type: replace
   path: /addons/name=loggr-syslog-agent-windows2019/jobs/name=loggr-syslog-agent-windows/properties/drain_ca_cert?
   value: "((log_cache_syslog_tls.ca))"

--- a/operations/test/remove-logging-pipeline-with-danger.yml
+++ b/operations/test/remove-logging-pipeline-with-danger.yml
@@ -142,7 +142,7 @@
 
 # update syslog agents
 - type: replace
-  path: /addons/name=loggr-syslog-agent/jobs/name=loggr-syslog-agent/properties/aggregate_drains?
+  path: /instance_groups/name=scheduler/jobs/name=loggr-syslog-binding-cache/properties/aggregate_drains?
   value: "syslog-tls://q-s3.log-cache.default.cf.bosh:6067"
 
 - type: replace


### PR DESCRIPTION
- this should speed up deploys considerably when the only change is a aggregate drain
- this should also make aggregate drains spread over deployments without a additional deploy

### WHAT is this change about?

move aggregate drains to the loggr-syslog-binding-cache job
- this should speed up deploys considerably when the only change is a aggregate drain
- this should also make aggregate drains spread over deployments without a additional deploy if those other deployments also make this change

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

- aggregate drains require deploying every vm on the system

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

- operators can now change aggregate drains(if specified in the loggr-syslog-binding-cache job), on one vm rather then changing every vm

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

- cats succeeds when the opsfile to use syslog for log-cache is used

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
