### PR TITLE
Add database_encryption to cc_deployment_updater

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1256,6 +1256,7 @@ instance_groups:
     properties:
       cc:
         db_encryption_key: ((cc_db_encryption_key))
+        database_encryption: *cc-database-encryption
         mutual_tls:
           ca_cert: "((cc_tls.ca))"
           private_key: "((cc_tls.private_key))"


### PR DESCRIPTION
### WHAT is this change about?

This change adds the `database_encryption` YAML block to the `cc_deployment_updater` job. This might not be required, but we're assuming that if you've configured encryption key rotation you should specify the `database_encryption` block. The spec in the `cc_deployment_updater` seems to suggest this can be configured:

https://github.com/cloudfoundry/capi-release/blob/develop/jobs/cc_deployment_updater/spec#L105-L110

And since this is configured for all other CC properties it seems sensible to maintain consistency.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

We've added it to reduce any confusion surrounding the cc properties configuration within the deployment manifest. By aligned all sections which specify `cc.properties` it reduces any confusion when rotating encryption keys for the cloud controller database.

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

This change aligns the CC properties in terms of the Encryption key configuration for each CC instance group(api, cc-worker, scheduler).

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component
