### PR TITLE
Remove obsolete `internal_api_password`

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -980,7 +980,6 @@ instance_groups:
           current_key_label: "encryption_key_0"
           keys:
             encryption_key_0: "((cc_db_encryption_key))"
-        internal_api_password: "((cc_internal_api_password))"
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"
         temporary_use_logcache: true
@@ -1206,7 +1205,6 @@ instance_groups:
       cc:
         db_encryption_key: "((cc_db_encryption_key))"
         database_encryption: *cc-database-encryption
-        internal_api_password: "((cc_internal_api_password))"
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"
         resource_pool: *blobstore-properties
@@ -1277,7 +1275,6 @@ instance_groups:
       cc:
         db_encryption_key: "((cc_db_encryption_key))"
         database_encryption: *cc-database-encryption
-        internal_api_password: "((cc_internal_api_password))"
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"
         resource_pool: *blobstore-properties
@@ -1929,8 +1926,6 @@ variables:
 - name: blobstore_secure_link_secret
   type: password
 - name: cc_db_encryption_key
-  type: password
-- name: cc_internal_api_password
   type: password
 - name: cc_staging_upload_password
   type: password

--- a/scripts/fixtures/unit-test-vars-store.yml
+++ b/scripts/fixtures/unit-test-vars-store.yml
@@ -673,7 +673,6 @@ cc_bridge_tps:
     -----END RSA PRIVATE KEY-----
 cc_database_password: dlhmrn13ejrthinn1ois
 cc_db_encryption_key: f0rlc2rzvq28e1j86b4x
-cc_internal_api_password: oir6xotljecrgrojj8co
 cc_logcache_tls:
   ca: |
     -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
### WHAT is this change about?

Remove obsolete `internal_api_password` for internal CF API (Capi/ CCNG). Instead of basic auth with the `internal_api_password` mTLS is used (for a long time already).
In CAPI `internal_api_password` was removed with version 1.144.0.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to get rid of unused/obsolete credentials

### Please provide any contextual information.

- cloudfoundry/capi-release/pull/286
- cloudfoundry/cloud_controller_ng/pull/3134

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO (however CAPI release passed CATS)

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO


### How should this change be described in cf-deployment release notes?

Remove `cc_internal_api_password` as mTLS is now used instead.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

run CATS

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

