### PR TITLE
Bumping pxc-release to 1.0.7

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -434,6 +434,7 @@ instance_groups:
   - name: pxc-mysql
     release: pxc
     properties:
+      mysql_version: "5.7"
       admin_password: ((cf_mysql_mysql_admin_password))
       engine_config:
         binlog:

--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -42,4 +42,5 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 | [`disable-logs-in-firehose.yml`](disable-logs-in-firehose.yml) | Logs are not sent to dopplers, only metrics | | **NO** |
 | [`disable-logs-in-firehose-windows2019.yml`](disable-logs-in-firehose-windows-2019.yml) | Logs are not sent to dopplers, only metrics | | **NO** |
 | [`use-native-garden-runc-runner.yml`](use-native-garden-runc-runner.yml) | Configure Garden to **not** create containers via containerd, using the native runner instead. | | **NO** |
+| [`use-mysql-version-8.0.yml`](use-mysql-version-8.0.yml) | Deploys or upgrades Percona 8.0 as the internal database. | When used in conjunction with [pxc-release](https://github.com/cloudfoundry/pxc-release) v1.0.0 or greater will deploy Percona 8.0 or upgrade Percona 5.7 to Percona 8.0| **NO** |
 | [`use-trusted-ca-cert-for-apps-cflinuxfs4.yml`](use-trusted-ca-cert-for-apps-cflinuxfs4.yml) | Same as [`use-trusted-ca-cert-for-apps.yml`](../use-trusted-ca-cert-for-apps.yml), but for cflinuxfs4 stack | | **NO** |

--- a/operations/experimental/use-mysql-version-8.0.yml
+++ b/operations/experimental/use-mysql-version-8.0.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=database/jobs/name=pxc-mysql/properties/mysql_version?
+  value: "8.0"

--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -62,3 +62,7 @@ use-trusted-ca-cert-for-apps-cflinuxfs4.yml:
     - add-cflinuxfs4.yml
   varsfiles:
     - ../example-vars-files/vars-use-trusted-ca-cert-for-apps.yml
+use-mysql-version-8.0.yml:
+  pathvalidator:
+    path: /instance_groups/name=database/jobs/name=pxc-mysql/properties/mysql_version?
+    expectedvalue: "8.0"


### PR DESCRIPTION
Redo of [our old PR](https://github.com/cloudfoundry/cf-deployment/pull/1049). We force pushed a change that auto closed the old one.

pxc-release 1.0.0 and greater have support for Percona 8.0. This is controlled by a new property mysql_version. An upgrade from Percona 5.7 to 8.0 will be performed. Also included an operations file to make the property mysql_version change from 5.7 to 8.0. The default continues to be Percona 5.7.

Co-authored-by: Colin Shield <cshield@vmware.com>
Co-authored-by: Andrew Garner <garnera@vmware.com>
Co-authored-by: Kevin Markwardt <kmarkwardt@vmware.com>

## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Bumping pxc-release to v1.0.7

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

This change introduces support for Percona 8.0. Releases of pxc-release prior to 1.0.0 only support Percona 5.7. Percona 5.7 has an EOL notice.

### Please provide any contextual information.

[Percona 5.7 will be EOL 01-Oct-2023](https://www.percona.com/services/policies/percona-software-support-lifecycle)
There are some significant changes from Percona 5.7 to Percona 8.0 of which you should be aware. Read the [compatibility documentation from Percona](https://dev.mysql.com/doc/refman/8.0/en/mysql-nutshell.html#mysql-nutshell-removals). This will provide details on where an application's SQL may fail to execute correctly.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO


### How should this change be described in cf-deployment release notes?

Bumping pxc-release to 1.0.7. pxc-release 1.0.0 and above include support for Percona 8.0. The default remains Percona 5.7. This can be changed by using the operations file 
- `operations/use-mysql-version-8.0.yml`

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Use `bosh -d cf deployment | grep pxc` and confirm that pxc/1.0.7 is deployed.

If applying the operations file `operations/use-mysql-version-8.0.yl` validate that the mysql instance is Percona 8.0 or greater.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work. Percona 5.7 is EOL October 2023.
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
#mysql-for-tas
@abg 
@kmarkwardt-vmware
