### PR TITLE
Remove obsolete cc_bulk_api_password

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -937,7 +937,6 @@ instance_groups:
           current_key_label: "encryption_key_0"
           keys:
             encryption_key_0: "((cc_db_encryption_key))"
-        bulk_api_password: "((cc_bulk_api_password))"
         internal_api_password: "((cc_internal_api_password))"
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"
@@ -1849,8 +1848,6 @@ variables:
 - name: blobstore_admin_users_password
   type: password
 - name: blobstore_secure_link_secret
-  type: password
-- name: cc_bulk_api_password
   type: password
 - name: cc_db_encryption_key
   type: password

--- a/scripts/fixtures/unit-test-vars-store.yml
+++ b/scripts/fixtures/unit-test-vars-store.yml
@@ -671,7 +671,6 @@ cc_bridge_tps:
     0Is0iF3Ei3KccY/b4ZCtKlEF5PRn19NPeJZsKXlKA9EWJ+JUFTTO7OV2toR2iWqE
     6uVGA2kJi0lkRVL4OwH9wdWFHAAkhDUGI3tHjKj/RtbEUm/0jMA4Kg==
     -----END RSA PRIVATE KEY-----
-cc_bulk_api_password: l52jrtwd0o7oqhm0zq07
 cc_database_password: dlhmrn13ejrthinn1ois
 cc_db_encryption_key: f0rlc2rzvq28e1j86b4x
 cc_internal_api_password: oir6xotljecrgrojj8co


### PR DESCRIPTION
* has been removed with https://github.com/cloudfoundry/capi-release/releases/tag/1.100.0

### WHAT is this change about?

Removed obsolete `cc_bulk_api_password` from cf manifest template and variable definition.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Removed an obsolete credential.

### Please provide any contextual information.

Credential was removed in capi-release 1.100.0: https://github.com/cloudfoundry/capi-release/releases/tag/1.100.0

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [X] YES - please choose the category from below. Feel free to provide additional details.
Manual operator intervention may be necessary to delete the credential from a secure store.
- [ ] NO

### How should this change be described in cf-deployment release notes?

Removed obsolete `cc_bulk_api_password`.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

After successful deployment of cf, you can do
```
bosh -d cf variables | grep bulk
```
and verify that the output is empty.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cloudfoundry/cf-capi
(no "App Runtime Deployments WG" team yet...)
