### PR TITLE
Add cflinuxfs4 support for php-buildpack

### DIFF
--- a/operations/experimental/add-cflinuxfs4.yml
+++ b/operations/experimental/add-cflinuxfs4.yml
@@ -48,6 +48,11 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
   value:
+    name: php_buildpack
+    package: php-buildpack-cflinuxfs4
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
     name: nginx_buildpack
     package: nginx-buildpack-cflinuxfs4
 - type: replace


### PR DESCRIPTION
### WHAT is this change about?

Add cflinuxfs4 support for php-buildpack.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Build php applications on cflinuxfs4 stack.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/989

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

php-buildpack 4.6.0 now supports cflinuxfs4: https://github.com/cloudfoundry/php-buildpack-release/releases/tag/4.6.0

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

"experimental-cats-cflinuxfs4" now must turn green: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-cats-cflinuxfs4

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
