### PR TITLE
clean leftovers from PR#1066

### DIFF
--- a/ci/pipelines/jammy-stemcell.yml
+++ b/ci/pipelines/jammy-stemcell.yml
@@ -236,7 +236,7 @@ resources:
   name: cf-deployment
   source:
     branch: release-candidate
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
     uri: git@github.com:cloudfoundry/cf-deployment.git
   type: git
 

--- a/ci/template/update-releases.yml
+++ b/ci/template/update-releases.yml
@@ -109,7 +109,7 @@ resources:
   icon: github
   source:
     uri: git@github.com:cloudfoundry/cf-deployment.git
-    private_key: ((cf_deployment_readwrite_deploy_key.private_key))
+    private_key: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: cf-deployment-develop
   type: git
@@ -445,7 +445,7 @@ jobs:
             updated-cf-deployment: #@ "updated-cf-deployment-{}-release-candidate".format(r.name)
             release: #@ r.name + "-release"
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: #@ r.name
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -615,7 +615,7 @@ jobs:
             updated-cf-deployment: #@ "updated-cf-deployment-{}-release-candidate".format(r.name)
             release: #@ r.name + "-release"
           params:
-            DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
             RELEASE_NAME: #@ r.name
         - task: retrieve-bosh-logs
           file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
@@ -1044,7 +1044,7 @@ jobs:
       BRANCH_REGEXP: "update-.*-release-.*"
       MONTHS: 1
       DELETE_STALE_BRANCHES: true
-      DEPLOY_KEY: ((cf_deployment_readwrite_deploy_key.private_key))
+      DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
 
 - name: setup-infrastructure-compilation
   serial: true


### PR DESCRIPTION
### WHAT is this change about?

#1066 which also replaces  "cf_deployment_readwrite_deploy_key" with "ard_wg_gitbot_ssh_key". For these two files it was missing. This PR aims to to clean the leftovers from  #1066
