### PR TITLE
ga cpu throttling

### DIFF
--- a/operations/enable-cpu-throttling.yml
+++ b/operations/enable-cpu-throttling.yml
@@ -1,5 +1,5 @@
 ---
 # Enabling this feature only makes sense if `set-cpu-weight` is enabled as well
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/experimental_cpu_throttling?
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/cpu_throttling?
   value: true


### PR DESCRIPTION
⚠️ This is blocked on Garden 1.22.5 being included in cf-d ⚠️ 

### WHAT is this change about?

GAing CPU throttling.

[Garden 1.22.5](https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.22.5) includes two new non-experimental properties.
  * Add `garden.cpu_throttling` bosh property. If this property is set it will override `garden.experimental_cpu_throttling`.
  * Add `garden.cpu_throttling_check_interval` bosh property. If this property is set it will override `garden.experimental_cpu_throttling_check_interval`.
  * For backwards compatibility, the experimental properties are still respected if the non-experimental properties are not set.
* ⚠️ The experimental properties `garden.experimental_cpu_throttling` and `garden.experimental_cpu_throttling_check_interval` are now deprecated. They will be removed in  a future release.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Users can use this property to throttle cpu of badly behaving apps. See more docs [here](https://docs.cloudfoundry.org/adminguide/using-cpu-entitlement-plugin.html).

### Please provide any contextual information.

* docs - https://docs.cloudfoundry.org/adminguide/using-cpu-entitlement-plugin.html

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

CPU throttling is now GA. The `enable-cpu-throttling.yml` opsfile now uses non-experimental properties. For backwards compatibility, the experimental properties are still respected if the non-experimental properties are not set. Read more about this feature [here](https://docs.cloudfoundry.org/adminguide/using-cpu-entitlement-plugin.html).

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?
1. When you deploy with this opsfile you should see that cpu throttling is enforced.
2. You can see this throttling if you set up the following scenario
  1. On one diego cell deploy 5 instances of dora named "cpu-hog" and one named "good-app"
    * `cd cf-acceptance-tests/assets/dora/ && cf push cpu-hog -i 5`
    * `cf push good-app`
  3. Use dora's stress-test endpoints to make all cpu-hog apps burst use more cpu than their entitlement.
    * Do this 5 times: `curl -X POST CPU-HOG-ROUTE/stress_testers?cpu=1&io=1`
  5. Download the cpu entitlement plugin to see this.
    * `$ cf install-plugin https://github.com/cloudfoundry/cpu-entitlement-plugin/releases/download/v0.0.5/cpu-entitlement-plugin-0.0.5.linux64`
    * `$ cf cpu cpu-hog`
   6. Use the stress-test endpoint to make good-app burst.
    * `curl -X POST GOOD-APP-ROUTE/stress_testers?cpu=1&io=1`
   8. Run `cf cpu dora` to see that dora gets priority for bursting. 

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
* @cloudfoundry/wg-app-runtime-platform-garden-containers-approvers 
