### PR TITLE
Add r-buildpack for cflinuxfs4

### DIFF
--- a/operations/experimental/add-cflinuxfs4.yml
+++ b/operations/experimental/add-cflinuxfs4.yml
@@ -43,6 +43,11 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
   value:
+    name: r_buildpack
+    package: r-buildpack-cflinuxfs4
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
     name: binary_buildpack
     package: binary-buildpack-cflinuxfs4
 - type: replace


### PR DESCRIPTION
### WHAT is this change about?

Add cflinuxfs4 support for r-buildpack.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/989

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

r-buildpack v1.2.0 now supports cflinuxsfs4

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Job "experimental-cats-cflinuxfs4" should show passing test:

`[detect] Buildpacks r when using cflinuxfs4 stack [It] makes the app reachable via its bound route`

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

