### PR TITLE
Scale up BOSH director VM in "bbr" env

### DIFF
--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -729,6 +729,7 @@ jobs:
       - get: bosh-bootloader
       - get: every-tuesday-morning
         trigger: true
+      - get: runtime-ci
     - task: combine-bbl-configs
       file: runtime-ci/tasks/combine-inputs/task.yml
       input_mapping:

--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -522,7 +522,7 @@ jobs:
       first-input: bosh-bootloader
       second-input: relint-envs
     params:
-      FIRST_DIR: plan-patches/bosh-lite-gcp
+      FIRST_DIR: plan-patches/network-lb-gcp
       SECOND_DIR: environments/test/bbr/bbl-config
   - task: setup-infrastructure
     <<: *bbr-bbl-up-task-config
@@ -735,7 +735,7 @@ jobs:
         first-input: bosh-bootloader
         second-input: relint-envs
       params:
-        FIRST_DIR: plan-patches/bosh-lite-gcp
+        FIRST_DIR: plan-patches/network-lb-gcp
         SECOND_DIR: environments/test/bbr/bbl-config
     - task: update-infrastructure
       <<: *bbr-bbl-up-task-config

--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -140,7 +140,7 @@ bbr-bbl-up-task: &bbr-bbl-up-task-config
   file: cf-deployment-concourse-tasks/bbl-up/task.yml
   input_mapping:
     bbl-state: relint-envs
-    bbl-config: bosh-bootloader
+    bbl-config: combined-inputs
   params:
     BBL_STATE_DIR: environments/test/bbr/bbl-state
     BBL_IAAS: gcp
@@ -150,7 +150,7 @@ bbr-bbl-up-task: &bbr-bbl-up-task-config
     BBL_LB_KEY: ((baba_yaga_cf_lb_cert.private_key))
     LB_DOMAIN: baba-yaga.cf-app.com
     BBL_ENV_NAME: baba-yaga-bbr
-    BBL_CONFIG_DIR: plan-patches/network-lb-gcp
+    BBL_CONFIG_DIR: .
   ensure:
     put: relint-envs
     params:
@@ -515,6 +515,15 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: relint-envs
     - get: bosh-bootloader
+    - get: runtime-ci
+  - task: combine-bbl-configs
+    file: runtime-ci/tasks/combine-inputs/task.yml
+    input_mapping:
+      first-input: bosh-bootloader
+      second-input: relint-envs
+    params:
+      FIRST_DIR: plan-patches/bosh-lite-gcp
+      SECOND_DIR: environments/test/bbr/bbl-config
   - task: setup-infrastructure
     <<: *bbr-bbl-up-task-config
   - put: bbr-pool
@@ -720,6 +729,14 @@ jobs:
       - get: bosh-bootloader
       - get: every-tuesday-morning
         trigger: true
+    - task: combine-bbl-configs
+      file: runtime-ci/tasks/combine-inputs/task.yml
+      input_mapping:
+        first-input: bosh-bootloader
+        second-input: relint-envs
+      params:
+        FIRST_DIR: plan-patches/bosh-lite-gcp
+        SECOND_DIR: environments/test/bbr/bbl-config
     - task: update-infrastructure
       <<: *bbr-bbl-up-task-config
     - put: bbr-pool


### PR DESCRIPTION
* load on director is too high and we sometimes see timeoutes when connecting to "uaa" process

### WHAT is this change about?

Scale up BOSH director VM to 4 core machine on "bbr" test environment.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

"bbr-deploy" job often fails with timeouts: https://app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/bbr-deploy/builds/117

### Please provide any contextual information.

PR for relint-envs: https://github.com/cloudfoundry/relint-envs/pull/4

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

N/A

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

PR is only for CI pipelines.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

"bbr-deploy" job has less fails.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
