### PR TITLE
Add certs for internal communication between CC and ASG Syncer

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1124,6 +1124,9 @@ instance_groups:
   - name: policy-server-asg-syncer
     release: cf-networking
     properties:
+      cc_internal:
+        client_cert: "((policy_server_asg_syncer_cc_client.certificate))"
+        client_key: "((policy_server_asg_syncer_cc_client.private_key))"
       uaa_client_secret: ((uaa_clients_network_policy_secret))
       uaa_ca: ((uaa_ssl.ca))
       locket:
@@ -2389,6 +2392,14 @@ variables:
     common_name: cc_uploader
     alternative_names:
     - cc_uploader
+    extended_key_usage:
+    - client_auth
+- name: policy_server_asg_syncer_cc_client
+  type: certificate
+  update_mode: converge
+  options:
+    ca: service_cf_internal_ca
+    common_name: policy_server_asg_syncer_cc_client
     extended_key_usage:
     - client_auth
 - name: cc_bridge_cc_uploader_server


### PR DESCRIPTION
Signed-off-by: David Sabeti <sabetid@vmware.com>

### WHAT is this change about?

An upcoming version of cf-networking-release (3.10.0) will introduce a communication path between the ASG syncer and the Cloud Controller. This communication happens over MTLS, so the asyc syncer needs a certificate signed by the same CA as the CC certificate. This change adds those certs for the ASG syncer.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

The new communication path allows the ASG syncer to skip updates based on information from a new CAPI endpoint. So, operators will benefit from less unnecessary traffic to the CC.

### Please provide any contextual information.

- cf-networking PR: https://github.com/cloudfoundry/cf-networking-release/pull/158

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

(Some tests -- such as http2 tests -- were skipped because the environment available to us was not configurable (for example, we could not configure our LB to enable https.)

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x ] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

`bosh variables | grep policy_server_asg_syncer_cc_client` command can verify the variable exists.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@cloudfoundry/runtime 