### PR TITLE
routing-api consumes gorouter link from primary gorouter so it does n…

### DIFF
--- a/operations/test/add-persistent-isolation-segment-router.yml
+++ b/operations/test/add-persistent-isolation-segment-router.yml
@@ -76,6 +76,10 @@
   value: router_primary
 
 - type: replace
+  path: /instance_groups/name=api/jobs/name=routing-api/consumes?/gorouter/from
+  value: router_primary
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/consumes?/router/from
   value: router_primary
 


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

This PR is in preparation for https://github.com/cloudfoundry/routing-release/pull/300, which has routing-api consume a bosh link from gorouter. It makes sure that, if customers use the ops file to add an isolation segment gorouter, that routing-api will consume the link from the correct (primary) gorouter.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Our CI caught that deploying isolation segment routers will cause a conflict of "Multiple Link Providers Found" deployment error. While we can't prevent errors that occur in the case of all isolation segment routers, we are making sure that isolation segment routers deployed via CF-Deployment ops files will not cause that error.

Note - we also confirmed that if this ops file is deployed with  a version of routing-api that does not consume any link (ie prior to the routing-release PR being released), the deployment will complete without error.

### Please provide any contextual information.

None.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Updates `operations/test/add-persistent-isolation-segment-router.yml` to make sure that routing-api consumes correct bosh link from the non-isolation-segment gorouter.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

> _Please specify either bosh cli or cf cli commands for our team (and cf operators) to verify the changes._

> _Few examples_
> 1. For a PR with a new job in the manifest, `bosh instances` can verify the job is running after upgrade. You can provide additional commands to verify the job is running as specified.
> 2. For a PR with new variables, `bosh variables | grep <var-name>` command can verify the variable exists. This is the simplest varification but you can also provide additional commands to test that the variable holds the desired value.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

We will wait for this change before releasing https://github.com/cloudfoundry/routing-release/pull/300. Hopefully this CF-D change is released on Friday, we can cut a new routing-release on Monday. Thank you Carson and Dave <3

### Tag your pair, your PM, and/or team!

#tas-journey-runtime-ecosystem 
