### PR TITLE
Integrate cflinuxfs4 into "cf-deployment" pipeline

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -22,6 +22,7 @@ groups:
   - experimental-deploy
   - experimental-smoke-tests
   - experimental-cats
+  - experimental-cats-cflinuxfs4
   - experimental-delete-deployment
   - lite-acquire-pool
   - lite-deploy
@@ -75,6 +76,7 @@ groups:
   - lint-cf-deployment-manifest
   - experimental-acquire-pool
   - experimental-cats
+  - experimental-cats-cflinuxfs4
   - experimental-deploy
   - experimental-delete-deployment
   - experimental-release-pool-manual
@@ -1023,7 +1025,7 @@ jobs:
       params: {release: experimental-pool}
 
 - name: experimental-deploy
-  serial_groups: [ experimental-cats, experimental-smokes ]
+  serial_groups: [ experimental-cats, experimental-cats-cflinuxfs4, experimental-smokes ]
   public: true
   plan:
   - get: experimental-pool
@@ -1123,6 +1125,7 @@ jobs:
         operations/scale-database-cluster.yml
         operations/stop-skipping-tls-validation.yml
         operations/use-operator-provided-router-tls-certificates.yml
+        operations/experimental/add-cflinuxfs4.yml
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
         operations/experimental/set-cpu-weight.yml
         operations/experimental/enable-cpu-throttling.yml
@@ -1237,6 +1240,39 @@ jobs:
         CONFIG_FILE_PATH: environments/test/hermione/integration_config.json
         REPORTER_CONFIG_FILE_PATH: environments/test/hermione/reporter_config.json
         RELINT_VERBOSE_AUTH: "true"
+
+- name: experimental-cats-cflinuxfs4
+  serial_groups: [ experimental-cats-cflinuxfs4 ]
+  public: true
+  plan:
+    - timeout: 4h
+      do:
+        - get: experimental-pool
+          trigger: true
+          passed: [ experimental-deploy ]
+        - in_parallel:
+            - get: cf-acceptance-tests-rc
+            - get: relint-envs
+            - get: cf-deployment-develop
+              passed: [ experimental-deploy ]
+            - get: cf-deployment-concourse-tasks
+        - task: update-integration-configs
+          file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+          params:
+            BBL_STATE_DIR: environments/test/hermione/bbl-state
+            CATS_INTEGRATION_CONFIG_FILE: environments/test/hermione/cflinuxfs4_integration_config.json
+          input_mapping:
+            bbl-state: relint-envs
+            integration-configs: relint-envs
+        - task: run-cats
+          input_mapping:
+            integration-config: updated-integration-configs
+            cf-acceptance-tests: cf-acceptance-tests-rc
+          file: cf-deployment-concourse-tasks/run-cats/task.yml
+          params:
+            CONFIG_FILE_PATH: environments/test/hermione/cflinuxfs4_integration_config.json
+            REPORTER_CONFIG_FILE_PATH: environments/test/hermione/reporter_config.json
+            RELINT_VERBOSE_AUTH: "true"
 
 - name: experimental-delete-deployment
   serial: true


### PR DESCRIPTION
* configure "experimental/add-cflinuxfs4.yml" ops file for "experimental-deploy" job
* add "experimental-cats-cflinuxfs4" job to run CATs with fs4 stack (job will be red until all issues have been resolved -> no downstream jobs to not block pipeline)

### WHAT is this change about?

Update "cf-deployment" pipeline with cflinuxfs4.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Validation of the experimental ops file for adding the cflinuxfs4 stack.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/989

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES (experimental-cats passes as it is configured to cflinuxfs3)
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO (pipeline update only)

### How should this change be described in cf-deployment release notes?

No changes in cf-deployment itself.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

"cf-deployment" pipeline passes, except for the new "experimental-cats-cflinuxfs4" job.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

