### PR TITLE
Disable v2 CF API on hermione

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1137,6 +1137,7 @@ jobs:
         operations/experimental/enable-cpu-throttling.yml
         operations/experimental/enable-oci-phase-1.yml
         operations/experimental/enable-containerd-for-processes.yml
+        operations/experimental/disable-v2-api.yml
         operations/increase-doppler-vm-type-from-minimal-to-small.yml
         operations/test/speed-up-dynamic-asgs.yml
       VARS_FILES: |


### PR DESCRIPTION
### WHAT is this change about?

Disables CF API v2 on the `hermione` test environment

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

This will validate that deployments can succeed using only the v3 API.

### Please provide any contextual information.

We recently discovered that disabling the v2 API would cause the [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests) to fail because two tests rely on a v2 endpoint that has not been ported to v3 (see [here](https://github.com/cloudfoundry/cloud_controller_ng/issues/2872) for more details). The endpoint in question is [/v2/service_instances/:guid/permissions](https://apidocs.cloudfoundry.org/16.22.0/service_instances/retrieving_permissions_on_a_service_instance.html), and PRs are now open to create an equivalent v3 endpoint.

The present PR depends on the following two PRs being merged first:
1. https://github.com/cloudfoundry/cloud_controller_ng/pull/2946
1. https://github.com/cloudfoundry/cf-acceptance-tests/pull/593
### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES (tested with v21.2.0)
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

n/a

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

n/a

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**