### PR TITLE
Fix "experimental-ops-files" job

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1189,8 +1189,13 @@ jobs:
       trigger: true
       passed: [ experimental-acquire-pool ]
     - get: runtime-ci
+    - get: cf-deployment-main
   - task: experimental-ops-files
     file: runtime-ci/tasks/summarize-ops-files/task.yml
+    input_mapping:
+      cf-deployment: cf-deployment-main
+    params:
+      TASK_LIST: "bosh-deploy-cf-latest-release bosh-deploy-cf-develop"
 
 - name: experimental-smoke-tests
   public: true


### PR DESCRIPTION
### WHAT is this change about?

Fix "experimental-ops-files" job: https://app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-ops-files

### Please provide any contextual information.

"summarize-ops-files" task was broken: https://github.com/cloudfoundry/runtime-ci/tree/main/tasks/summarize-ops-files

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Not relevant for release notes.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Job is green and prints all experimental ops files used in the "experimental" deployment:
https://app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-ops-files

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
