### PR TITLE
Add a temporary test ops file for routing update

### DIFF
--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -29,6 +29,10 @@ baseReleases:
   repository: cloudfoundry-incubator/pxc-release
 - name: routing
   repository: cloudfoundry/routing-release
+  requiredOpsFiles:
+  # this file is only required until routing-release and its breaking config change are consumed
+  # (PR https://github.com/cloudfoundry/cf-deployment/pull/1005). It can be removed afterwards.
+  - operations/test/temp-gorouter-certs-as-list.yml
 - name: silk
   repository: cloudfoundry/silk-release
 - name: statsd-injector

--- a/operations/test/temp-gorouter-certs-as-list.yml
+++ b/operations/test/temp-gorouter-certs-as-list.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs?
+  value:
+  - ((diego_instance_identity_ca.ca))
+  - ((cc_tls.ca))
+  - ((uaa_ssl.ca))
+  - ((network_policy_server_external.ca))

--- a/units/tests/test_test/operations.yml
+++ b/units/tests/test_test/operations.yml
@@ -27,3 +27,4 @@ scale-to-one-az-addon-parallel-cats.yml:
   - ../scale-to-one-az.yml
   - scale-to-one-az-addon-parallel-cats.yml
 speed-up-dynamic-asgs.yml: {}
+temp-gorouter-certs-as-list.yml: {}


### PR DESCRIPTION
In order to update routing release we need a temporary ops file that will change the gorouter ca certs into an array.

Linked PRs:
* https://github.com/cloudfoundry/cf-deployment/pull/1005
* https://github.com/cloudfoundry/routing-release/pull/297
* https://github.com/cloudfoundry/gorouter/pull/316