### PR TITLE
Add missing alternative_names option to `policy_server_asg_syncer_cc_client`

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2401,6 +2401,8 @@ variables:
   options:
     ca: service_cf_internal_ca
     common_name: policy_server_asg_syncer_cc_client
+    alternative_names:
+      - policy_server_asg_syncer_cc_client
     extended_key_usage:
     - client_auth
 - name: cc_bridge_cc_uploader_server


### PR DESCRIPTION
### WHAT is this change about?

Add an alternative_name to the automatically issued certificate for policy_server_asg_syncer_cc_client.

### Please provide any contextual information.

As-per https://github.com/alphagov/paas-cf/commit/f78080:

> In Go 1.15, treating the CommonName field of an x.509 certificate as a host name when no Subject Alternative Name is present is [deprecated](https://golang.org/doc/go1.15#commonname).

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The certificates issued by `service_cf_internal_ca` for `policy_server_asg_syncer_cc_client` should have an alternative name

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@alphagov
