### PR TITLE
Revert "Updated compiled releases with credhub 2.12.14"

### DIFF
--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -82,12 +82,12 @@
   path: /releases/name=credhub
   value:
     name: credhub
-    sha1: 70f2a111a4915d345cf4200db68aa5e07993ec12
+    sha1: 6fdc94b9311951f0795220d8db0791886995a1fe
     stemcell:
       os: ubuntu-jammy
       version: "1.18"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/credhub-2.12.14-ubuntu-jammy-1.18-20221117-192642-971004395.tgz
-    version: 2.12.14
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/credhub-2.12.13-ubuntu-jammy-1.18-20221109-211503-940885651.tgz
+    version: 2.12.13
 - type: replace
   path: /releases/name=diego
   value:


### PR DESCRIPTION
* reverting because of https://github.com/pivotal/credhub-release/issues/74

This reverts commit 0e788a1a5d7cb25df11f40b0730189fdb979253a.

### WHAT is this change about?

Reverting credhub-release from 2.12.14 back to 2.12.13.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Release pipeline is blocked with 2.12.14.

### Please provide any contextual information.

https://github.com/pivotal/credhub-release/issues/74

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Use release notes from Concourse job as usual.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

"cf-deployment" pipeline succeeds.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

