### PR TITLE
Adapt gorouter ca_cert list to a list

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1396,11 +1396,11 @@ instance_groups:
         tls_pem:
         - cert_chain: "((router_ssl.certificate))"
           private_key: "((router_ssl.private_key))"
-        ca_certs: |
-          ((diego_instance_identity_ca.ca))
-          ((cc_tls.ca))
-          ((uaa_ssl.ca))
-          ((network_policy_server_external.ca))
+        ca_certs:
+          - ((diego_instance_identity_ca.ca))
+          - ((cc_tls.ca))
+          - ((uaa_ssl.ca))
+          - ((network_policy_server_external.ca))
         backends:
           cert_chain: ((gorouter_backend_tls.certificate))
           private_key: ((gorouter_backend_tls.private_key))

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1397,10 +1397,10 @@ instance_groups:
         - cert_chain: "((router_ssl.certificate))"
           private_key: "((router_ssl.private_key))"
         ca_certs:
-          - ((diego_instance_identity_ca.ca))
-          - ((cc_tls.ca))
-          - ((uaa_ssl.ca))
-          - ((network_policy_server_external.ca))
+        - ((diego_instance_identity_ca.ca))
+        - ((cc_tls.ca))
+        - ((uaa_ssl.ca))
+        - ((network_policy_server_external.ca))
         backends:
           cert_chain: ((gorouter_backend_tls.certificate))
           private_key: ((gorouter_backend_tls.private_key))

--- a/operations/test/add-persistent-isolation-segment-router.yml
+++ b/operations/test/add-persistent-isolation-segment-router.yml
@@ -41,10 +41,10 @@
           routing_table_sharding_mode: segments
           ssl_skip_validation: true
           enable_ssl: true
-          ca_certs: |
-            ((diego_instance_identity_ca.ca))
-            ((cc_tls.ca))
-            ((uaa_ssl.ca))
+          ca_certs:
+          - ((diego_instance_identity_ca.ca))
+          - ((cc_tls.ca))
+          - ((uaa_ssl.ca))
           backends:
             cert_chain: ((gorouter_backend_tls.certificate))
             private_key: ((gorouter_backend_tls.private_key))


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

https://github.com/cloudfoundry/gorouter/pull/316 changes the CA list for gorouter (`router.ca_certs`) to an array. The intention is that then the CA list can be augmented via BOSH opsfile, as opsfiles can modify arrays but not concatenate strings.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

We are unable to extend the router CA list with some additional custom CAs without repeating the CA list from the CF deployment, as opsfiles cannot concatenate strings.

Each entry in the array may still contain a string that includes multiple contatenated PEM certificates.

### Please provide any contextual information.

https://github.com/cloudfoundry/gorouter/pull/316
https://github.com/cloudfoundry/routing-release/pull/297

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [x] YES - please choose the category from below. Feel free to provide additional details.
- [ ] NO

> **Types of breaking changes:**

4. modifies the name or deletes a property of a job or instance group in the main manifest

The type of a property is modified. `router.ca_certs` is changed from a `string` to an `array[string]`.

### How should this change be described in cf-deployment release notes?

Change the gorouter CA Certs property to accept an array of PEM encoded certificates, which allow extension via BOSH opsfiles.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

When using the routing release that includes https://github.com/cloudfoundry/routing-release/pull/297 and https://github.com/cloudfoundry/gorouter/pull/316, the router.ca_certs property needs to be changed to an array of PEM encoded certs. No change besides the cf-deployment default manifest adapted to the new routing-release is necessary.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

