### PR TITLE
Revert "Updated manifest with credhub-release 2.12.14"

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2838,9 +2838,9 @@ releases:
   version: 0.337.0
   sha1: b86a961dabb5c0420efb039e581535d75820d8a9
 - name: credhub
-  url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.12.14
-  version: 2.12.14
-  sha1: 9c10df4cbfab12c74437076d4c3f72229dd8c720
+  url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.12.13
+  version: 2.12.13
+  sha1: 443103820a9e35f0489e77d79f83e410823e5ce2
 - name: diego
   url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.69.0
   version: 2.69.0


### PR DESCRIPTION
* reverting because of https://github.com/pivotal/credhub-release/issues/74

This reverts commit 28110b3fabda6a79e495249ceeae5675e1b6f18b (credhub-release version in cf-deployment.yml)

### WHAT is this change about?

Reverting credhub-release from 2.12.14 back to 2.12.13.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Release pipeline is blocked with 2.12.14.

### Please provide any contextual information.

https://github.com/pivotal/credhub-release/issues/74

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Use release notes from Concourse job as usual.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

"cf-deployment" pipeline succeeds.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

