### PR TITLE
Fix update-windows-utilities job

### DIFF
--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -98,7 +98,6 @@ opsReleases:
 - name: windows-utilities
   repository: cloudfoundry-incubator/windows-utilities-release
   requiredOpsFiles:
-  - operations/windows2019-cell.yml
   - operations/use-online-windows2019fs.yml
   prependOpsFileToList: true
 - name: garden-windows

--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -12270,7 +12270,6 @@ jobs:
             operations/scale-to-one-az.yml
             operations/use-compiled-releases.yml
             operations/experimental/use-compiled-releases-windows.yml
-            operations/windows2019-cell.yml
             operations/use-online-windows2019fs.yml
           REGENERATE_CREDENTIALS: false
           BOSH_DEPLOY_ARGS: --parallel 50
@@ -15220,7 +15219,7 @@ jobs:
       BBL_STATE_DIR: environments/test/greengrass/bbl-state
       BBL_CONFIG_DIR: environments/test/greengrass/bbl-config
       BBL_IAAS: gcp
-      BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/greengrass/google_account_creds.json
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((greengrass_gcp_service_account_json))
       BBL_GCP_REGION: europe-west3
       BBL_ENV_NAME: greengrass-compile
       SKIP_LB_CREATION: true
@@ -15260,7 +15259,7 @@ jobs:
       bbl-state: relint-envs
     params:
       BBL_STATE_DIR: environments/test/greengrass/bbl-state
-      BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/greengrass/google_account_creds.json
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((greengrass_gcp_service_account_json))
     ensure:
       put: relint-envs
       params:

--- a/ci/template/update-releases.yml
+++ b/ci/template/update-releases.yml
@@ -1061,7 +1061,7 @@ jobs:
       BBL_STATE_DIR: environments/test/greengrass/bbl-state
       BBL_CONFIG_DIR: environments/test/greengrass/bbl-config
       BBL_IAAS: gcp
-      BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/greengrass/google_account_creds.json
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((greengrass_gcp_service_account_json))
       BBL_GCP_REGION: europe-west3
       BBL_ENV_NAME: greengrass-compile
       SKIP_LB_CREATION: true
@@ -1102,7 +1102,7 @@ jobs:
       bbl-state: relint-envs
     params:
       BBL_STATE_DIR: environments/test/greengrass/bbl-state
-      BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/greengrass/google_account_creds.json
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((greengrass_gcp_service_account_json))
     ensure:
       put: relint-envs
       params:


### PR DESCRIPTION
* ops file "operations/windows2019-cell.yml" was applied twice which didn't work
* and use greengrass key stored in credhub

### WHAT is this change about?

Fix update-releases pipeline.

