### PR TITLE
Feat: add ops file to use Jammy in CF-D

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -42,3 +42,4 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 | [`disable-logs-in-firehose.yml`](disable-logs-in-firehose.yml) | Logs are not sent to dopplers, only metrics | | **NO** |
 | [`disable-logs-in-firehose-windows2019.yml`](disable-logs-in-firehose-windows-2019.yml) | Logs are not sent to dopplers, only metrics | | **NO** |
 | [`use-native-garden-runc-runner.yml`](use-native-garden-runc-runner.yml) | Configure Garden to **not** create containers via containerd, using the native runner instead. | | **NO** |
+| [`use-jammy.yml`](use-jammy.yml) | Use the new beta Jammy stemcell | This is incompatible with `../use-compiled-releases.yml` | **NO** |

--- a/operations/experimental/use-jammy.yml
+++ b/operations/experimental/use-jammy.yml
@@ -1,6 +1,6 @@
 - path: /stemcells/alias=default
-   type: replace
-   value:
-     alias: default
-     os: ubuntu-jammy
-     version: latest
+  type: replace
+  value:
+    alias: default
+    os: ubuntu-jammy
+    version: latest

--- a/operations/experimental/use-jammy.yml
+++ b/operations/experimental/use-jammy.yml
@@ -1,0 +1,6 @@
+- path: /stemcells/alias=default
+   type: replace
+   value:
+     alias: default
+     os: ubuntu-jammy
+     version: latest

--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -57,3 +57,4 @@ use-compiled-releases-windows.yml:
   - use-compiled-releases-windows.yml
 use-create-swap-delete-vm-strategy.yml: {}
 use-native-garden-runc-runner.yml: {}
+use-jammy.yml: {}


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

This is a PR to develop.

### WHAT is this change about?

This expermental ops file will allow operators to use the jammy stemcell
when applied.

* Requires a jammy stemcell to have been uploaded to any given CF-D
  environment.
* Will not work with compiled releases at present.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Operators and maintainers want to start testing CF-D with the Jammy stemcell.

### Please provide any contextual information.

#946

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO
- [x] N/A

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component
- [x] N/A

### Please provide Acceptance Criteria for this change?

```
bosh deploy -d cf-deployment -o operations/experimental/use-jammy.yml -v system_domain="<system-domain>"
```

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cloudfoundry/app-runtime-deployments-wg-approvers 