### PR TITLE
Add Ops-File To Enable CC V2 API Rate Limit

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -699,8 +699,8 @@ instance_groups:
             authorities: clients.read,clients.write,clients.admin
             authorized-grant-types: client_credentials
             scopes:
-              - openid
-              - cloud_controller_service_permissions.read
+            - openid
+            - cloud_controller_service_permissions.read
             secret: "((uaa_clients_cc-service-dashboards_secret))"
           cc_service_key_client:
             authorities: credhub.read,credhub.write
@@ -713,23 +713,23 @@ instance_groups:
             override: true
             refresh-token-validity: 2592000
             scopes:
-              - network.admin
-              - network.write
-              - cloud_controller.read
-              - cloud_controller.write
-              - openid
-              - password.write
-              - cloud_controller.admin
-              - scim.read
-              - scim.write
-              - doppler.firehose
-              - uaa.user
-              - routing.router_groups.read
-              - routing.router_groups.write
-              - cloud_controller.admin_read_only
-              - cloud_controller.global_auditor
-              - perm.admin
-              - clients.read
+            - network.admin
+            - network.write
+            - cloud_controller.read
+            - cloud_controller.write
+            - openid
+            - password.write
+            - cloud_controller.admin
+            - scim.read
+            - scim.write
+            - doppler.firehose
+            - uaa.user
+            - routing.router_groups.read
+            - routing.router_groups.write
+            - cloud_controller.admin_read_only
+            - cloud_controller.global_auditor
+            - perm.admin
+            - clients.read
             secret: ''
           cf_smoke_tests:
             authorities: cloud_controller.admin,clients.read
@@ -759,10 +759,10 @@ instance_groups:
             override: true
             redirect-uri: "https://uaa.((system_domain))/login"
             scopes:
-              - openid
-              - cloud_controller.read
-              - cloud_controller.write
-              - cloud_controller.admin
+            - openid
+            - cloud_controller.read
+            - cloud_controller.write
+            - cloud_controller.admin
             secret: "((uaa_clients_ssh-proxy_secret))"
           routing_api_client:
             authorities: routing.routes.write,routing.routes.read,routing.router_groups.read

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -698,7 +698,9 @@ instance_groups:
           cc-service-dashboards:
             authorities: clients.read,clients.write,clients.admin
             authorized-grant-types: client_credentials
-            scope: openid,cloud_controller_service_permissions.read
+            scopes:
+              - openid
+              - cloud_controller_service_permissions.read
             secret: "((uaa_clients_cc-service-dashboards_secret))"
           cc_service_key_client:
             authorities: credhub.read,credhub.write
@@ -710,7 +712,24 @@ instance_groups:
             authorized-grant-types: password,refresh_token
             override: true
             refresh-token-validity: 2592000
-            scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor,perm.admin,clients.read
+            scopes:
+              - network.admin
+              - network.write
+              - cloud_controller.read
+              - cloud_controller.write
+              - openid
+              - password.write
+              - cloud_controller.admin
+              - scim.read
+              - scim.write
+              - doppler.firehose
+              - uaa.user
+              - routing.router_groups.read
+              - routing.router_groups.write
+              - cloud_controller.admin_read_only
+              - cloud_controller.global_auditor
+              - perm.admin
+              - clients.read
             secret: ''
           cf_smoke_tests:
             authorities: cloud_controller.admin,clients.read
@@ -739,7 +758,11 @@ instance_groups:
             autoapprove: true
             override: true
             redirect-uri: "https://uaa.((system_domain))/login"
-            scope: openid,cloud_controller.read,cloud_controller.write,cloud_controller.admin
+            scopes:
+              - openid
+              - cloud_controller.read
+              - cloud_controller.write
+              - cloud_controller.admin
             secret: "((uaa_clients_ssh-proxy_secret))"
           routing_api_client:
             authorities: routing.routes.write,routing.routes.read,routing.router_groups.read

--- a/operations/README.md
+++ b/operations/README.md
@@ -38,6 +38,7 @@ This is the README for Ops-files. To learn more about `cf-deployment`, go to the
 | [`disable-http2.yml`](disable-http2.yml) | Prevent gorouter from accepting and forwarding HTTP/2 requests. | | **NO** |
 | [`disable-dynamic-asgs.yml`](disable-dynamic-asgs.yml) | Disable dynamic updates for security groups. | | **NO** |
 | [`enable-cc-rate-limiting.yml`](enable-cc-rate-limiting.yml) | Enable rate limiting for UAA-authenticated endpoints. | Introduces variables `cc_rate_limiter_general_limit` and `cc_rate_limiter_unauthenticated_limit` | **NO** |
+| [`enable-cc-v2-rate-limiting.yml`](enable-cc-rate-limiting.yml) | Enable V2 API rate limiting for UAA-authenticated endpoints. | Introduces variables `cc_v2_rate_limiter_general_limit`, `cc_v2_rate_limiter_admin_limit` and `cc_v2_rate_limiter_reset_interval_in_minutes` | **NO** |
 | [`enable-cpu-throttling.yml`](enable-cpu-throttling.yml) | Configure Garden containers with CPU entitlement. | This ops file requires `set-cpu-weight.yml`. | **YES** |
 | [`enable-nfs-ldap.yml`](enable-nfs-ldap.yml) | Enables LDAP authentication for NFS volume services | Requires `enable-nfs-volume-service.yml`. Introduces [new variables](example-vars-files/vars-enable-nfs-ldap.yml) | **NO** |
 | [`enable-nfs-volume-service.yml`](enable-nfs-volume-service.yml) | Enables volume support and deploys an NFS broker and volume driver | As of cf-deployment v2, you must use the `nfsbrokerpush` errand to cf push the nfs broker after `bosh deploy` completes. | **YES** |

--- a/operations/enable-cc-v2-rate-limiting.yml
+++ b/operations/enable-cc-v2-rate-limiting.yml
@@ -1,0 +1,11 @@
+---
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/rate_limiter_v2_api?
+  value:
+    enabled: true
+    general_limit: "((cc_v2_rate_limiter_general_limit))"
+    admin_limit: "((cc_v2_rate_limiter_admin_limit))"
+    reset_interval_in_minutes: "((cc_v2_rate_limiter_reset_interval_in_minutes))"
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/cf/scopes/-
+  value: "cloud_controller.v2_api_rate_limit_exempt"

--- a/units/tests/standard_test/operations.yml
+++ b/units/tests/standard_test/operations.yml
@@ -12,6 +12,11 @@ enable-cc-rate-limiting.yml:
   vars:
   - cc_rate_limiter_general_limit=blah
   - cc_rate_limiter_unauthenticated_limit=something
+enable-cc-v2-rate-limiting.yml:
+  vars:
+  - cc_v2_rate_limiter_general_limit=blah
+  - cc_v2_rate_limiter_admin_limit=something
+  - cc_v2_rate_limiter_reset_interval_in_minutes=else
 enable-cpu-throttling.yml: {}
 enable-nfs-ldap.yml:
   ops:


### PR DESCRIPTION
### WHAT is this change about?

- Refactor UAA client scopes to use a yaml list instead of single line strings. This will make it easier for ops files to manipulate scopes. This is allowed in uaa-release: https://github.com/cloudfoundry/uaa-release/pull/89
- Add new ops file `enable-cc-v2-rate-limiting.yml` to enable rate limiting for CC V2 API. The ops file is optional and not used per default. Same as for `enable-cc-rate-limiting.yml`

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

- Refactor UAA client scopes to use a yaml list instead of single line strings. **This can be a breaking change if cf-d consumers have ops-files which manipulate UAA scopes**
- Add new ops file `enable-cc-v2-rate-limiting.yml` to enable rate limiting for CC V2 API

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [x] YES - new ops file `enable-cc-v2-rate-limiting.yml` to enable rate limiting for CC V2 API
- [ ] NO

### Does this PR make a change to an experimental or GA'd feature/component?
No.

### Please provide Acceptance Criteria for this change?

UAA should be deployed successfully and login with CF CLI should work

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@jochenehret @philippthun @stephanme 
