### PR TITLE
Pipeline commits from main

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,4 @@ We have a [utility](https://github.com/ishustava/migrator) to help you migrate.
 ## <a name='migrating'></a>Can I Transition from `cf-release`?
 CF-Deployment replaces the [manifest generation scripts in cf-release][cf-release-url] which have been deprecated and are no longer supported by the Release Integration team.
 Although the team is no longer working on or supporting migrations from `cf-release` to `cf-deployment`, you can still find the tooling and documentation in the [cf-deployment-transition repo](https://github.com/cloudfoundry/cf-deployment-transition).
+

--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1065,7 +1065,7 @@ jobs:
       vars-files: relint-envs
     params:
       BBL_STATE_DIR: environments/test/hermione/bbl-state
-      SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
+      SYSTEM_DOMAIN: cf.hermione.env.wg-ard.ci.cloudfoundry.org
       OPS_FILES: |
         operations/aws.yml
         operations/use-compiled-releases.yml
@@ -1100,7 +1100,7 @@ jobs:
       bbl-state: relint-envs
     params:
       BBL_STATE_DIR: environments/test/hermione/bbl-state
-      SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
+      SYSTEM_DOMAIN: cf.hermione.env.wg-ard.ci.cloudfoundry.org
   - task: collect-ops-files-develop
     file: cf-deployment-concourse-tasks/collect-ops-files/task.yml
     input_mapping:
@@ -1120,7 +1120,7 @@ jobs:
       vars-files: relint-envs
     params:
       BBL_STATE_DIR: environments/test/hermione/bbl-state
-      SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
+      SYSTEM_DOMAIN: cf.hermione.env.wg-ard.ci.cloudfoundry.org
       OPS_FILES: |
         operations/aws.yml
         operations/use-compiled-releases.yml
@@ -1156,7 +1156,7 @@ jobs:
       params:
         BBL_STATE_DIR: environments/test/hermione/bbl-state
         INSTANCE_GROUP_NAME: credhub
-        SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
+        SYSTEM_DOMAIN: cf.hermione.env.wg-ard.ci.cloudfoundry.org
         SECURITY_GROUP_NAME: credhub
     - task: open-asgs-for-uaa
       file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
@@ -1165,7 +1165,7 @@ jobs:
       params:
         BBL_STATE_DIR: environments/test/hermione/bbl-state
         INSTANCE_GROUP_NAME: uaa
-        SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
+        SYSTEM_DOMAIN: cf.hermione.env.wg-ard.ci.cloudfoundry.org
         SECURITY_GROUP_NAME: uaa
     - task: set-feature-flags
       file: cf-deployment-concourse-tasks/set-feature-flags/task.yml
@@ -1173,7 +1173,7 @@ jobs:
         bbl-state: relint-envs
       params:
         BBL_STATE_DIR: environments/test/hermione/bbl-state
-        SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
+        SYSTEM_DOMAIN: cf.hermione.env.wg-ard.ci.cloudfoundry.org
         ENABLED_FEATURE_FLAGS: |
           diego_docker
           task_creation

--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1065,7 +1065,7 @@ jobs:
       vars-files: relint-envs
     params:
       BBL_STATE_DIR: environments/test/hermione/bbl-state
-      SYSTEM_DOMAIN: hermione.cf-app.com
+      SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
       OPS_FILES: |
         operations/aws.yml
         operations/use-compiled-releases.yml
@@ -1100,7 +1100,7 @@ jobs:
       bbl-state: relint-envs
     params:
       BBL_STATE_DIR: environments/test/hermione/bbl-state
-      SYSTEM_DOMAIN: hermione.cf-app.com
+      SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
   - task: collect-ops-files-develop
     file: cf-deployment-concourse-tasks/collect-ops-files/task.yml
     input_mapping:
@@ -1120,7 +1120,7 @@ jobs:
       vars-files: relint-envs
     params:
       BBL_STATE_DIR: environments/test/hermione/bbl-state
-      SYSTEM_DOMAIN: hermione.cf-app.com
+      SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
       OPS_FILES: |
         operations/aws.yml
         operations/use-compiled-releases.yml
@@ -1156,7 +1156,7 @@ jobs:
       params:
         BBL_STATE_DIR: environments/test/hermione/bbl-state
         INSTANCE_GROUP_NAME: credhub
-        SYSTEM_DOMAIN: hermione.cf-app.com
+        SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
         SECURITY_GROUP_NAME: credhub
     - task: open-asgs-for-uaa
       file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
@@ -1165,7 +1165,7 @@ jobs:
       params:
         BBL_STATE_DIR: environments/test/hermione/bbl-state
         INSTANCE_GROUP_NAME: uaa
-        SYSTEM_DOMAIN: hermione.cf-app.com
+        SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
         SECURITY_GROUP_NAME: uaa
     - task: set-feature-flags
       file: cf-deployment-concourse-tasks/set-feature-flags/task.yml
@@ -1173,7 +1173,7 @@ jobs:
         bbl-state: relint-envs
       params:
         BBL_STATE_DIR: environments/test/hermione/bbl-state
-        SYSTEM_DOMAIN: hermione.cf-app.com
+        SYSTEM_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
         ENABLED_FEATURE_FLAGS: |
           diego_docker
           task_creation

--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -118,7 +118,7 @@ experimental-bbl-up-task: &experimental-bbl-up-task-config
     bbl-state: relint-envs
   params:
     BBL_AWS_ACCESS_KEY_ID: ((hermione_aws_access_key_id))
-    BBL_AWS_REGION: us-west-2
+    BBL_AWS_REGION: eu-central-1
     BBL_AWS_SECRET_ACCESS_KEY: ((hermione_aws_secret_access_key))
     BBL_CONFIG_DIR: environments/test/hermione/bbl-config
     BBL_ENV_NAME: hermione-experimental
@@ -127,7 +127,7 @@ experimental-bbl-up-task: &experimental-bbl-up-task-config
     BBL_LB_CERT_CHAIN: ((hermione_lb.ca))
     BBL_LB_KEY: ((hermione_lb.private_key))
     BBL_STATE_DIR: environments/test/hermione/bbl-state
-    LB_DOMAIN: hermione.cf-app.com
+    LB_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
     TRUSTED_CA: ((relint_ca.certificate))
   ensure:
     put: relint-envs

--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -127,7 +127,7 @@ experimental-bbl-up-task: &experimental-bbl-up-task-config
     BBL_LB_CERT_CHAIN: ((hermione_lb.ca))
     BBL_LB_KEY: ((hermione_lb.private_key))
     BBL_STATE_DIR: environments/test/hermione/bbl-state
-    LB_DOMAIN: hermione.env.wg-ard.ci.cloudfoundry.org
+    LB_DOMAIN: cf.hermione.env.wg-ard.ci.cloudfoundry.org
     TRUSTED_CA: ((relint_ca.certificate))
   ensure:
     put: relint-envs


### PR DESCRIPTION
Some commits for `ci/pipelines` were accidentally pushed directly to the "main" branch. Cherry-pick those to "develop" so that a fast-forward merge from "develop" to "release-candidate" to "main" is possible again.
