### PR TITLE
Use ARD WG Git Bot for CI pipelines

### DIFF
--- a/ci/pipelines/bionic-stemcell.yml
+++ b/ci/pipelines/bionic-stemcell.yml
@@ -230,15 +230,13 @@ resources:
   name: cf-acceptance-tests-rc
   source:
     branch: release-candidate
-    private_key: ((cf_acceptance_tests_readwrite_deploy_key.private_key))
-    uri: git@github.com:cloudfoundry/cf-acceptance-tests.git
+    uri: https://github.com/cloudfoundry/cf-acceptance-tests.git
   type: git
 - icon: github
   name: cf-deployment
   source:
     branch: release-candidate
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
-    uri: git@github.com:cloudfoundry/cf-deployment.git
+    uri: https://github.com/cloudfoundry/cf-deployment.git
   type: git
 - icon: github
   name: cf-deployment-concourse-tasks
@@ -249,7 +247,7 @@ resources:
   name: relint-envs
   source:
     branch: main
-    private_key: ((hagrid_env_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
     uri: git@github.com:cloudfoundry/relint-envs.git
   type: git
 - icon: github
@@ -262,6 +260,6 @@ resources:
   source:
     branch: main
     pool: cf-deployment/stable
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
     uri: git@github.com:cloudfoundry/relint-ci-pools
   type: pool

--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -146,7 +146,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cf-deployment/fresh
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: upgrade-pool
   type: pool
@@ -155,7 +155,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cf-deployment/upgrade
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: experimental-pool
   type: pool
@@ -164,7 +164,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cf-deployment/experimental
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: lite-pool
   type: pool
@@ -173,7 +173,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cf-deployment/lite
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: bbr-pool
   type: pool
@@ -182,7 +182,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: bbr
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: windows-pool
   type: pool
@@ -191,7 +191,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cf-deployment/windows
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: relint-envs
   type: git
@@ -199,7 +199,7 @@ resources:
   source:
     branch: main
     uri: git@github.com:cloudfoundry/relint-envs.git
-    private_key: ((hagrid_env_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: daily
   type: time
@@ -233,7 +233,7 @@ resources:
   source:
     branch: develop
     uri: git@github.com:cloudfoundry/cf-deployment.git
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
     ignore_paths:
     - .envrc
     - .overcommit.yml
@@ -248,7 +248,7 @@ resources:
   source:
     branch: release-candidate
     uri: git@github.com:cloudfoundry/cf-deployment.git
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
     ignore_paths:
     - .envrc
     - .overcommit.yml
@@ -263,7 +263,7 @@ resources:
   source:
     branch: main
     uri: git@github.com:cloudfoundry/cf-deployment.git
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
     ignore_paths:
     - .envrc
     - .overcommit.yml
@@ -291,8 +291,7 @@ resources:
   icon: github
   source:
     branch: release-candidate
-    uri: git@github.com:cloudfoundry/cf-acceptance-tests.git
-    private_key: ((cf_acceptance_tests_readwrite_deploy_key.private_key))
+    uri: https://github.com/cloudfoundry/cf-acceptance-tests.git
 
 - name: cf-smoke-tests
   type: git
@@ -313,8 +312,7 @@ resources:
     driver: git
     uri: git@github.com:cloudfoundry/cf-relint-ci-semver.git
     branch: main
-    private_key: ((cf_relint_ci_semver_readwrite_deploy_key.private_key))
-    git_user: "CF MEGA BOT <cf-mega@pivotal.io>"
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
     file: cf-deployment-version
 
 - name: disaster-recovery-acceptance-tests

--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -247,7 +247,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cf-deployment/fresh
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: lite-pool
   type: pool
@@ -256,7 +256,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cf-deployment/lite
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: upgrade-pool
   type: pool
@@ -265,7 +265,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cf-deployment/upgrade
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: stable-pool
   type: pool
@@ -274,7 +274,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cf-deployment/stable
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: experimental-pool
   type: pool
@@ -283,7 +283,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cf-deployment/experimental
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: cats-pool
   type: pool
@@ -292,7 +292,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cats
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: bbr-pool
   type: pool
@@ -301,7 +301,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: bbr
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: windows-pool
   type: pool
@@ -310,7 +310,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: cf-deployment/windows
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 # Plan patches
 - name: bosh-bootloader
@@ -340,7 +340,7 @@ resources:
   source:
     branch: main
     uri: git@github.com:cloudfoundry/relint-envs.git
-    private_key: ((hagrid_env_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 # Time
 - name: every-tuesday-morning

--- a/ci/pipelines/pull-requests.yml
+++ b/ci/pipelines/pull-requests.yml
@@ -28,42 +28,42 @@ resources:
   - name: cf-deployment-all-branches
     type: pull-request
     source:
-      access_token: ((github_status_bot_repo_access_token))
+      access_token: ((ard_wg_gitbot_token))
       repository: cloudfoundry/cf-deployment
   - name: cf-deployment-main
     type: pull-request
     source:
-      access_token: ((github_status_bot_repo_access_token))
+      access_token: ((ard_wg_gitbot_token))
       repository: cloudfoundry/cf-deployment
       base_branch: main
   - name: cf-deployment-rc
     type: pull-request
     source:
-      access_token: ((github_status_bot_repo_access_token))
+      access_token: ((ard_wg_gitbot_token))
       repository: cloudfoundry/cf-deployment
       base_branch: release-candidate
   - name: cf-deployment-develop
     type: pull-request
     source:
-      access_token: ((github_status_bot_repo_access_token))
+      access_token: ((ard_wg_gitbot_token))
       repository: cloudfoundry/cf-deployment
       base_branch: develop
 
   - name: cats-all-branches
     type: pull-request
     source:
-      access_token: ((github_status_bot_repo_access_token))
+      access_token: ((ard_wg_gitbot_token))
       repository: cloudfoundry/cf-acceptance-tests
   - name: cats-main
     type: pull-request
     source:
-      access_token: ((github_status_bot_repo_access_token))
+      access_token: ((ard_wg_gitbot_token))
       repository: cloudfoundry/cf-acceptance-tests
       base_branch: main
   - name: cats-develop
     type: pull-request
     source:
-      access_token: ((github_status_bot_repo_access_token))
+      access_token: ((ard_wg_gitbot_token))
       repository: cloudfoundry/cf-acceptance-tests
       base_branch: develop
 

--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -160,35 +160,34 @@ resources:
   source:
     branch: develop
     uri: git@github.com:cloudfoundry/cf-deployment.git
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 - name: cf-deployment-release-candidate
   type: git
   icon: github
   source:
     branch: release-candidate
     uri: git@github.com:cloudfoundry/cf-deployment.git
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 - name: cf-deployment-main
   type: git
   source:
     branch: main
     uri: git@github.com:cloudfoundry/cf-deployment.git
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 - name: cf-deployment-version
   type: semver
   source:
     driver: git
     uri: git@github.com:cloudfoundry/cf-relint-ci-semver.git
     branch: main
-    private_key: ((cf_relint_ci_semver_readwrite_deploy_key.private_key))
-    git_user: CF MEGA BOT <cf-mega@pivotal.io>
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
     file: cf-deployment-version
 - name: cf-deployment-release
   type: github-release
   source:
     owner: cloudfoundry
     repository: cf-deployment
-    access_token: ((cf_deployment_release_bot_access_token))
+    access_token: ((ard_wg_gitbot_token))
 - name: cf-deployment-concourse-tasks
   type: git
   icon: github
@@ -200,14 +199,14 @@ resources:
   source:
     branch: main
     uri: git@github.com:cloudfoundry/relint-envs.git
-    private_key: ((hagrid_env_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 - name: relint-team
   type: git
   icon: github
   source:
     branch: main
     uri: git@github.com:cloudfoundry/relint-team.git
-    private_key: ((runtime_ci_private_read_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 - name: runtime-ci
   type: git
   icon: github
@@ -977,7 +976,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: update-release-pool
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 - name: pre-dev-dagobah
   type: pool
   icon: pool
@@ -985,7 +984,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: update-release-pool
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 - name: pre-dev-endor
   type: pool
   icon: pool
@@ -993,7 +992,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: update-release-pool
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 - name: pre-dev-hoth
   type: pool
   icon: pool
@@ -1001,7 +1000,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: update-release-pool
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 - name: pre-dev-tatooine
   type: pool
   icon: pool
@@ -1009,7 +1008,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: update-release-pool
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 jobs:
 - name: acquire-bosh-dns-aliases-pre-dev-lock
   public: true

--- a/ci/template/update-releases.yml
+++ b/ci/template/update-releases.yml
@@ -117,7 +117,7 @@ resources:
   source:
     branch: develop
     uri: git@github.com:cloudfoundry/cf-deployment.git
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: cf-deployment-release-candidate
   type: git
@@ -125,14 +125,14 @@ resources:
   source:
     branch: release-candidate
     uri: git@github.com:cloudfoundry/cf-deployment.git
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: cf-deployment-main
   type: git  
   source:
     branch: main
     uri: git@github.com:cloudfoundry/cf-deployment.git
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: cf-deployment-version
   type: semver
@@ -140,8 +140,7 @@ resources:
     driver: git
     uri: git@github.com:cloudfoundry/cf-relint-ci-semver.git
     branch: main
-    private_key: ((cf_relint_ci_semver_readwrite_deploy_key.private_key))
-    git_user: "CF MEGA BOT <cf-mega@pivotal.io>"
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
     file: cf-deployment-version
 
 - name: cf-deployment-release
@@ -149,7 +148,7 @@ resources:
   source:
     owner: cloudfoundry
     repository: cf-deployment
-    access_token: ((cf_deployment_release_bot_access_token))
+    access_token: ((ard_wg_gitbot_token))
 
 - name: cf-deployment-concourse-tasks
   type: git
@@ -163,7 +162,7 @@ resources:
   source:
     branch: main
     uri: git@github.com:cloudfoundry/relint-envs.git
-    private_key: ((hagrid_env_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: relint-team
   type: git
@@ -171,7 +170,7 @@ resources:
   source:
     branch: main
     uri: git@github.com:cloudfoundry/relint-team.git
-    private_key: ((runtime_ci_private_read_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: runtime-ci
   type: git
@@ -302,7 +301,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: update-release-pool
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 #@ for e in data.values.preDevEnvs:
 - name: #@ "pre-dev-" + e.name
@@ -312,7 +311,7 @@ resources:
     uri: git@github.com:cloudfoundry/relint-ci-pools
     branch: main
     pool: update-release-pool
-    private_key: ((relint_ci_pools_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 #@ end
 
 jobs:


### PR DESCRIPTION
### WHAT is this change about?

Use only ARD WG Git Bot for git and github operations. Where authentication is not required, use https git URL.
