### PR TITLE
Add cflinuxfs4 to update releases pipeline

### DIFF
--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -127,8 +127,6 @@ opsReleases:
   - operations/use-online-windows2019fs.yml
 - name: cflinuxfs4
   repository: cloudfoundry/cflinuxfs4-release
-  requiredOpsFiles:
-  - operations/experimental/add-cflinuxfs4.yml
 
 untestedOpsReleases:
 - name: datadog-firehose-nozzle

--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -125,6 +125,10 @@ opsReleases:
   requiredOpsFiles:
   - operations/windows2019-cell.yml
   - operations/use-online-windows2019fs.yml
+- name: cflinuxfs4
+  repository: cloudfoundry/cflinuxfs4-release
+  requiredOpsFiles:
+  - operations/experimental/add-cflinuxfs4.yml
 
 untestedOpsReleases:
 - name: datadog-firehose-nozzle

--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -14398,11 +14398,10 @@ jobs:
           pool-lock: pre-dev-pool
         params:
           BBL_JSON_CONFIG: pool-lock/metadata
-          OPS_FILES: |-
+          OPS_FILES: |
             operations/scale-to-one-az.yml
             operations/use-compiled-releases.yml
             operations/experimental/use-compiled-releases-windows.yml
-            operations/experimental/add-cflinuxfs4.yml
           REGENERATE_CREDENTIALS: false
           BOSH_DEPLOY_ARGS: --parallel 50
       - task: ensure-api-healthy

--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -116,6 +116,8 @@ groups:
   - update-metric-store
   - acquire-envoy-nginx-pre-dev-lock
   - update-envoy-nginx
+  - acquire-cflinuxfs4-pre-dev-lock
+  - update-cflinuxfs4
   - update-datadog-firehose-nozzle
 - name: update-windows-stemcells-and-releases
   jobs:
@@ -446,6 +448,10 @@ resources:
   type: bosh-io-release
   source:
     repository: cloudfoundry-incubator/envoy-nginx-release
+- name: cflinuxfs4-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry/cflinuxfs4-release
 - name: datadog-firehose-nozzle-release
   type: bosh-io-release
   source:
@@ -936,6 +942,12 @@ resources:
     bucket: component-bump-logs
     json_key: ((greengrass_gcp_service_account_json))
     regexp: envoy-nginx/cf-(\d+)-(\d+)-(\d+)\.tgz
+- name: cflinuxfs4-component-bump-logs-gcs
+  type: gcs-resource
+  source:
+    bucket: component-bump-logs
+    json_key: ((greengrass_gcp_service_account_json))
+    regexp: cflinuxfs4/cf-(\d+)-(\d+)-(\d+)\.tgz
 - name: windows2019-stemcell
   type: bosh-io-stemcell
   icon: dna
@@ -14219,6 +14231,243 @@ jobs:
             file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
             params:
               RELEASE_REPOSITORY: cloudfoundry-incubator/envoy-nginx-release
+          - put: slack-alert
+            params:
+              channel_file: slack-channel/channel.txt
+              icon_emoji: ':cloudfoundrylogo:'
+              text: |
+                $TEXT_FILE_CONTENT
+
+                CI job: https://app-runtime-deployments.ci.cloudfoundry.org/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+                If you're unfamiliar with the update-release pre-validation, please review the following FAQ: https://docs.google.com/document/d/1dUIk2HWbUzdxWs-pNZ-cCqH7CuSNDBixIUoXIFkFpz0
+              text_file: slack-message/message.txt
+              username: Release Integration
+      ensure:
+        do:
+        - task: delete-deployment
+          file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+            IGNORE_ERRORS: true
+          attempts: 3
+        - task: remove-gcp-dns
+          file: runtime-ci/tasks/manage-gcp-dns/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+            GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
+            GCP_DNS_ZONE_NAME: wg-ard
+            ACTION: remove
+        - task: bbl-down
+          file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+          on_failure:
+            do:
+            - task: bbl-cleanup-leftovers
+              file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
+              input_mapping:
+                bbl-state: updated-bbl-state
+                pool-lock: pre-dev-pool
+              output_mapping:
+                updated-bbl-state: clean-bbl-state
+              params:
+                BBL_JSON_CONFIG: pool-lock/metadata
+            ensure:
+              put: relint-envs
+              params:
+                repository: clean-bbl-state
+                rebase: true
+          on_success:
+            put: relint-envs
+            params:
+              repository: updated-bbl-state
+              rebase: true
+    ensure:
+      do:
+      - put: pre-dev-pool
+        params:
+          release: pre-dev-pool
+- name: acquire-cflinuxfs4-pre-dev-lock
+  public: true
+  plan:
+  - in_parallel:
+    - get: cflinuxfs4-release
+      trigger: true
+      params:
+        tarball: false
+  - put: pre-dev-pool
+    params:
+      acquire: true
+- name: update-cflinuxfs4
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: pre-dev-pool
+      passed:
+      - acquire-cflinuxfs4-pre-dev-lock
+      trigger: true
+    - get: cflinuxfs4-release
+      params:
+        tarball: false
+      passed:
+      - acquire-cflinuxfs4-pre-dev-lock
+    - get: cf-deployment-release-candidate
+    - get: cf-deployment-develop
+    - get: stemcell
+      params:
+        tarball: false
+    - get: cf-deployment-concourse-tasks
+    - get: runtime-ci
+    - get: relint-envs
+    - get: relint-team
+  - task: update-additional-ops-files-cflinuxfs4-release-candidate
+    file: runtime-ci/tasks/update-single-opsfile-release/task.yml
+    input_mapping:
+      original-ops-file: cf-deployment-release-candidate
+      release: cflinuxfs4-release
+    output_mapping:
+      updated-ops-file: updated-cf-deployment-cflinuxfs4-release-candidate
+    params:
+      RELEASE_NAME: cflinuxfs4
+  - do:
+    - task: bbl-up
+      file: cf-deployment-concourse-tasks/bbl-up/task.yml
+      params:
+        BBL_JSON_CONFIG: pool-lock/metadata
+      input_mapping:
+        bbl-state: relint-envs
+        bbl-config: relint-envs
+        pool-lock: pre-dev-pool
+      on_failure:
+        do:
+        - task: bbl-cleanup-leftovers
+          file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
+          input_mapping:
+            bbl-state: updated-bbl-state
+            pool-lock: pre-dev-pool
+          output_mapping:
+            updated-bbl-state: clean-bbl-state
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+        ensure:
+          put: relint-envs
+          params:
+            repository: clean-bbl-state
+            rebase: true
+      on_success:
+        put: relint-envs
+        params:
+          repository: updated-bbl-state
+          rebase: true
+    - task: add-gcp-dns
+      file: runtime-ci/tasks/manage-gcp-dns/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+        pool-lock: pre-dev-pool
+      params:
+        BBL_JSON_CONFIG: pool-lock/metadata
+        GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
+        GCP_DNS_ZONE_NAME: wg-ard
+        ACTION: add
+    - do:
+      - task: combine-vars-files
+        file: runtime-ci/tasks/combine-inputs/task.yml
+        input_mapping:
+          first-input: cf-deployment-release-candidate
+          second-input: relint-envs
+        output_mapping:
+          combined-inputs: combined-vars-files
+      - task: deploy-cf
+        file: runtime-ci/tasks/bosh-deploy-with-first-ops/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          cf-deployment: updated-cf-deployment-cflinuxfs4-release-candidate
+          ops-files: updated-cf-deployment-cflinuxfs4-release-candidate
+          vars-files: combined-vars-files
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          OPS_FILES: |-
+            operations/scale-to-one-az.yml
+            operations/use-compiled-releases.yml
+            operations/experimental/use-compiled-releases-windows.yml
+            operations/experimental/add-cflinuxfs4.yml
+          REGENERATE_CREDENTIALS: false
+          BOSH_DEPLOY_ARGS: --parallel 50
+      - task: ensure-api-healthy
+        file: runtime-ci/tasks/ensure-api-healthy/task.yml
+        input_mapping:
+          cats-integration-config: relint-envs
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+      - task: run-errand-smoke-tests
+        file: cf-deployment-concourse-tasks/run-errand/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          ERRAND_NAME: smoke_tests
+      on_success:
+        do:
+        - task: update-additional-ops-files-cflinuxfs4-develop
+          file: runtime-ci/tasks/update-single-opsfile-release/task.yml
+          input_mapping:
+            original-ops-file: cf-deployment-develop
+            release: cflinuxfs4-release
+          output_mapping:
+            updated-ops-file: updated-cf-deployment-cflinuxfs4-develop
+          params:
+            RELEASE_NAME: cflinuxfs4
+        - put: cf-deployment-develop
+          params:
+            rebase: true
+            repository: updated-cf-deployment-cflinuxfs4-develop
+      on_failure:
+        do:
+        - task: push-to-release-branch
+          file: runtime-ci/tasks/push-to-release-branch/task.yml
+          input_mapping:
+            updated-cf-deployment: updated-cf-deployment-cflinuxfs4-release-candidate
+            release: cflinuxfs4-release
+          params:
+            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            RELEASE_NAME: cflinuxfs4
+        - task: retrieve-bosh-logs
+          file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+        - put: cflinuxfs4-component-bump-logs-gcs
+          params:
+            file: bosh-logs/cf-*.tgz
+        ensure:
+          do:
+          - task: create-slack-message
+            file: runtime-ci/tasks/create-slack-message/task.yml
+            input_mapping:
+              release: cflinuxfs4-release
+            params:
+              BOSH_LOGS_PREFIX: https://storage.cloud.google.com/component-bump-logs/cflinuxfs4
+              RELEASE_NAME: cflinuxfs4
+          - task: lookup-slack-channel-for-release-owner
+            file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
+            params:
+              RELEASE_REPOSITORY: cloudfoundry/cflinuxfs4-release
           - put: slack-alert
             params:
               channel_file: slack-channel/channel.txt


### PR DESCRIPTION
### WHAT is this change about?

#1008 / #989  adds `cflinuxfs4` via an optional ops-file. This PR adds `cflinuxfs4` to the update releases pipeline so that we always use the latest version.


### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?
CI/Pipeline change only

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?
- not relevant, CI only

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?
`update-cflinuxfs4` job in update releases pipeline should be green

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@jochenehret 

