### PR TITLE
Add ops file to enable HTTP/2 routing

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -25,6 +25,7 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 | [`enable-containerd-for-processes.yml`](enable-containerd-for-processes.yml) | Configure Garden to run processes via containerd. | This ops file **cannot** be deployed in conjunction with `rootless-containers.yml`. | **YES** |
 | [`enable-cpu-throttling.yml`](enable-cpu-throttling.yml) | Configure Garden containers with CPU entitlement. | This ops file requires `set-cpu-weight.yml`. | **YES** |
 | [`enable-direct-io-grootfs.yml`](enable-direct-io-grootfs.yml) | Configure Garden to enable directIO for grootfs. | | **NO** |
+| [`enable-http2.yml`](enable-http2.yml) | Configure Gorouter to enable HTTP/2 routing. | | **NO** |
 | [`enable-iptables-logger.yml`](enable-iptables-logger.yml) | Enables iptables logger. | | **YES** |
 | [`enable-nginx-routing-integrity-windows2019.yml`](enable-nginx-routing-integrity-windows2019.yml) | Enables container proxy on the Windows 2019 Diego Cell `rep` and configures gorouter to opt into TLS-enabled connections to the backend. | **Warning: this is very experimental** Requires `../windows2019-cell.yml` | **NO** |
 | [`enable-oci-phase-1.yml`](enable-oci-phase-1.yml) | Configure CC, Diego, and Garden to create app and task containers more efficiently via OCI image specs. | This ops file **cannot** be deployed in conjunction with `rootless-containers.yml`. | **NO** |

--- a/operations/experimental/enable-http2.yml
+++ b/operations/experimental/enable-http2.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/enable_http2?
+  value: true

--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -31,6 +31,7 @@ enable-bpm-garden.yml: {}
 enable-containerd-for-processes.yml: {}
 enable-cpu-throttling.yml: {}
 enable-direct-io-grootfs.yml: {}
+enable-http2.yml: {}
 enable-iptables-logger.yml: {}
 enable-nginx-routing-integrity-windows2019.yml:
   ops:


### PR DESCRIPTION
- Should no longer be needed after cloudfoundry/routing-release#215 is
merged

Overall HTTP/2 issue: cloudfoundry/routing-release#200

Authored-by: Greg Cobb <gcobb@pivotal.io>

## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

> Provide an interim way to enable HTTP/2 routing until cloudfoundry/routing-release#215 is merged and released.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

> Add experimental ops file to enable HTTP/2 routing.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

> After deploying with this ops file (or a routing release containing cloudfoundry/routing-release#215), the CATs added in https://github.com/cloudfoundry/cf-acceptance-tests/pull/473 should pass.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
