### PR TITLE
Update the test iso seg ops-file

### DIFF
--- a/operations/test/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/test/add-persistent-isolation-segment-diego-cell.yml
@@ -23,6 +23,8 @@
           - ((uaa_ssl.ca))
     - name: garden
       release: garden-runc
+      provides:
+        iptables: nil
       properties:
         garden:
           containerd_mode: true


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

This PR updates the `operations/test/add-persistent-isolation-segment-diego-cell.yml` test ops-file used in CI to ignore the duplicate `iptables` BOSH link it introduces.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

CI was failing after the bump to silk v3.0.0.

### Please provide any contextual information.

https://release-integration.ci.cf-app.com/teams/main/pipelines/cf-deployment/jobs/fresh-deploy/builds/3493

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO
- [x] N/A

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A (this is not a user-facing change)

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component
- [x] CI test fixture

### Please provide Acceptance Criteria for this change?

It is possible to deploy with the `operations/test/add-persistent-isolation-segment-diego-cell.yml` test ops-file.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
