### PR TITLE
CI: remove deliver tracker story task

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -317,13 +317,6 @@ resources:
     git_user: "CF MEGA BOT <cf-mega@pivotal.io>"
     file: cf-deployment-version
 
-- name: deliver-tracker-story
-  type: tracker
-  source:
-    token: ((cf_relint_tracker_api_token))
-    project_id: "1382120"
-    tracker_url: https://www.pivotaltracker.com
-
 - name: disaster-recovery-acceptance-tests
   type: git
   icon: github
@@ -1848,10 +1841,6 @@ jobs:
   - put: cf-deployment-release-candidate
     params:
       repository: cf-deployment-develop
-  - put: deliver-tracker-story
-    params:
-      repos:
-        - cf-deployment-develop
 
 - name: ship-it-patch
   public: true


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

Removes unused task `deliver-tracker-story` from cf-deployment pipeline. This task is an artifact of when the folks managing this repo used a public tracker project. We've since switched to using GH projects.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

N/A - this is a CI-only change.

### Please provide any contextual information.

- [slack thread](https://cloudfoundry.slack.com/archives/C033ALST37V/p1675323741810389).

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] N/A - CI-only change
- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Shouldn't be described in the release notes.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] CI
- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

- `fly` the changes to the cf-deployment pipeline.
- See the bless-manifest job complete successfully.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@jochenehret 