### PR TITLE
Add nginx-buildpack to cflinuxfs4 ops file

### DIFF
--- a/operations/experimental/add-cflinuxfs4.yml
+++ b/operations/experimental/add-cflinuxfs4.yml
@@ -43,6 +43,11 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
   value:
+    name: nginx_buildpack
+    package: nginx-buildpack-cflinuxfs4
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
     name: r_buildpack
     package: r-buildpack-cflinuxfs4
 - type: replace


### PR DESCRIPTION
### WHAT is this change about?

Add nginx-buildpack to cflinuxfs4 ops file. Latest release v1.2.0 supports cflinuxfs4:
https://github.com/cloudfoundry/nginx-buildpack/releases/tag/v1.2.0

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

One more buildpack for the cflinuxfs4 rollout.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/989

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

The **nginx-buildpack** now supports cflinuxfs4: https://github.com/cloudfoundry/nginx-buildpack/releases/tag/v1.2.0

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

This test in "experimental-cats-cflinuxfs4" should pass:
```
  [FAIL] [detect] Buildpacks nginx when using cflinuxfs4 stack [It] makes the app reachable via its bound route
  /go/src/github.com/cloudfoundry/cf-acceptance-tests/detect/buildpacks.go:225
```

https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-cats-cflinuxfs4

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

