### PR TITLE
Change region for experimental hermione

### DIFF
--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -122,7 +122,7 @@ experimental-bbl-up-task: &experimental-bbl-up-task-config
     bbl-state: relint-envs
   params:
     BBL_AWS_ACCESS_KEY_ID: ((hermione_aws_access_key_id))
-    BBL_AWS_REGION: eu-central-1
+    BBL_AWS_REGION: eu-west-3
     BBL_AWS_SECRET_ACCESS_KEY: ((hermione_aws_secret_access_key))
     BBL_CONFIG_DIR: environments/test/hermione/bbl-config
     BBL_ENV_NAME: hermione-experimental


### PR DESCRIPTION


### WHAT is this change about?
Change region for experimental hermione...

### Please provide any contextual information.

The ☁️ is full  . Setting it to eu-west-3.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO


### How should this change be described in cf-deployment release notes?
N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?
N/A
- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?
experimental-deploy stays green.

> _Please specify either bosh cli or cf cli commands for our team (and cf operators) to verify the changes._

> _Few examples_
> 1. For a PR with a new job in the manifest, `bosh instances` can verify the job is running after upgrade. You can provide additional commands to verify the job is running as specified.
> 2. For a PR with new variables, `bosh variables | grep <var-name>` command can verify the variable exists. This is the simplest varification but you can also provide additional commands to test that the variable holds the desired value.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

