### PR TITLE
Enable bbl config option for "cedric" environment

### DIFF
--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -181,7 +181,7 @@ windows-bbl-up-task: &windows-bbl-up-task-config
     bbl-state: relint-envs
     bbl-config: relint-envs
   params:
-    # BBL_CONFIG_DIR: environments/test/cedric/bbl-config
+    BBL_CONFIG_DIR: environments/test/cedric/bbl-config
     # BBL_ENV_NAME: cedric-windows
     BBL_GCP_REGION: europe-west3
     BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/cedric/cedric.key.json


### PR DESCRIPTION
### WHAT is this change about?

Enable bbl config for cedric/Windows environment to scale up BOSH director to 4 CPUs.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

BOSH operations fail sporadically with timeouts because director is overloaded.

### Please provide any contextual information.

https://github.com/cloudfoundry/relint-envs/pull/5

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Not relevant for release notes.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

"windows" jobs fail less often.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
