### PR TITLE
Feat: Send logs and metrics to Log Cache using mTLS

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -86,7 +86,6 @@ addons:
         cert: "((syslog_agent_metrics_tls.certificate))"
         key: "((syslog_agent_metrics_tls.private_key))"
         server_name: syslog_agent_metrics
-      drain_ca_cert: "((log_cache_syslog_tls.ca))"
 
 - name: prom_scraper
   include:
@@ -1378,7 +1377,7 @@ instance_groups:
         server_name: loggr_syslog_binding_cache_metrics
       aggregate_drains:
       - url: "syslog-tls://log-cache.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true"
-        ca: "((syslog_agent_log_cache_tls.ca))"
+        ca: "((log_cache_syslog_tls.ca))"
         cert: "((syslog_agent_log_cache_tls.certificate))"
         key: "((syslog_agent_log_cache_tls.private_key))"
   - name: loggr-udp-forwarder

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2281,7 +2281,7 @@ variables:
     alternative_names:
     - "syslog_agent"
     extended_key_usage:
-      - client_auth
+    - client_auth
 - name: log_cache_syslog_tls
   type: certificate
   update_mode: converge
@@ -2289,9 +2289,9 @@ variables:
     ca: loggregator_ca
     common_name: log-cache.service.cf.internal
     alternative_names:
-      - "log-cache.service.cf.internal"
+    - "log-cache.service.cf.internal"
     extended_key_usage:
-      - server_auth
+    - server_auth
 - name: router_ca
   type: certificate
   options:
@@ -2319,7 +2319,7 @@ variables:
     alternative_names:
     - routing-api.service.cf.internal
     extended_key_usage:
-      - server_auth
+    - server_auth
 - name: routing_api_tls_client
   type: certificate
   update_mode: converge
@@ -2329,7 +2329,7 @@ variables:
     alternative_names:
     - routing-api-client
     extended_key_usage:
-      - client_auth
+    - client_auth
 - name: uaa_ca
   type: certificate
   options:
@@ -2396,7 +2396,7 @@ variables:
     ca: service_cf_internal_ca
     common_name: policy_server_asg_syncer_cc_client
     alternative_names:
-      - policy_server_asg_syncer_cc_client
+    - policy_server_asg_syncer_cc_client
     extended_key_usage:
     - client_auth
 - name: cc_bridge_cc_uploader_server
@@ -2548,7 +2548,7 @@ variables:
     alternative_names:
     - metrics_agent
     extended_key_usage:
-      - server_auth
+    - server_auth
 - name: metrics_discovery_metrics_tls
   type: certificate
   update_mode: converge
@@ -2558,7 +2558,7 @@ variables:
     alternative_names:
     - metrics_discovery_metrics
     extended_key_usage:
-      - server_auth
+    - server_auth
 - name: scrape_config_generator_metrics_tls
   type: certificate
   update_mode: converge
@@ -2568,7 +2568,7 @@ variables:
     alternative_names:
     - scrape_config_generator_metrics
     extended_key_usage:
-      - server_auth
+    - server_auth
 
 - name: log_cache_metrics_tls
   type: certificate

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1376,7 +1376,11 @@ instance_groups:
         cert: "((loggr_syslog_binding_cache_metrics_tls.certificate))"
         key: "((loggr_syslog_binding_cache_metrics_tls.private_key))"
         server_name: loggr_syslog_binding_cache_metrics
-      aggregate_drains: "syslog-tls://log-cache.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true"
+      aggregate_drains:
+      - url: "syslog-tls://log-cache.service.cf.internal:6067?include-metrics-deprecated=true&ssl-strict-internal=true"
+        ca: "((syslog_agent_log_cache_tls.ca))"
+        cert: "((syslog_agent_log_cache_tls.certificate))"
+        key: "((syslog_agent_log_cache_tls.private_key))"
   - name: loggr-udp-forwarder
     release: loggregator-agent
     properties: *loggr-udp-forwarder-properties
@@ -1497,6 +1501,7 @@ instance_groups:
   - name: log-cache-syslog-server
     release: log-cache
     properties:
+      syslog_client_ca_cert: "((syslog_agent_log_cache_tls.ca))"
       tls:
         cert: "((log_cache_syslog_tls.certificate))"
         key: "((log_cache_syslog_tls.private_key))"
@@ -2268,6 +2273,16 @@ variables:
     common_name: localhost
     alternative_names:
     - localhost
+- name: syslog_agent_log_cache_tls
+  type: certificate
+  update_mode: converge
+  options:
+    ca: loggregator_ca
+    common_name: syslog_agent
+    alternative_names:
+    - "syslog_agent"
+    extended_key_usage:
+      - client_auth
 - name: log_cache_syslog_tls
   type: certificate
   update_mode: converge


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

Aggregate drains now uses mututal tls for log-cache connections

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

It makes log-cache more secure

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Log cache continues to work

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**