### PR TITLE
Add cflinuxfs4 package for golang-buildpack

### DIFF
--- a/operations/experimental/add-cflinuxfs4.yml
+++ b/operations/experimental/add-cflinuxfs4.yml
@@ -28,6 +28,11 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
   value:
+    name: go_buildpack
+    package: go-buildpack-cflinuxfs4
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
     name: dotnet_core_buildpack
     package: dotnet-core-buildpack-cflinuxfs4
 - type: replace


### PR DESCRIPTION
### WHAT is this change about?

Add cflinuxfs4 package for golang-buildpack. Works with latest go-buildpack-release: 
https://github.com/cloudfoundry/go-buildpack-release/releases/tag/1.10.1

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Support buildpacks with cflinuxfs4 stack.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/989

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES (buildpack test with go-buildpack passed: https://app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-cats-cflinuxfs4/builds/21)
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

cflinuxfs4 support for golang-buildpack added

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

CATs golang buildpack test passes for cflinuxfs4 stack

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

