### PR TITLE
2 attempts for "bosh-deploy-cf-develop" tasks

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -836,6 +836,7 @@ jobs:
         environments/test/trelawney/add-external-ips-for-cloud-sql-db.yml
         environments/test/trelawney/scale-log-api-to-4.yml
   - task: bosh-deploy-cf-develop
+    attempts: 2
     file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
     input_mapping:
       bbl-state: relint-envs
@@ -1112,6 +1113,7 @@ jobs:
         environments/test/hermione/increase-doppler-vm-type-from-minimal-to-small.yml
         environments/test/hermione/scale-diego-cell-to-6.yml
   - task: bosh-deploy-cf-develop
+    attempts: 2
     file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
     input_mapping:
       bbl-state: relint-envs

--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -784,6 +784,7 @@ jobs:
       BBL_STATE_DIR: environments/test/trelawney/bbl-state
       VARS_DIR: environments/test/trelawney
   - task: bosh-deploy-cf-latest-release
+    attempts: 2
     file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
     input_mapping:
       bbl-state: relint-envs
@@ -1058,6 +1059,7 @@ jobs:
         environments/test/hermione/increase-doppler-vm-type-from-minimal-to-small.yml
         environments/test/hermione/scale-diego-cell-to-6.yml
   - task: bosh-deploy-cf-latest-release
+    attempts: 2
     file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
     input_mapping:
       bbl-state: relint-envs


### PR DESCRIPTION
* if this task fails in "upgrade-deploy" or "experimental-deploy", we have to start again from the beginning which takes very long (because first "bosh-deploy-cf-latest-release" is executed)
