### PR TITLE
Gorouter uses TLS for public CAPI blobstore route

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -870,8 +870,10 @@ instance_groups:
         - name: blobstore
           port: 8080
           registration_interval: 20s
+          server_cert_domain_san: "blobstore.((system_domain))"
           tags:
             component: blobstore
+          tls_port: 4443
           uris:
           - blobstore.((system_domain))
 - name: api
@@ -2102,6 +2104,7 @@ variables:
     ca: service_cf_internal_ca
     common_name: blobstore.service.cf.internal
     alternative_names:
+    - "blobstore.((system_domain))"
     - blobstore.service.cf.internal
 - name: diego_auctioneer_client
   type: certificate


### PR DESCRIPTION
- TLS everywhere!
- The blobstore TLS port was already used for internal routes.

## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

Change the `blobstore.((system_domain))` route to use TLS between the Gorouter and the internal CAPI blobstore. This will only apply to environments that use the internal blobstore instead of an external (fog) blobstore.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

In addition to the added security of using TLS everywhere, Gorouter will prune non-TLS backends after a 120s TTL. If there is an issue with NATs or something else causes Gorouter to miss the blobstore's route registration heartbeat, then the `blobstore.((system_domain))` will not work, preventing users from downloading packages/droplets/etc.

### Please provide any contextual information.

This is (I believe) the last step in a larger effort to make all of Gorouter's backends TLS and eventually remove the ability to register non-TLS backends.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Gorouter uses TLS for public CAPI blobstore route.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

1. Deploy using the default, internal capi blobstore (`singleton-blobstore`)
2. Push an app
3. Download its droplet: 
```
❯ cf download-droplet <app>
Downloading current droplet for app <app> in org <org> / space <space> as admin...
Droplet downloaded successfully at /path/to/droplet_blah.tgz
OK
```

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cloudfoundry/wg-app-runtime-interfaces-capi-approvers 
@ameowlia 
@tcdowney who did [the same thing for CC](https://github.com/cloudfoundry/cf-deployment/pull/574)