### PR TITLE
CI: add mysql 8 upgrade to experimental CI fan-out

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1080,6 +1080,7 @@ jobs:
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
         operations/experimental/enable-oci-phase-1.yml
         operations/experimental/enable-containerd-for-processes.yml
+        operations/experimental/use-mysql-version-8.0.yml
         operations/increase-doppler-vm-type-from-minimal-to-small.yml
         operations/scale-diego-cell-to-6.yml
         operations/test/speed-up-dynamic-asgs.yml

--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -42,5 +42,5 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 | [`disable-logs-in-firehose.yml`](disable-logs-in-firehose.yml) | Logs are not sent to dopplers, only metrics | | **NO** |
 | [`disable-logs-in-firehose-windows2019.yml`](disable-logs-in-firehose-windows-2019.yml) | Logs are not sent to dopplers, only metrics | | **NO** |
 | [`use-native-garden-runc-runner.yml`](use-native-garden-runc-runner.yml) | Configure Garden to **not** create containers via containerd, using the native runner instead. | | **NO** |
-| [`use-mysql-version-8.0.yml`](use-mysql-version-8.0.yml) | Deploys or upgrades Percona 8.0 as the internal database. | When used in conjunction with [pxc-release](https://github.com/cloudfoundry/pxc-release) v1.0.0 or greater will deploy Percona 8.0 or upgrade Percona 5.7 to Percona 8.0| **NO** |
+| [`use-mysql-version-8.0.yml`](use-mysql-version-8.0.yml) | Deploys or upgrades Percona 8.0 as the internal database. | When used in conjunction with [pxc-release](https://github.com/cloudfoundry/pxc-release) v1.0.0 or greater will deploy Percona 8.0 or upgrade Percona 5.7 to Percona 8.0| **YES** |
 | [`use-trusted-ca-cert-for-apps-cflinuxfs4.yml`](use-trusted-ca-cert-for-apps-cflinuxfs4.yml) | Same as [`use-trusted-ca-cert-for-apps.yml`](../use-trusted-ca-cert-for-apps.yml), but for cflinuxfs4 stack | | **NO** |


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

Test [operations/experimental/use-mysql-version-8.0.yml](https://github.com/cloudfoundry/cf-deployment/blob/develop/operations/experimental/use-mysql-version-8.0.yml) in experimental fan-out in CI

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

N/A

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/pull/1049#discussion_r1107807061

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Experimental fan-out in CI succeeds.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@davewalter 