### PR TITLE
CI: add mysql 8 upgrade to experimental

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1080,7 +1080,6 @@ jobs:
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
         operations/experimental/enable-oci-phase-1.yml
         operations/experimental/enable-containerd-for-processes.yml
-        operations/experimental/use-mysql-version-8.0.yml
         operations/increase-doppler-vm-type-from-minimal-to-small.yml
         operations/scale-diego-cell-to-6.yml
         operations/test/speed-up-dynamic-asgs.yml
@@ -1137,6 +1136,7 @@ jobs:
         operations/experimental/enable-oci-phase-1.yml
         operations/experimental/enable-containerd-for-processes.yml
         operations/experimental/disable-v2-api.yml
+        operations/experimental/use-mysql-version-8.0.yml
         operations/increase-doppler-vm-type-from-minimal-to-small.yml
         operations/scale-diego-cell-to-6.yml
         operations/test/speed-up-dynamic-asgs.yml


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

Test [operations/experimental/use-mysql-version-8.0.yml](https://github.com/cloudfoundry/cf-deployment/blob/develop/operations/experimental/use-mysql-version-8.0.yml) in experimental fan-out in CI.

Previously, in #1053 I accidentally added this to the first deploy rather than the upgrade. That was a mistake that needed correcting.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

N/A

### Please provide any contextual information.

* https://github.com/cloudfoundry/cf-deployment/pull/1049#discussion_r1107807061
* #1053 

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Experimental fan-out in CI succeeds.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None