### PR TITLE
Adds support for cf-deployment Prometheus metrics

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -980,6 +980,10 @@ instance_groups:
           ca_cert: "((cc_tls.ca))"
           public_cert: "((cc_tls.certificate))"
           private_key: "((cc_tls.private_key))"
+        prom_scraper_tls:
+          ca_cert: ((cc_prom_scraper_scrape_tls.ca))
+          private_key: ((cc_prom_scraper_scrape_tls.private_key))
+          public_cert: ((cc_prom_scraper_scrape_tls.certificate))
         public_tls:
           ca_cert: "((cc_public_tls.ca))"
           certificate: "((cc_public_tls.certificate))"
@@ -2699,6 +2703,18 @@ variables:
     - prom_scraper_metrics
     extended_key_usage:
     - server_auth
+
+- name: cc_prom_scraper_scrape_tls
+  options:
+    alternative_names:
+    - cloud-controller-ng.service.cf.internal
+    ca: metric_scraper_ca
+    common_name: cloud-controller-ng.service.cf.internal
+    extended_key_usage:
+    - client_auth
+    - server_auth
+  type: certificate
+  update_mode: converge
 
 - name: rlp_gateway_metrics_tls
   type: certificate


### PR DESCRIPTION
### WHAT is this change about?

This commit adds the variable and manifest parameters that will be required for future consumption by code to support the `prom_scraper` Prometheus metrics scraper.

This PR is intended to support the work that will be merged in these two PRs: https://github.com/cloudfoundry/capi-release/pull/240 and https://github.com/cloudfoundry/cloud_controller_ng/pull/2781 . You probably should merge this PR _after_ those two get merged in to their primary branches, but it shouldn't cause any trouble if you merged this PR in before one or both of those got merged in.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

I believe that it's true that most of the rest of CF uses prom_scraper to gather metrics and Cloud Controller / CAPI is one of the last holdouts. This work is required to support the changes made to CC / CAPI to eventually migrate from StatsD to prom_scraper.

### Please provide any contextual information.

Here is the CAPI Team's Tracker story that tracks the work: https://www.pivotaltracker.com/story/show/181067519 . That story tracks this Cloud Controller Github Issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/2648

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

Update cf-deployment manifest to support work to switch over to `prom_scraper`. This supports work to address https://github.com/cloudfoundry/cloud_controller_ng/issues/2648

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Acceptance criteria:
* CAPI releases released prior to to Thursday, April 28th successfully pass cf-acceptance-tests.
* CAPI releases released after the two PRs mentioned above have been merged in successfully pass cf-acceptance-tests, _and_ our new Prometheus metrics appear in the firehose. After installing the Loggregator Firehose Plugin for the `cf` CLI, and targeting a running Cloud Foundry, run the following command, and wait for a minutes or two for output:

```
cf nozzle -n ValueMetric | grep --line-buffered cc_http_status_2XX
```

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

This allows us to get a capi release that supports the old metrics we were using and new Prometheus based metrics

### Tag your pair, your PM, and/or team!

cc @dalvarado @moleske @MerricdeLauney @tjvman @sethboyles