### PR TITLE
Revert CF-Networking and Silk releases to v2.43.0

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2750,9 +2750,9 @@ releases:
   version: 1.127.0
   sha1: 2552942c605a5b57556ffb1c8a44ef8bb601b9ce
 - name: cf-networking
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=3.1.0
-  version: 3.1.0
-  sha1: 0c197afd09b79aa872051480412327c1a04120dd
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.43.0
+  version: 2.43.0
+  sha1: 707884b81c744a9e4006b2b6ac1fea075d604224
 - name: cf-smoke-tests
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
@@ -2830,9 +2830,9 @@ releases:
   version: 1.8.51
   sha1: 0bf5670f968364ab3de3751bc77972489ed3bdb4
 - name: silk
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=3.1.0
-  version: 3.1.0
-  sha1: 3ecad2d4b7a94df95aaaba66f9f5085356b75810
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.43.0
+  version: 2.43.0
+  sha1: 66e5d68d70e82680fc5a6b9f2357732e573c2480
 - name: staticfile-buildpack
   url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.29
   version: 1.5.29

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -56,8 +56,8 @@
     stemcell:
       os: ubuntu-xenial
       version: "621.5"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/cf-networking-3.1.0-ubuntu-xenial-621.5-20220310-152425-548847059.tgz
-    version: 3.1.0
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/cf-networking-2.43.0-ubuntu-xenial-621.5-20220113-181412-725797188.tgz
+    version: 2.43.0
 - type: replace
   path: /releases/name=cf-smoke-tests
   value:
@@ -266,8 +266,8 @@
     stemcell:
       os: ubuntu-xenial
       version: "621.5"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/silk-3.1.0-ubuntu-xenial-621.5-20220310-152348-404945925.tgz
-    version: 3.1.0
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/silk-2.43.0-ubuntu-xenial-621.5-20220113-181201-335981005.tgz
+    version: 2.43.0
 - type: replace
   path: /releases/name=staticfile-buildpack
   value:


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

This PR reverts cf-networking-release and silk-release to v2.430.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

There are bugs in v3.0.0 and v3.1.0 of cf-networking-release and silk-release that cause app deploys to fail on "large" deployments.

### Please provide any contextual information.

[Slack conversation with @ameowlia](https://cloudfoundry.slack.com/archives/C01ABMVNE9E/p1647038551593199)

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

> _Something brief that conveys the change and is written with the **persona (Alana, Cody...)** in mind. See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

CATs pass in CI.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
