### PR TITLE
Remove unused q-s3.log-cache.default.cf.bosh

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2266,7 +2266,6 @@ variables:
     ca: loggregator_ca
     common_name: log-cache.service.cf.internal
     alternative_names:
-      - "q-s3.log-cache.default.cf.bosh"
       - "log-cache.service.cf.internal"
     extended_key_usage:
       - server_auth


### PR DESCRIPTION
We cargo culted this from the ops file when we inlined it into
cf-deployment. It seems unnecessary since the default bosh dns strategy
is "smart" and clients should use the service alias.

The only consumers we expect this to affect would be someone who picked
this up in the last two weeks and started using the q-s3 domain instead
of the service alias, which we assume is a null set.



### WHAT is this change about?

Removing alias that is not currently renamed by the "rename network" ops file so is kind of broken now.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Unable to rename the network using cf-deployment. 

### Please provide any contextual information.

https://cloudfoundry.slack.com/archives/C2U7KA7M4/p1646315931755709?thread_ts=1645812408.133929&cid=C2U7KA7M4

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [X] YESish
- [ ] NO

> **Types of breaking changes:**
> 4. modifies the name or deletes a property of a ~~job or instance group~~ certificate in the main manifest

### How should this change be described in cf-deployment release notes?

> _Something brief that conveys the change and is written with the **persona (Alana, Cody...)** in mind. See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

Removes q-s3.log-cache.default.cf.bosh alias which we believe is unused.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

> _Please specify either bosh cli or cf cli commands for our team (and cf operators) to verify the changes._

> _Few examples_
> 1. For a PR with a new job in the manifest, `bosh instances` can verify the job is running after upgrade. You can provide additional commands to verify the job is running as specified.
> 2. For a PR with new variables, `bosh variables | grep <var-name>` command can verify the variable exists. This is the simplest varification but you can also provide additional commands to test that the variable holds the desired value.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@andrew-edgar  @Benjamintf1 

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
