### PR TITLE
Use mTLS between service-discovery-controller and NATS

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1264,6 +1264,10 @@ instance_groups:
           ca: ((cf_app_sd_server_tls.ca))
         server:
           tls: ((cf_app_sd_server_tls))
+      nats:
+        tls_enabled: true
+        cert_chain: ((nats_client_cert.certificate))
+        private_key: ((nats_client_cert.private_key))
     release: cf-networking
   - name: statsd_injector
     release: statsd-injector


### PR DESCRIPTION
### WHAT is this change about?

This commit enables mTLS between service-discovery-controller and NATS.

Only the client auth has to be specified in YAML; the NATS CA gets into service-discovery-controller via the nats-tls BOSH link.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

As an operator, I want my Cloud Foundry to use mTLS for all internal traffic. This change removes one more plaintext communication link, between `service-discovery-controller` and NATS.

### Please provide any contextual information.

This PR depends on https://github.com/cloudfoundry/cf-networking-release/pull/88 being released first.

This PR contributes to https://github.com/cloudfoundry/cf-deployment/issues/929, where me and @ameowlia are trying to remove plaintext NATS.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change?

No.

### How should this change be described in cf-deployment release notes?

This change removes one more plaintext communication link, between `service-discovery-controller` and NATS. This gets `cf-deployment` closer to using [TLS for Everything](https://github.com/cloudfoundry/cf-deployment/issues/906).

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

No.

### Does this PR make a change to an experimental or GA'd feature/component?

GA'd feature/component

### Please provide Acceptance Criteria for this change?

**Before this change:** SSH onto a `scheduler` VM. Run `lsof -i :4222` and note traffic from `service-discovery-controller` to NATS plaintext port.

**After this change:** Deploy this PR alongside the `cf-networking-release` PR linked above. SSH back onto a `scheduler` VM. See that `lsof -i :4222` no longer lists `service-discovery-controller`. See that `lsof -i :4224` shows that traffic going to NATS TLS port instead.

### What is the level of urgency for publishing this change?

Does not exist a critical issue but blocks us delivering https://github.com/cloudfoundry/cf-deployment/issues/929