### PR TITLE
Add staticfile-buildpack with cflinuxfs4 support

### DIFF
--- a/operations/experimental/add-cflinuxfs4.yml
+++ b/operations/experimental/add-cflinuxfs4.yml
@@ -13,6 +13,11 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
   value:
+    name: staticfile_buildpack
+    package: staticfile-buildpack-cflinuxfs4
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
     name: java_buildpack
     package: java-buildpack-cflinuxfs4
 - type: replace


### PR DESCRIPTION
### WHAT is this change about?

staticfile-buildpack v1.5.39 now supports cflinuxfs4
https://github.com/cloudfoundry/staticfile-buildpack-release/releases/tag/1.5.39

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Build CF apps with staticfile-buildpack on cflinuxfs4 stack.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/989

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

staticfile-buildpack now supports cflinuxfs4

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Test "[detect] Buildpacks staticfile when using cflinuxfs4 stack [It] makes the app reachable via its bound route" should pass in "experimental-cats-cflinuxfs4" job:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-cats-cflinuxfs4

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

