### PR TITLE
Manual merge stemcell update from main

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1,6 +1,6 @@
 ---
 name: cf
-manifest_version: v27.2.0
+manifest_version: v27.3.0
 update:
   canaries: 1
   canary_watch_time: 30000-1200000
@@ -2897,4 +2897,4 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-jammy
-  version: "1.93"
+  version: "1.95"


### PR DESCRIPTION
### WHAT is this change about?

Manual merge automatic stemcell update from "main" into "develop" because branch protection rules failed the "update-stemcell-minor" job.

https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/update-releases/jobs/update-stemcell-minor/builds/5
