### PR TITLE
Remove plaintext NATS

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -377,21 +377,6 @@ instance_groups:
   networks:
   - name: default
   jobs:
-  - name: nats
-    release: nats
-    provides:
-      nats: {as: nats, shared: true}
-    properties:
-      nats:
-        hostname: nats.service.cf.internal
-        user: nats
-        password: "((nats_password))"
-        internal:
-          tls:
-            ca: "((nats_internal_cert.ca))"
-            certificate: "((nats_internal_cert.certificate))"
-            enabled: true
-            private_key: "((nats_internal_cert.private_key))"
   - name: nats-tls
     release: nats
     provides:

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1624,11 +1624,6 @@ instance_groups:
       tls: *cfdot_tls_client_properties
   - name: route_emitter
     release: diego
-    consumes:
-      nats:
-        ip_addresses: false
-      nats-tls:
-        ip_addresses: false
     properties:
       bpm:
         enabled: true

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1264,6 +1264,10 @@ instance_groups:
           ca: ((cf_app_sd_server_tls.ca))
         server:
           tls: ((cf_app_sd_server_tls))
+      nats:
+        tls_enabled: true
+        cert_chain: ((nats_client_cert.certificate))
+        private_key: ((nats_client_cert.private_key))
     release: cf-networking
   - name: statsd_injector
     release: statsd-injector


### PR DESCRIPTION
### WHAT is this change about?

This commit removes the plaintext NATS nodes. All the software used in `cf-deployment` has been modified to handle this and use NATS over mTLS.
    
Without the `nats` job, and without the `nats` link, everything standard in `cf-deployment` will use the `nats-tls` job and link. Any users with custom components that still require plaintext NATS can re-enable it by keeping the plaintext NATS job.

### What customer problem is being addressed?

Until now cf-deployment has deployed a NATS cluster that contained both plaintext and TLS nodes. Internal communication was over mTLS, but clients could choose to connect over plaintext.

Communicating over plaintext is undesirable, as discussed by many users in https://github.com/cloudfoundry/cf-deployment/issues/906. Previous work on this issue has stopped components relying on plaintext NATS, but we should carry on and remove it entirely.

### Please provide any contextual information.

This PR addresses this issue: https://github.com/cloudfoundry/cf-deployment/issues/929

We have already merged all prerequisite PRs:

- https://github.com/cloudfoundry/routing-release/pull/214
- https://github.com/cloudfoundry/cf-networking-release/pull/88
- https://github.com/cloudfoundry/cf-deployment/pull/931

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

YES - removes the existing `nats` job which could impact operators with custom components using NATS

All route registrars will also need a change introduced in https://github.com/cloudfoundry/routing-release/pull/214.

### How should this change be described in cf-deployment release notes?

As an operator I now know that all NATS traffic is sent over mTLS.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

No

### Does this PR make a change to an experimental or GA'd feature/component?

GA'd feature/component

### Please provide Acceptance Criteria for this change?

Deploy this change, run the acceptance tests, and see how they pass despite the lack of plaintext NATS.

### What is the level of urgency for publishing this change?

Slightly Less than Urgent

### Tag your pair, your PM, and/or team!

Collaborating with @ameowlia on this