### PR TITLE
Configure ARD WG GitBot for bbl tasks

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1462,6 +1462,8 @@ jobs:
         BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/snitch/snitch-lite.key.json
         BBL_IAAS: gcp
         BBL_STATE_DIR: environments/test/snitch/bbl-state
+        GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+        GIT_COMMIT_USERNAME: "ARD WG Bot"
         SKIP_LB_CREATION: true
       input_mapping:
         bbl-state: relint-envs

--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -83,6 +83,8 @@ fresh-bbl-up-task: &fresh-bbl-up-task-config
     BBL_LB_CERT: ../lb-certs/luna.crt
     BBL_LB_KEY: ../lb-certs/luna.key
     BBL_STATE_DIR: environments/test/luna/bbl-state
+    GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+    GIT_COMMIT_USERNAME: "ARD WG Bot"
     LB_DOMAIN: cf.luna.env.wg-ard.ci.cloudfoundry.org
   ensure:
     put: relint-envs
@@ -104,6 +106,8 @@ upgrade-bbl-up-task: &upgrade-bbl-up-task-config
     BBL_LB_CERT: ../lb-certs/trelawney.crt
     BBL_LB_KEY: ../lb-certs/trelawney.key
     BBL_STATE_DIR: environments/test/trelawney/bbl-state
+    GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+    GIT_COMMIT_USERNAME: "ARD WG Bot"
     LB_DOMAIN: cf.trelawney.env.wg-ard.ci.cloudfoundry.org
   ensure:
     put: relint-envs
@@ -127,6 +131,8 @@ experimental-bbl-up-task: &experimental-bbl-up-task-config
     BBL_LB_CERT_CHAIN: ((hermione_lb.ca))
     BBL_LB_KEY: ((hermione_lb.private_key))
     BBL_STATE_DIR: environments/test/hermione/bbl-state
+    GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+    GIT_COMMIT_USERNAME: "ARD WG Bot"
     LB_DOMAIN: cf.hermione.env.wg-ard.ci.cloudfoundry.org
     TRUSTED_CA: ((relint_ca.certificate))
   ensure:
@@ -147,6 +153,8 @@ bbr-bbl-up-task: &bbr-bbl-up-task-config
     BBL_GCP_REGION: europe-west3
     BBL_LB_CERT: ../lb-certs/baba-yaga.crt
     BBL_LB_KEY: ../lb-certs/baba-yaga.key
+    GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+    GIT_COMMIT_USERNAME: "ARD WG Bot"
     LB_DOMAIN: cf.baba-yaga.env.wg-ard.ci.cloudfoundry.org
     BBL_ENV_NAME: baba-yaga-bbr
     BBL_CONFIG_DIR: .
@@ -168,6 +176,8 @@ lite-bbl-up-task: &lite-bbl-up-task-config
     BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/snitch/snitch-lite.key.json
     BBL_IAAS: gcp
     BBL_STATE_DIR: environments/test/snitch/bbl-state
+    GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+    GIT_COMMIT_USERNAME: "ARD WG Bot"
     SKIP_LB_CREATION: true
   ensure:
     put: relint-envs
@@ -189,6 +199,8 @@ windows-bbl-up-task: &windows-bbl-up-task-config
     BBL_LB_CERT: ../cert.pem
     BBL_LB_KEY: ../key.pem
     BBL_STATE_DIR: environments/test/cedric/bbl-state
+    GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+    GIT_COMMIT_USERNAME: "ARD WG Bot"
     LB_DOMAIN: cf.cedric.env.wg-ard.ci.cloudfoundry.org
   ensure:
     put: relint-envs
@@ -210,6 +222,8 @@ stable-bbl-up-task: &stable-bbl-up-task-config
     BBL_LB_CERT: ../lb-certs/cert.pem
     BBL_LB_KEY: ../lb-certs/key.pem
     BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+    GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+    GIT_COMMIT_USERNAME: "ARD WG Bot"
     LB_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org
   ensure:
     put: relint-envs
@@ -231,6 +245,8 @@ cats-bbl-up-task: &cats-bbl-up-task-config
     BBL_LB_CERT: ../lb-certs/cats.crt
     BBL_LB_KEY: ../lb-certs/cats.key
     BBL_STATE_DIR: environments/test/cats/bbl-state
+    GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+    GIT_COMMIT_USERNAME: "ARD WG Bot"
     LB_DOMAIN: cf.cats.env.wg-ard.ci.cloudfoundry.org
   ensure:
     put: relint-envs
@@ -637,6 +653,8 @@ jobs:
       BBL_GCP_REGION: europe-west3
       BBL_LB_CERT: ../certs/maxime.crt
       BBL_LB_KEY: ../certs/maxime.key
+      GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+      GIT_COMMIT_USERNAME: "ARD WG Bot"
       LB_DOMAIN: cf.maxime.env.wg-ard.ci.cloudfoundry.org
     ensure:
       put: relint-envs
@@ -867,6 +885,8 @@ jobs:
     params:
       BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/luna/luna-fresh.key.json
       BBL_STATE_DIR: environments/test/luna/bbl-state
+      GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+      GIT_COMMIT_USERNAME: "ARD WG Bot"
     ensure:
       put: relint-envs
       params:
@@ -895,6 +915,8 @@ jobs:
     params:
       BBL_STATE_DIR: environments/test/trelawney/bbl-state
       BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/trelawney/trelawney.key.json
+      GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+      GIT_COMMIT_USERNAME: "ARD WG Bot"
     ensure:
       put: relint-envs
       params:
@@ -922,6 +944,8 @@ jobs:
       BBL_STATE_DIR: environments/test/hermione/bbl-state
       BBL_AWS_ACCESS_KEY_ID: ((hermione_aws_access_key_id))
       BBL_AWS_SECRET_ACCESS_KEY: ((hermione_aws_secret_access_key))
+      GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+      GIT_COMMIT_USERNAME: "ARD WG Bot"
     input_mapping:
       bbl-state: relint-envs
     ensure:
@@ -952,6 +976,8 @@ jobs:
     params:
       BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/bbr/baba-yaga.key.json
       BBL_STATE_DIR: environments/test/bbr/bbl-state
+      GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+      GIT_COMMIT_USERNAME: "ARD WG Bot"
     ensure:
       put: relint-envs
       params:
@@ -982,6 +1008,8 @@ jobs:
     params:
       BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/snitch/snitch-lite.key.json
       BBL_STATE_DIR: environments/test/snitch/bbl-state
+      GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+      GIT_COMMIT_USERNAME: "ARD WG Bot"
     ensure:
       put: relint-envs
       params:
@@ -1010,6 +1038,8 @@ jobs:
     params:
       BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/cats/ard-cats.key.json
       BBL_STATE_DIR: environments/test/cats/bbl-state
+      GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+      GIT_COMMIT_USERNAME: "ARD WG Bot"
     ensure:
       put: relint-envs
       params:
@@ -1038,6 +1068,8 @@ jobs:
     params:
       BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/bellatrix/bellatrix.key.json
       BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+      GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+      GIT_COMMIT_USERNAME: "ARD WG Bot"
     ensure:
       put: relint-envs
       params:
@@ -1068,6 +1100,8 @@ jobs:
         params:
           BBL_GCP_SERVICE_ACCOUNT_KEY: environments/dev/maxime/maxime.key.json
           BBL_STATE_DIR: environments/dev/maxime/bbl-state
+          GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+          GIT_COMMIT_USERNAME: "ARD WG Bot"
         ensure:
           put: relint-envs
           params:
@@ -1096,6 +1130,8 @@ jobs:
     params:
       BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/cedric/cedric.key.json
       BBL_STATE_DIR: environments/test/cedric/bbl-state
+      GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+      GIT_COMMIT_USERNAME: "ARD WG Bot"
     ensure:
       put: relint-envs
       params:

--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -15221,6 +15221,8 @@ jobs:
       BBL_GCP_SERVICE_ACCOUNT_KEY: ((greengrass_gcp_service_account_json))
       BBL_GCP_REGION: europe-west3
       BBL_ENV_NAME: greengrass-compile
+      GIT_COMMIT_EMAIL: app-deployments@cloudfoundry.org
+      GIT_COMMIT_USERNAME: ARD WG Bot
       SKIP_LB_CREATION: true
     input_mapping:
       bbl-state: relint-envs
@@ -15259,6 +15261,8 @@ jobs:
     params:
       BBL_STATE_DIR: environments/test/greengrass/bbl-state
       BBL_GCP_SERVICE_ACCOUNT_KEY: ((greengrass_gcp_service_account_json))
+      GIT_COMMIT_EMAIL: app-deployments@cloudfoundry.org
+      GIT_COMMIT_USERNAME: ARD WG Bot
     ensure:
       put: relint-envs
       params:

--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -153,7 +153,7 @@ resources:
   icon: github
   source:
     uri: git@github.com:cloudfoundry/cf-deployment.git
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 - name: cf-deployment-develop
   type: git
   icon: github
@@ -1203,7 +1203,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-bosh-dns-aliases-release-candidate
             release: bosh-dns-aliases-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: bosh-dns-aliases
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -1487,7 +1487,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-bpm-release-candidate
             release: bpm-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: bpm
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -1771,7 +1771,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-capi-release-candidate
             release: capi-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: capi
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -2055,7 +2055,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-cf-networking-release-candidate
             release: cf-networking-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: cf-networking
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -2339,7 +2339,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-cf-smoke-tests-release-candidate
             release: cf-smoke-tests-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: cf-smoke-tests
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -2623,7 +2623,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-cflinuxfs3-release-candidate
             release: cflinuxfs3-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: cflinuxfs3
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -2907,7 +2907,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-diego-release-candidate
             release: diego-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: diego
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -3191,7 +3191,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-garden-runc-release-candidate
             release: garden-runc-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: garden-runc
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -3475,7 +3475,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-log-cache-release-candidate
             release: log-cache-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: log-cache
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -3759,7 +3759,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-loggregator-release-candidate
             release: loggregator-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: loggregator
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -4043,7 +4043,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-loggregator-agent-release-candidate
             release: loggregator-agent-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: loggregator-agent
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -4327,7 +4327,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-nats-release-candidate
             release: nats-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: nats
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -4611,7 +4611,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-pxc-release-candidate
             release: pxc-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: pxc
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -4895,7 +4895,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-routing-release-candidate
             release: routing-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: routing
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -5179,7 +5179,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-silk-release-candidate
             release: silk-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: silk
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -5463,7 +5463,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-statsd-injector-release-candidate
             release: statsd-injector-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: statsd-injector
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -5747,7 +5747,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-uaa-release-candidate
             release: uaa-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: uaa
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -6031,7 +6031,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-credhub-release-candidate
             release: credhub-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: credhub
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -6315,7 +6315,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-cf-cli-release-candidate
             release: cf-cli-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: cf-cli
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -6599,7 +6599,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-metrics-discovery-release-candidate
             release: metrics-discovery-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: metrics-discovery
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -6883,7 +6883,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-binary-buildpack-release-candidate
             release: binary-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: binary-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -7167,7 +7167,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-dotnet-core-buildpack-release-candidate
             release: dotnet-core-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: dotnet-core-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -7451,7 +7451,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-go-buildpack-release-candidate
             release: go-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: go-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -7735,7 +7735,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-java-buildpack-release-candidate
             release: java-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: java-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -8019,7 +8019,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-nginx-buildpack-release-candidate
             release: nginx-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: nginx-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -8303,7 +8303,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-nodejs-buildpack-release-candidate
             release: nodejs-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: nodejs-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -8587,7 +8587,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-php-buildpack-release-candidate
             release: php-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: php-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -8871,7 +8871,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-python-buildpack-release-candidate
             release: python-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: python-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -9155,7 +9155,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-r-buildpack-release-candidate
             release: r-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: r-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -9439,7 +9439,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-ruby-buildpack-release-candidate
             release: ruby-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: ruby-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -9723,7 +9723,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-staticfile-buildpack-release-candidate
             release: staticfile-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: staticfile-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -9959,7 +9959,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-backup-and-restore-sdk-release-candidate
             release: backup-and-restore-sdk-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: backup-and-restore-sdk
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -10195,7 +10195,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-cf-app-sd-release-candidate
             release: cf-app-sd-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: cf-app-sd
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -10417,7 +10417,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-haproxy-release-candidate
             release: haproxy-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: haproxy
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -10653,7 +10653,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-mapfs-release-candidate
             release: mapfs-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: mapfs
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -10889,7 +10889,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-nfs-volume-release-candidate
             release: nfs-volume-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: nfs-volume
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -11125,7 +11125,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-smb-volume-release-candidate
             release: smb-volume-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: smb-volume
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -11361,7 +11361,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-postgres-release-candidate
             release: postgres-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: postgres
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -11598,7 +11598,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-syslog-release-candidate
             release: syslog-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: syslog
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -11835,7 +11835,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-windows-syslog-release-candidate
             release: windows-syslog-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: windows-syslog
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -12073,7 +12073,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-hwc-buildpack-release-candidate
             release: hwc-buildpack-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: hwc-buildpack
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -12311,7 +12311,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-windows-utilities-release-candidate
             release: windows-utilities-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: windows-utilities
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -12547,7 +12547,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-garden-windows-release-candidate
             release: garden-windows-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: garden-windows
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -12785,7 +12785,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-winc-release-candidate
             release: winc-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: winc
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -13022,7 +13022,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-windowsfs-release-candidate
             release: windowsfs-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: windowsfs
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -13258,7 +13258,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-node-exporter-release-candidate
             release: node-exporter-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: node-exporter
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -13494,7 +13494,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-system-metrics-release-candidate
             release: system-metrics-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: system-metrics
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -13730,7 +13730,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-system-metrics-scraper-release-candidate
             release: system-metrics-scraper-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: system-metrics-scraper
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -13966,7 +13966,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-metric-store-release-candidate
             release: metric-store-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: metric-store
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -14204,7 +14204,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-envoy-nginx-release-candidate
             release: envoy-nginx-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: envoy-nginx
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -14440,7 +14440,7 @@ jobs:
             updated-cf-deployment: updated-cf-deployment-cflinuxfs4-release-candidate
             release: cflinuxfs4-release
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: cflinuxfs4
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -15203,7 +15203,7 @@ jobs:
       BRANCH_REGEXP: update-.*-release-.*
       MONTHS: 1
       DELETE_STALE_BRANCHES: true
-      DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+      DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
 - name: setup-infrastructure-compilation
   serial: true
   public: true

--- a/ci/template/update-releases.yml
+++ b/ci/template/update-releases.yml
@@ -1063,6 +1063,8 @@ jobs:
       BBL_GCP_SERVICE_ACCOUNT_KEY: ((greengrass_gcp_service_account_json))
       BBL_GCP_REGION: europe-west3
       BBL_ENV_NAME: greengrass-compile
+      GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+      GIT_COMMIT_USERNAME: "ARD WG Bot"
       SKIP_LB_CREATION: true
     input_mapping:
       bbl-state: relint-envs
@@ -1102,6 +1104,8 @@ jobs:
     params:
       BBL_STATE_DIR: environments/test/greengrass/bbl-state
       BBL_GCP_SERVICE_ACCOUNT_KEY: ((greengrass_gcp_service_account_json))
+      GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+      GIT_COMMIT_USERNAME: "ARD WG Bot"
     ensure:
       put: relint-envs
       params:


### PR DESCRIPTION
### WHAT is this change about?

Configure ARD WG GitBot for all bbl-up and bbl-destroy tasks. Default is:
```
  GIT_COMMIT_EMAIL: "cf-release-integration@pivotal.io"
  GIT_COMMIT_USERNAME: "CI Bot"
```
https://github.com/cloudfoundry/cf-deployment-concourse-tasks/blob/e53dae9558f879e992999b6241b70c2f2a154037/bbl-up/task.yml#L126

Also replace (already deleted) "cf_deployment_readwrite_deploy_key" with "ard_wg_gitbot_ssh_key".