### PR TITLE
    Update cf-deployment for nats-tls client certs required in nats v42+

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -397,6 +397,10 @@ instance_groups:
             ca: "((nats_client_cert.ca))"
             private_key: "((nats_server_cert.private_key))"
             certificate: "((nats_server_cert.certificate))"
+        client:
+          tls:
+            private_key: "((nats_client_cert.private_key))"
+            certificate: "((nats_client_cert.certificate))"
 - name: database
   migrated_from:
   - name: mysql


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Support the upcoming changes to [nats-tls requiring it to have client-cert info](https://github.com/cloudfoundry/nats-release/pull/42) for health checks.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Allows nats-release v43 to be pushed out, resolving issues with never-ending streams of warnings in the nats-tls stderr logs.

### Please provide any contextual information.

https://github.com/cloudfoundry/nats-release/pull/42
https://github.com/cloudfoundry/nats-release/issues/32

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

Nothing necessary?

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

cf deploys and all bosh instances report as healthy

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
