### PR TITLE
Expand Cloud Controller username lookup scope

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -717,8 +717,9 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: "((uaa_clients_cf_smoke_tests_secret))"
           cloud_controller_username_lookup:
-            authorities: scim.userids
+            authorities: scim.userids,scim.read
             authorized-grant-types: client_credentials
+            override: true
             secret: "((uaa_clients_cloud_controller_username_lookup_secret))"
           credhub_admin_client:
             authorities: credhub.read,credhub.write


### PR DESCRIPTION
### WHAT is this change about?

We are working on a partial username search feature for CAPI /v3/organizations/:guid/users, and we have to update the UAA scope to enable it.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Users can do a partial username search via CAPI by querying UAA https://docs.cloudfoundry.org/api/uaa/version/75.22.0/index.html#list-3


### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES, potentially
- [ ] NO 

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?



### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

> _Please specify either bosh cli or cf cli commands for our team (and cf operators) to verify the changes._

For a PR with a partial username lookup in CAPI the `cloud_controller_username_lookup` UAA client is getting `scim.read` scope

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@jdgonzaleza, @cloudfoundry/cf-cli