### PR TITLE
Add bionic stemcell validation pipeline

### DIFF
--- a/ci/pipelines/bionic-stemcell.md
+++ b/ci/pipelines/bionic-stemcell.md
@@ -1,16 +1,15 @@
 # bionic-stemcell
 
-Test cf-d on the Ubuntu bionic stemcell.
+Test cf-d on the Ubuntu Bionic stemcell.
 
 ## Triggers
 
-This pipeline is automatically triggered when new bionic stemcells are published, or when a cf-d commit passes through the cf-deployment CI to be promoted to the `release-candidate` branch.
+This pipeline is automatically triggered when new Bionic stemcells are published, or when a cf-d commit passes through the cf-deployment CI to be promoted to the `release-candidate` branch.
 
 ## Cleanup
 
-If the pipeline succeeds, then it will cleanup after itself.
-
-If the pipeline fails then there will be an orphaned Toolsmiths environment. This is by design so that we can examine the pipeline to determine the causes of any failure. In this situation, an environment can be manually unclaimed with the `unclaim-env-manual` job.
+If the pipeline succeeds, then it will clean up the CF BOSH deployment after itself. The bbl environment is "stable-bellatrix" and is managed by the "infrastructure" pipeline:
+https://app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/infrastructure?group=stable-bellatrix
 
 ## Pipeline Management
 

--- a/ci/pipelines/bionic-stemcell.md
+++ b/ci/pipelines/bionic-stemcell.md
@@ -1,0 +1,17 @@
+# bionic-stemcell
+
+Test cf-d on the Ubuntu bionic stemcell.
+
+## Triggers
+
+This pipeline is automatically triggered when new bionic stemcells are published, or when a cf-d commit passes through the cf-deployment CI to be promoted to the `release-candidate` branch.
+
+## Cleanup
+
+If the pipeline succeeds, then it will cleanup after itself.
+
+If the pipeline fails then there will be an orphaned Toolsmiths environment. This is by design so that we can examine the pipeline to determine the causes of any failure. In this situation, an environment can be manually unclaimed with the `unclaim-env-manual` job.
+
+## Pipeline Management
+
+This pipeline is managed directly by the `ci/pipelines/bionic-stemcell.yml` file and the `ci/configure` script. To update the pipeline, run `ci/configure bionic-stemcell`.

--- a/ci/pipelines/bionic-stemcell.yml
+++ b/ci/pipelines/bionic-stemcell.yml
@@ -188,6 +188,7 @@ jobs:
     - get: stable-pool
       passed:
       - run-cats
+      trigger: true
     - in_parallel:
         steps:
         - get: cf-deployment-concourse-tasks

--- a/ci/pipelines/bionic-stemcell.yml
+++ b/ci/pipelines/bionic-stemcell.yml
@@ -1,88 +1,30 @@
-resources:
-- icon: github
-  name: cf-acceptance-tests
-  source:
-    branch: release-candidate
-    uri: https://github.com/sap-contributions/cf-acceptance-tests.git
-  type: git
-  check_every: 1m
-
-- icon: github
-  name: cf-deployment
-  source:
-    branch: release-candidate
-    uri: https://github.com/sap-contributions/cf-deployment.git
-  type: git
-  check_every: 1m
-
-- icon: github
-  name: cf-deployment-concourse-tasks
-  source:
-    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
-  type: git
-
-- icon: dna
-  name: bionic-stemcell
-  source:
-    name: bosh-google-kvm-ubuntu-bionic-go_agent
-  type: bosh-io-stemcell
-
-- icon: github
-  name: runtime-ci
-  source:
-    uri: https://github.com/cloudfoundry/runtime-ci.git
-  type: git
-
-- name: bbl-state
-  type: s3
-  source:
-    region_name: eu-central-1
-    bucket: bionic-stemcell-test
-    versioned_file: bbl-state.tar.gz
-    access_key_id: #TODO
-    secret_access_key: #TODO
-    initial_version: '0'
-
 jobs:
-- name: bbl-up
-  serial: true
+- name: claim-env
   plan:
-  - in_parallel:
-    - get: cf-deployment-concourse-tasks
-    - get: bbl-state
-      params:
-        unpack: true
-    - task: bbl-up
-      file: cf-deployment-concourse-tasks/bbl-up/task.yml
-      input_mapping:
-        bbl-config: cf-load-test-pipeline
-      params:
-        BBL_AWS_ACCESS_KEY_ID: #TODO
-        BBL_AWS_SECRET_ACCESS_KEY: #TODO
-        BBL_AWS_REGION: eu-west-1
-        BBL_IAAS: aws
-        BBL_CONFIG_DIR: bbl-patches
-        BBL_LB_CERT: ../cert.pem
-        BBL_LB_KEY: ../key
-        SKIP_LB_CREATION: false
-        LB_DOMAIN: ((sys_domain))
-        STORE_BBL_STATE_AS_TARBALL: true
-      ensure:
-        put: bbl-state
-        params:
-          file: updated-bbl-state/bbl-state.tgz
+  - get: bionic-stemcell
+    trigger: true
+  - get: cf-deployment
+    trigger: true
+  - params:
+      action: claim
+    put: toolsmiths-env
+    timeout: 4h
+  serial: true
 
 - name: deploy-cf
   plan:
   - in_parallel:
       steps:
+      - get: toolsmiths-env
+        passed:
+        - claim-env
+        trigger: true
       - get: bionic-stemcell
+        passed:
+        - claim-env
       - get: cf-deployment
       - get: cf-deployment-concourse-tasks
       - get: runtime-ci
-      - get: bbl-state
-        passed:
-        - bbl-up
   - file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
     params:
       IGNORE_ERRORS: "true"
@@ -101,6 +43,7 @@ jobs:
         source:
           repository: cloudfoundry/cf-deployment-concourse-tasks
       inputs:
+      - name: toolsmiths-env
       - name: cf-deployment-concourse-tasks
       run:
         dir: ""
@@ -156,10 +99,11 @@ jobs:
   plan:
   - in_parallel:
       steps:
-      - get: cf-deployment-concourse-tasks
-      - get: cf-deployment # remove in PR | replace with toolsmiths env 
+      - get: toolsmiths-env
         passed:
         - deploy-cf
+        trigger: true
+      - get: cf-deployment-concourse-tasks
   - file: cf-deployment-concourse-tasks/run-errand/task.yml
     params:
       ERRAND_NAME: smoke_tests
@@ -172,11 +116,12 @@ jobs:
   plan:
   - in_parallel:
       steps:
-      - get: cf-deployment-concourse-tasks
-      - get: cf-acceptance-tests
-      - get: cf-deployment # remove in PR | replace with toolsmiths env 
+      - get: toolsmiths-env
         passed:
         - run-smoke-tests
+        trigger: true
+      - get: cf-deployment-concourse-tasks
+      - get: cf-acceptance-tests
   - config:
       image_resource:
         source:
@@ -184,6 +129,7 @@ jobs:
         type: docker-image
       inputs:
       - name: cf-deployment-concourse-tasks
+      - name: toolsmiths-env
       outputs:
       - name: integration-configs
       params:
@@ -249,3 +195,73 @@ jobs:
     task: run-cats
   public: true
   serial: true
+
+- name: unclaim-env
+  plan:
+  - get: toolsmiths-env
+    passed:
+    - run-cats
+    trigger: true
+  - params:
+      action: unclaim
+      env_file: toolsmiths-env/metadata
+    put: toolsmiths-env
+  serial: true
+
+- name: unclaim-env-manual
+  plan:
+  - get: toolsmiths-env
+  - params:
+      action: unclaim
+      env_file: toolsmiths-env/metadata
+    put: toolsmiths-env
+  serial: true
+
+resource_types:
+- name: toolsmiths-cf-pool
+  source:
+    repository: cftoolsmiths/toolsmiths-envs-resource
+  type: docker-image
+
+resources:
+- icon: github
+  name: cf-acceptance-tests
+  source:
+    branch: release-candidate
+    private_key: ((cf_acceptance_tests_readwrite_deploy_key.private_key))
+    uri: git@github.com:cloudfoundry/cf-acceptance-tests.git
+  type: git
+
+- icon: github
+  name: cf-deployment
+  source:
+    branch: release-candidate
+    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    uri: git@github.com:cloudfoundry/cf-deployment.git
+  type: git
+
+- icon: github
+  name: cf-deployment-concourse-tasks
+  source:
+    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
+  type: git
+
+- icon: dna
+  name: bionic-stemcell
+  source:
+    name: bosh-google-kvm-ubuntu-bionic-go_agent
+  type: bosh-io-stemcell
+
+- icon: github
+  name: runtime-ci
+  source:
+    uri: https://github.com/cloudfoundry/runtime-ci.git
+  type: git
+
+- icon: pool
+  name: toolsmiths-env
+  source:
+    api_token: ((toolsmiths_api_token))
+    hostname: environments.toolsmiths.cf-app.com
+    pool_name: cf-deployment
+  type: toolsmiths-cf-pool

--- a/ci/pipelines/bionic-stemcell.yml
+++ b/ci/pipelines/bionic-stemcell.yml
@@ -1,0 +1,267 @@
+resource_types:
+- name: toolsmiths-cf-pool
+  source:
+    repository: cftoolsmiths/toolsmiths-envs-resource
+  type: docker-image
+
+resources:
+- icon: github
+  name: cf-acceptance-tests
+  source:
+    branch: release-candidate
+    private_key: ((cf_acceptance_tests_readwrite_deploy_key.private_key))
+    uri: git@github.com:cloudfoundry/cf-acceptance-tests.git
+  type: git
+
+- icon: github
+  name: cf-deployment
+  source:
+    branch: release-candidate
+    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    uri: git@github.com:cloudfoundry/cf-deployment.git
+  type: git
+
+- icon: github
+  name: cf-deployment-concourse-tasks
+  source:
+    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
+  type: git
+
+- icon: dna
+  name: jammy-stemcell
+  source:
+    name: bosh-google-kvm-ubuntu-jammy-go_agent
+  type: bosh-io-stemcell
+
+- icon: github
+  name: runtime-ci
+  source:
+    uri: https://github.com/cloudfoundry/runtime-ci.git
+  type: git
+
+- icon: pool
+  name: toolsmiths-env
+  source:
+    api_token: ((toolsmiths_api_token))
+    hostname: environments.toolsmiths.cf-app.com
+    pool_name: cf-deployment
+  type: toolsmiths-cf-pool
+
+jobs:
+- name: claim-env
+  plan:
+  - get: jammy-stemcell
+    trigger: true
+  - get: cf-deployment
+    trigger: true
+  - params:
+      action: claim
+    put: toolsmiths-env
+    timeout: 4h
+  serial: true
+
+- name: deploy-cf
+  plan:
+  - in_parallel:
+      steps:
+      - get: toolsmiths-env
+        passed:
+        - claim-env
+        trigger: true
+      - get: jammy-stemcell
+        passed:
+        - claim-env
+      - get: cf-deployment
+      - get: cf-deployment-concourse-tasks
+      - get: runtime-ci
+  - file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+    params:
+      IGNORE_ERRORS: "true"
+    task: bosh-delete-cf-deployment
+  - file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
+    task: bosh-cleanup
+  - file: runtime-ci/tasks/bosh-upload-stemcell/task.yml
+    input_mapping:
+      stemcell: jammy-stemcell
+    task: upload-jammy-stemcell
+  - task: update-dns-runtime-config
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: cloudfoundry/cf-deployment-concourse-tasks
+      inputs:
+      - name: toolsmiths-env
+      - name: cf-deployment-concourse-tasks
+      run:
+        dir: ""
+        path: bash
+        args:
+        - -c
+        - |
+          #!/bin/bash
+          source cf-deployment-concourse-tasks/shared-functions
+          setup_bosh_env_vars
+          cat <<EOT > /tmp/add-jammy.yml
+          ---
+          - type: replace
+            path: /addons/name=bosh-dns/include/stemcell/-
+            value:
+              os: ubuntu-jammy
+          EOT
+          bosh runtime-config --name=dns > /tmp/dns.yml
+          bosh interpolate -o /tmp/add-jammy.yml /tmp/dns.yml > /tmp/updated-dns.yml
+          bosh -n update-runtime-config --name=dns /tmp/updated-dns.yml
+  - file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
+    input_mapping:
+      ops-files: cf-deployment
+    params:
+      OPS_FILES: |
+        operations/experimental/use-jammy.yml
+        operations/use-internal-lookup-for-route-services.yml
+        operations/experimental/colocate-smoke-tests-on-cc-worker.yml
+    task: deploy-cf
+  - in_parallel:
+      steps:
+      - file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
+        params:
+          INSTANCE_GROUP_NAME: credhub
+          SECURITY_GROUP_NAME: credhub
+        task: open-asgs-for-credhub
+      - file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
+        params:
+          INSTANCE_GROUP_NAME: uaa
+          SECURITY_GROUP_NAME: uaa
+        task: open-asgs-for-uaa
+      - file: cf-deployment-concourse-tasks/set-feature-flags/task.yml
+        params:
+          ENABLED_FEATURE_FLAGS: |
+            diego_docker
+            task_creation
+            service_instance_sharing
+        task: enable-docker-and-tasks
+  public: true
+  serial: true
+
+- name: run-smoke-tests
+  plan:
+  - in_parallel:
+      steps:
+      - get: toolsmiths-env
+        passed:
+        - deploy-cf
+        trigger: true
+      - get: cf-deployment-concourse-tasks
+  - file: cf-deployment-concourse-tasks/run-errand/task.yml
+    params:
+      ERRAND_NAME: smoke_tests
+      INSTANCE: cc-worker/first
+    task: bosh-run-errand-smoke-tests
+  public: true
+  serial: true
+
+- name: run-cats
+  plan:
+  - in_parallel:
+      steps:
+      - get: toolsmiths-env
+        passed:
+        - run-smoke-tests
+        trigger: true
+      - get: cf-deployment-concourse-tasks
+      - get: cf-acceptance-tests
+  - config:
+      image_resource:
+        source:
+          repository: cloudfoundry/cf-deployment-concourse-tasks
+        type: docker-image
+      inputs:
+      - name: cf-deployment-concourse-tasks
+      - name: toolsmiths-env
+      outputs:
+      - name: integration-configs
+      params:
+        GIT_COMMIT_EMAIL: cf-release-integration@pivotal.io
+        GIT_COMMIT_USERNAME: CI Bot
+      platform: linux
+      run:
+        args:
+        - -c
+        - |
+          #!/bin/bash
+          source cf-deployment-concourse-tasks/shared-functions
+          DOMAIN="$(jq -r '.cf.api_url' toolsmiths-env/metadata | cut -d. -f2-)"
+          pushd integration-configs > /dev/null
+          git init
+          set_git_config
+          cat <<EOT > integration-config.json
+          {
+            "api": "api.${DOMAIN}",
+            "admin_user": "admin",
+            "admin_password": "",
+            "apps_domain": "${DOMAIN}",
+            "artifacts_directory": "logs",
+            "skip_ssl_validation": true,
+            "use_http": true,
+            "timeout_scale": 1,
+            "include_apps": true,
+            "include_backend_compatibility": true,
+            "include_capi_no_bridge": true,
+            "include_container_networking": true,
+            "include_detect": true,
+            "include_docker": true,
+            "include_internet_dependent": true,
+            "include_route_services": true,
+            "include_routing": true,
+            "include_security_groups": true,
+            "include_service_instance_sharing": true,
+            "include_services": true,
+            "include_ssh": true,
+            "include_sso": true,
+            "include_tasks": true,
+            "include_tcp_routing": true,
+            "include_v3": true,
+            "include_zipkin": true,
+            "credhub_client": "credhub_admin_client",
+            "credhub_secret": "",
+            "credhub_mode": "assisted"
+          }
+          EOT
+          git add .
+          git commit -m "Create integration config"
+        path: bash
+    task: create-integration-config
+  - file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+    params:
+      CATS_INTEGRATION_CONFIG_FILE: integration-config.json
+    task: update-integration-configs
+  - file: cf-deployment-concourse-tasks/run-cats/task.yml
+    input_mapping:
+      integration-config: updated-integration-configs
+    params:
+      CONFIG_FILE_PATH: integration-config.json
+    task: run-cats
+  public: true
+  serial: true
+
+- name: unclaim-env
+  plan:
+  - get: toolsmiths-env
+    passed:
+    - run-cats
+    trigger: true
+  - params:
+      action: unclaim
+      env_file: toolsmiths-env/metadata
+    put: toolsmiths-env
+  serial: true
+
+- name: unclaim-env-manual
+  plan:
+  - get: toolsmiths-env
+  - params:
+      action: unclaim
+      env_file: toolsmiths-env/metadata
+    put: toolsmiths-env
+  serial: true

--- a/ci/pipelines/bionic-stemcell.yml
+++ b/ci/pipelines/bionic-stemcell.yml
@@ -33,7 +33,45 @@ resources:
     uri: https://github.com/cloudfoundry/runtime-ci.git
   type: git
 
+- name: bbl-state
+  type: s3
+  source:
+    region_name: eu-central-1
+    bucket: bionic-stemcell-test
+    versioned_file: bbl-state.tar.gz
+    access_key_id: #TODO
+    secret_access_key: #TODO
+    initial_version: '0'
+
 jobs:
+- name: bbl-up
+  serial: true
+  plan:
+  - in_parallel:
+    - get: cf-deployment-concourse-tasks
+    - get: bbl-state
+      params:
+        unpack: true
+    - task: bbl-up
+      file: cf-deployment-concourse-tasks/bbl-up/task.yml
+      input_mapping:
+        bbl-config: cf-load-test-pipeline
+      params:
+        BBL_AWS_ACCESS_KEY_ID: #TODO
+        BBL_AWS_SECRET_ACCESS_KEY: #TODO
+        BBL_AWS_REGION: eu-west-1
+        BBL_IAAS: aws
+        BBL_CONFIG_DIR: bbl-patches
+        BBL_LB_CERT: ../cert.pem
+        BBL_LB_KEY: ../key
+        SKIP_LB_CREATION: false
+        LB_DOMAIN: ((sys_domain))
+        STORE_BBL_STATE_AS_TARBALL: true
+      ensure:
+        put: bbl-state
+        params:
+          file: updated-bbl-state/bbl-state.tgz
+
 - name: deploy-cf
   plan:
   - in_parallel:
@@ -42,6 +80,9 @@ jobs:
       - get: cf-deployment
       - get: cf-deployment-concourse-tasks
       - get: runtime-ci
+      - get: bbl-state
+        passed:
+        - bbl-up
   - file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
     params:
       IGNORE_ERRORS: "true"

--- a/ci/pipelines/bionic-stemcell.yml
+++ b/ci/pipelines/bionic-stemcell.yml
@@ -1,25 +1,19 @@
-resource_types:
-- name: toolsmiths-cf-pool
-  source:
-    repository: cftoolsmiths/toolsmiths-envs-resource
-  type: docker-image
-
 resources:
 - icon: github
   name: cf-acceptance-tests
   source:
     branch: release-candidate
-    private_key: ((cf_acceptance_tests_readwrite_deploy_key.private_key))
-    uri: git@github.com:cloudfoundry/cf-acceptance-tests.git
+    uri: https://github.com/sap-contributions/cf-acceptance-tests.git
   type: git
+  check_every: 1m
 
 - icon: github
   name: cf-deployment
   source:
     branch: release-candidate
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
-    uri: git@github.com:cloudfoundry/cf-deployment.git
+    uri: https://github.com/sap-contributions/cf-deployment.git
   type: git
+  check_every: 1m
 
 - icon: github
   name: cf-deployment-concourse-tasks
@@ -28,9 +22,9 @@ resources:
   type: git
 
 - icon: dna
-  name: jammy-stemcell
+  name: bionic-stemcell
   source:
-    name: bosh-google-kvm-ubuntu-jammy-go_agent
+    name: bosh-google-kvm-ubuntu-bionic-go_agent
   type: bosh-io-stemcell
 
 - icon: github
@@ -39,38 +33,12 @@ resources:
     uri: https://github.com/cloudfoundry/runtime-ci.git
   type: git
 
-- icon: pool
-  name: toolsmiths-env
-  source:
-    api_token: ((toolsmiths_api_token))
-    hostname: environments.toolsmiths.cf-app.com
-    pool_name: cf-deployment
-  type: toolsmiths-cf-pool
-
 jobs:
-- name: claim-env
-  plan:
-  - get: jammy-stemcell
-    trigger: true
-  - get: cf-deployment
-    trigger: true
-  - params:
-      action: claim
-    put: toolsmiths-env
-    timeout: 4h
-  serial: true
-
 - name: deploy-cf
   plan:
   - in_parallel:
       steps:
-      - get: toolsmiths-env
-        passed:
-        - claim-env
-        trigger: true
-      - get: jammy-stemcell
-        passed:
-        - claim-env
+      - get: bionic-stemcell
       - get: cf-deployment
       - get: cf-deployment-concourse-tasks
       - get: runtime-ci
@@ -82,8 +50,8 @@ jobs:
     task: bosh-cleanup
   - file: runtime-ci/tasks/bosh-upload-stemcell/task.yml
     input_mapping:
-      stemcell: jammy-stemcell
-    task: upload-jammy-stemcell
+      stemcell: bionic-stemcell
+    task: upload-bionic-stemcell
   - task: update-dns-runtime-config
     config:
       platform: linux
@@ -92,7 +60,6 @@ jobs:
         source:
           repository: cloudfoundry/cf-deployment-concourse-tasks
       inputs:
-      - name: toolsmiths-env
       - name: cf-deployment-concourse-tasks
       run:
         dir: ""
@@ -103,22 +70,22 @@ jobs:
           #!/bin/bash
           source cf-deployment-concourse-tasks/shared-functions
           setup_bosh_env_vars
-          cat <<EOT > /tmp/add-jammy.yml
+          cat <<EOT > /tmp/add-bionic.yml
           ---
           - type: replace
             path: /addons/name=bosh-dns/include/stemcell/-
             value:
-              os: ubuntu-jammy
+              os: ubuntu-bionic
           EOT
           bosh runtime-config --name=dns > /tmp/dns.yml
-          bosh interpolate -o /tmp/add-jammy.yml /tmp/dns.yml > /tmp/updated-dns.yml
+          bosh interpolate -o /tmp/add-bionic.yml /tmp/dns.yml > /tmp/updated-dns.yml
           bosh -n update-runtime-config --name=dns /tmp/updated-dns.yml
   - file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
     input_mapping:
       ops-files: cf-deployment
     params:
       OPS_FILES: |
-        operations/experimental/use-jammy.yml
+        operations/use-bionic-stemcell.yml
         operations/use-internal-lookup-for-route-services.yml
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
     task: deploy-cf
@@ -148,11 +115,10 @@ jobs:
   plan:
   - in_parallel:
       steps:
-      - get: toolsmiths-env
+      - get: cf-deployment-concourse-tasks
+      - get: cf-deployment # remove in PR | replace with toolsmiths env 
         passed:
         - deploy-cf
-        trigger: true
-      - get: cf-deployment-concourse-tasks
   - file: cf-deployment-concourse-tasks/run-errand/task.yml
     params:
       ERRAND_NAME: smoke_tests
@@ -165,12 +131,11 @@ jobs:
   plan:
   - in_parallel:
       steps:
-      - get: toolsmiths-env
-        passed:
-        - run-smoke-tests
-        trigger: true
       - get: cf-deployment-concourse-tasks
       - get: cf-acceptance-tests
+      - get: cf-deployment # remove in PR | replace with toolsmiths env 
+        passed:
+        - run-smoke-tests
   - config:
       image_resource:
         source:
@@ -178,7 +143,6 @@ jobs:
         type: docker-image
       inputs:
       - name: cf-deployment-concourse-tasks
-      - name: toolsmiths-env
       outputs:
       - name: integration-configs
       params:
@@ -243,25 +207,4 @@ jobs:
       CONFIG_FILE_PATH: integration-config.json
     task: run-cats
   public: true
-  serial: true
-
-- name: unclaim-env
-  plan:
-  - get: toolsmiths-env
-    passed:
-    - run-cats
-    trigger: true
-  - params:
-      action: unclaim
-      env_file: toolsmiths-env/metadata
-    put: toolsmiths-env
-  serial: true
-
-- name: unclaim-env-manual
-  plan:
-  - get: toolsmiths-env
-  - params:
-      action: unclaim
-      env_file: toolsmiths-env/metadata
-    put: toolsmiths-env
   serial: true

--- a/ci/pipelines/bionic-stemcell.yml
+++ b/ci/pipelines/bionic-stemcell.yml
@@ -1,53 +1,61 @@
 jobs:
-- name: claim-env
+- name: stable-acquire-pool
   plan:
-  - get: bionic-stemcell
-    trigger: true
-  - get: cf-deployment
-    trigger: true
-  - params:
-      action: claim
-    put: toolsmiths-env
+  - in_parallel:
+      steps:
+      - get: bionic-stemcell
+        trigger: true
+      - get: cf-deployment
+        trigger: true
+      - params:
+          acquire: true
+        put: stable-pool
     timeout: 4h
   serial: true
-
 - name: deploy-cf
   plan:
   - in_parallel:
       steps:
-      - get: toolsmiths-env
+      - get: stable-pool
         passed:
-        - claim-env
+        - stable-acquire-pool
         trigger: true
       - get: bionic-stemcell
         passed:
-        - claim-env
+        - stable-acquire-pool
       - get: cf-deployment
+        passed:
+        - stable-acquire-pool
       - get: cf-deployment-concourse-tasks
       - get: runtime-ci
+      - get: relint-envs
   - file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+    input_mapping:
+      bbl-state: relint-envs
     params:
+      BBL_STATE_DIR: environments/test/bellatrix/bbl-state
       IGNORE_ERRORS: "true"
-    task: bosh-delete-cf-deployment
-  - file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
-    task: bosh-cleanup
+    task: guarantee-no-existing-cf-deployment
   - file: runtime-ci/tasks/bosh-upload-stemcell/task.yml
     input_mapping:
+      bbl-state: relint-envs
       stemcell: bionic-stemcell
+    params:
+      BBL_STATE_DIR: environments/test/bellatrix/bbl-state
     task: upload-bionic-stemcell
-  - task: update-dns-runtime-config
-    config:
-      platform: linux
+  - config:
       image_resource:
-        type: docker-image
+        name: ""
         source:
           repository: cloudfoundry/cf-deployment-concourse-tasks
+        type: docker-image
       inputs:
-      - name: toolsmiths-env
+      - name: bbl-state
       - name: cf-deployment-concourse-tasks
+      params:
+        BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+      platform: linux
       run:
-        dir: ""
-        path: bash
         args:
         - -c
         - |
@@ -64,174 +72,166 @@ jobs:
           bosh runtime-config --name=dns > /tmp/dns.yml
           bosh interpolate -o /tmp/add-bionic.yml /tmp/dns.yml > /tmp/updated-dns.yml
           bosh -n update-runtime-config --name=dns /tmp/updated-dns.yml
+        path: bash
+    input_mapping:
+      bbl-state: relint-envs
+    task: update-dns-runtime-config
   - file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
     input_mapping:
+      bbl-state: relint-envs
       ops-files: cf-deployment
     params:
+      BBL_STATE_DIR: environments/test/bellatrix/bbl-state
       OPS_FILES: |
         operations/use-bionic-stemcell.yml
         operations/use-internal-lookup-for-route-services.yml
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
+      SYSTEM_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org
     task: deploy-cf
   - in_parallel:
       steps:
       - file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
+        input_mapping:
+          bbl-state: relint-envs
         params:
+          BBL_STATE_DIR: environments/test/bellatrix/bbl-state
           INSTANCE_GROUP_NAME: credhub
           SECURITY_GROUP_NAME: credhub
+          SYSTEM_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org
         task: open-asgs-for-credhub
       - file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
+        input_mapping:
+          bbl-state: relint-envs
         params:
+          BBL_STATE_DIR: environments/test/bellatrix/bbl-state
           INSTANCE_GROUP_NAME: uaa
           SECURITY_GROUP_NAME: uaa
+          SYSTEM_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org
         task: open-asgs-for-uaa
       - file: cf-deployment-concourse-tasks/set-feature-flags/task.yml
+        input_mapping:
+          bbl-state: relint-envs
         params:
+          BBL_STATE_DIR: environments/test/bellatrix/bbl-state
           ENABLED_FEATURE_FLAGS: |
             diego_docker
             task_creation
             service_instance_sharing
+          SYSTEM_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org
         task: enable-docker-and-tasks
   public: true
   serial: true
-
+  serial_groups:
+  - stable-smokes
+  - stable-cats
 - name: run-smoke-tests
   plan:
-  - in_parallel:
-      steps:
-      - get: toolsmiths-env
-        passed:
-        - deploy-cf
-        trigger: true
-      - get: cf-deployment-concourse-tasks
+  - do:
+    - get: stable-pool
+      passed:
+      - deploy-cf
+      trigger: true
+    - in_parallel:
+        steps:
+        - get: relint-envs
+        - get: cf-deployment-concourse-tasks
   - file: cf-deployment-concourse-tasks/run-errand/task.yml
+    input_mapping:
+      bbl-state: relint-envs
     params:
+      BBL_STATE_DIR: environments/test/bellatrix/bbl-state
       ERRAND_NAME: smoke_tests
       INSTANCE: cc-worker/first
     task: bosh-run-errand-smoke-tests
   public: true
   serial: true
-
+  serial_groups:
+  - stable-smokes
 - name: run-cats
   plan:
-  - in_parallel:
-      steps:
-      - get: toolsmiths-env
-        passed:
-        - run-smoke-tests
-        trigger: true
-      - get: cf-deployment-concourse-tasks
-      - get: cf-acceptance-tests
-  - config:
-      image_resource:
-        source:
-          repository: cloudfoundry/cf-deployment-concourse-tasks
-        type: docker-image
-      inputs:
-      - name: cf-deployment-concourse-tasks
-      - name: toolsmiths-env
-      outputs:
-      - name: integration-configs
+  - do:
+    - get: stable-pool
+      passed:
+      - run-smoke-tests
+      trigger: true
+    - in_parallel:
+        steps:
+        - get: relint-envs
+        - get: cf-deployment-concourse-tasks
+        - get: cf-acceptance-tests-rc
+    - file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+        cf-acceptance-tests: cf-acceptance-tests-rc
+        integration-configs: relint-envs
       params:
-        GIT_COMMIT_EMAIL: cf-release-integration@pivotal.io
-        GIT_COMMIT_USERNAME: CI Bot
-      platform: linux
-      run:
-        args:
-        - -c
-        - |
-          #!/bin/bash
-          source cf-deployment-concourse-tasks/shared-functions
-          DOMAIN="$(jq -r '.cf.api_url' toolsmiths-env/metadata | cut -d. -f2-)"
-          pushd integration-configs > /dev/null
-          git init
-          set_git_config
-          cat <<EOT > integration-config.json
-          {
-            "api": "api.${DOMAIN}",
-            "admin_user": "admin",
-            "admin_password": "",
-            "apps_domain": "${DOMAIN}",
-            "artifacts_directory": "logs",
-            "skip_ssl_validation": true,
-            "use_http": true,
-            "timeout_scale": 1,
-            "include_apps": true,
-            "include_backend_compatibility": true,
-            "include_capi_no_bridge": true,
-            "include_container_networking": true,
-            "include_detect": true,
-            "include_docker": true,
-            "include_internet_dependent": true,
-            "include_route_services": true,
-            "include_routing": true,
-            "include_security_groups": true,
-            "include_service_instance_sharing": true,
-            "include_services": true,
-            "include_ssh": true,
-            "include_sso": true,
-            "include_tasks": true,
-            "include_tcp_routing": true,
-            "include_v3": true,
-            "include_zipkin": true,
-            "credhub_client": "credhub_admin_client",
-            "credhub_secret": "",
-            "credhub_mode": "assisted"
-          }
-          EOT
-          git add .
-          git commit -m "Create integration config"
-        path: bash
-    task: create-integration-config
-  - file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
-    params:
-      CATS_INTEGRATION_CONFIG_FILE: integration-config.json
-    task: update-integration-configs
-  - file: cf-deployment-concourse-tasks/run-cats/task.yml
-    input_mapping:
-      integration-config: updated-integration-configs
-    params:
-      CONFIG_FILE_PATH: integration-config.json
-    task: run-cats
+        BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+        CATS_INTEGRATION_CONFIG_FILE: environments/test/bellatrix/integration_config.json
+      task: update-integration-configs
+    - file: cf-deployment-concourse-tasks/run-cats/task.yml
+      input_mapping:
+        cf-acceptance-tests: cf-acceptance-tests-rc
+        integration-config: updated-integration-configs
+      params:
+        CAPTURE_LOGS: "true"
+        CONFIG_FILE_PATH: environments/test/bellatrix/integration_config.json
+        NODES: "12"
+      task: run-cats
+    timeout: 4h
   public: true
   serial: true
-
-- name: unclaim-env
+  serial_groups:
+  - stable-cats
+- name: stable-delete-deployment
   plan:
-  - get: toolsmiths-env
-    passed:
-    - run-cats
-    trigger: true
-  - params:
-      action: unclaim
-      env_file: toolsmiths-env/metadata
-    put: toolsmiths-env
+  - do:
+    - get: stable-pool
+      passed:
+      - run-cats
+    - in_parallel:
+        steps:
+        - get: cf-deployment-concourse-tasks
+        - get: relint-envs
+    - file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+      params:
+        BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+        IGNORE_ERRORS: "true"
+      task: delete-deployment-cf
+    - file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+      params:
+        BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+      task: run-bosh-cleanup
+    - params:
+        release: stable-pool
+      put: stable-pool
+    timeout: 4h
+  public: true
   serial: true
-
-- name: unclaim-env-manual
+- ensure:
+    try:
+      params:
+        release: stable-pool
+      put: stable-pool
+  name: stable-release-pool-manual
   plan:
-  - get: toolsmiths-env
-  - params:
-      action: unclaim
-      env_file: toolsmiths-env/metadata
-    put: toolsmiths-env
-  serial: true
-
-resource_types:
-- name: toolsmiths-cf-pool
-  source:
-    repository: cftoolsmiths/toolsmiths-envs-resource
-  type: docker-image
-
+  - get: stable-pool
 resources:
+- icon: dna
+  name: bionic-stemcell
+  source:
+    name: bosh-google-kvm-ubuntu-bionic-go_agent
+  type: bosh-io-stemcell
 - icon: github
-  name: cf-acceptance-tests
+  name: cf-acceptance-tests-rc
   source:
     branch: release-candidate
     private_key: ((cf_acceptance_tests_readwrite_deploy_key.private_key))
     uri: git@github.com:cloudfoundry/cf-acceptance-tests.git
   type: git
-
 - icon: github
   name: cf-deployment
   source:
@@ -239,29 +239,28 @@ resources:
     private_key: ((cf_deployment_readwrite_deploy_key.private_key))
     uri: git@github.com:cloudfoundry/cf-deployment.git
   type: git
-
 - icon: github
   name: cf-deployment-concourse-tasks
   source:
     uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
   type: git
-
-- icon: dna
-  name: bionic-stemcell
+- icon: github
+  name: relint-envs
   source:
-    name: bosh-google-kvm-ubuntu-bionic-go_agent
-  type: bosh-io-stemcell
-
+    branch: main
+    private_key: ((hagrid_env_readwrite_deploy_key.private_key))
+    uri: git@github.com:cloudfoundry/relint-envs.git
+  type: git
 - icon: github
   name: runtime-ci
   source:
     uri: https://github.com/cloudfoundry/runtime-ci.git
   type: git
-
 - icon: pool
-  name: toolsmiths-env
+  name: stable-pool
   source:
-    api_token: ((toolsmiths_api_token))
-    hostname: environments.toolsmiths.cf-app.com
-    pool_name: cf-deployment
-  type: toolsmiths-cf-pool
+    branch: main
+    pool: cf-deployment/stable
+    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    uri: git@github.com:cloudfoundry/relint-ci-pools
+  type: pool


### PR DESCRIPTION
### WHAT is this change about?

This PR adds a pipeline to deploy & then run tests against the `bionic` stemcell, in the same way as is currently done for `jammy`.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?
- Adds a new pipeline for testing the `bionic` stemcell

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Please provide Acceptance Criteria for this change?
1. Validate that the [bionic-stemcell pipeline](https://release-integration.ci.cf-app.com/teams/main/pipelines/bionic-stemcell) remains green (it uses the pipeline yml included in this PR) & is doing the intended work (testing the bionic stemcell).

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@iaftab-alam 