### PR TITLE
Add ops file for trusted ca certs for cflinuxfs4

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -43,3 +43,4 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 | [`disable-logs-in-firehose.yml`](disable-logs-in-firehose.yml) | Logs are not sent to dopplers, only metrics | | **NO** |
 | [`disable-logs-in-firehose-windows2019.yml`](disable-logs-in-firehose-windows-2019.yml) | Logs are not sent to dopplers, only metrics | | **NO** |
 | [`use-native-garden-runc-runner.yml`](use-native-garden-runc-runner.yml) | Configure Garden to **not** create containers via containerd, using the native runner instead. | | **NO** |
+| [`use-trusted-ca-cert-for-apps-cflinuxfs4.yml`](use-trusted-ca-cert-for-apps-cflinuxfs4.yml) | Same as [`use-trusted-ca-cert-for-apps.yml`](../use-trusted-ca-cert-for-apps.yml), but for cflinuxfs4 stack | | **NO** |

--- a/operations/experimental/use-trusted-ca-cert-for-apps-cflinuxfs4.yml
+++ b/operations/experimental/use-trusted-ca-cert-for-apps-cflinuxfs4.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs4-rootfs-setup/properties/cflinuxfs4-rootfs/trusted_certs/-
+  value: ((trusted_cert_for_apps.ca))

--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -59,5 +59,7 @@ use-compiled-releases-windows.yml:
 use-create-swap-delete-vm-strategy.yml: {}
 use-native-garden-runc-runner.yml: {}
 use-trusted-ca-cert-for-apps-cflinuxfs4.yml:
+  ops:
+    - add-cflinuxfs4.yml
   varsfiles:
     - ../example-vars-files/vars-use-trusted-ca-cert-for-apps.yml

--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -58,3 +58,6 @@ use-compiled-releases-windows.yml:
   - use-compiled-releases-windows.yml
 use-create-swap-delete-vm-strategy.yml: {}
 use-native-garden-runc-runner.yml: {}
+use-trusted-ca-cert-for-apps-cflinuxfs4.yml:
+  varsfiles:
+    - example-vars-files/vars-use-trusted-ca-cert-for-apps.yml

--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -60,4 +60,4 @@ use-create-swap-delete-vm-strategy.yml: {}
 use-native-garden-runc-runner.yml: {}
 use-trusted-ca-cert-for-apps-cflinuxfs4.yml:
   varsfiles:
-    - example-vars-files/vars-use-trusted-ca-cert-for-apps.yml
+    - ../example-vars-files/vars-use-trusted-ca-cert-for-apps.yml

--- a/units/tests/standard_test/operations.yml
+++ b/units/tests/standard_test/operations.yml
@@ -148,5 +148,5 @@ use-swift-blobstore.yml:
   - example-vars-files/vars-use-swift-blobstore.yml
 use-trusted-ca-cert-for-apps.yml:
   varsfiles:
-  - example-vars-files/vars-use-trusted-ca-cert-for-apps.yml
+  - ../example-vars-files/vars-use-trusted-ca-cert-for-apps.yml
 windows2019-cell.yml: {}

--- a/units/tests/standard_test/operations.yml
+++ b/units/tests/standard_test/operations.yml
@@ -148,5 +148,5 @@ use-swift-blobstore.yml:
   - example-vars-files/vars-use-swift-blobstore.yml
 use-trusted-ca-cert-for-apps.yml:
   varsfiles:
-  - ../example-vars-files/vars-use-trusted-ca-cert-for-apps.yml
+  - example-vars-files/vars-use-trusted-ca-cert-for-apps.yml
 windows2019-cell.yml: {}


### PR DESCRIPTION
### WHAT is this change about?

Ops file to enable trusted ca for apps for cflinuxfs4, similar to existing ops file: https://github.com/cloudfoundry/cf-deployment/blob/main/operations/use-trusted-ca-cert-for-apps.yml

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Enable secure app communication also on cflinuxfs4 stack.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/989

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES (this ops file is not used in CATs)
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Doesn't need explicit documentation.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

For now, only unit tests must pass.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

