### PR TITLE
Remove experimental CATS cflinuxfs4 Job

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -22,7 +22,6 @@ groups:
   - experimental-deploy
   - experimental-smoke-tests
   - experimental-cats
-  - experimental-cats-cflinuxfs4
   - experimental-delete-deployment
   - lite-acquire-pool
   - lite-deploy
@@ -76,7 +75,6 @@ groups:
   - lint-cf-deployment-manifest
   - experimental-acquire-pool
   - experimental-cats
-  - experimental-cats-cflinuxfs4
   - experimental-deploy
   - experimental-delete-deployment
   - experimental-release-pool-manual
@@ -1026,7 +1024,7 @@ jobs:
       params: {release: experimental-pool}
 
 - name: experimental-deploy
-  serial_groups: [ experimental-cats, experimental-cats-cflinuxfs4, experimental-smokes ]
+  serial_groups: [ experimental-cats, experimental-smokes ]
   public: true
   plan:
   - get: experimental-pool
@@ -1249,39 +1247,6 @@ jobs:
         CONFIG_FILE_PATH: environments/test/hermione/integration_config.json
         REPORTER_CONFIG_FILE_PATH: environments/test/hermione/reporter_config.json
         RELINT_VERBOSE_AUTH: "true"
-
-- name: experimental-cats-cflinuxfs4
-  serial_groups: [ experimental-cats-cflinuxfs4 ]
-  public: true
-  plan:
-    - timeout: 4h
-      do:
-        - get: experimental-pool
-          trigger: true
-          passed: [ experimental-deploy ]
-        - in_parallel:
-            - get: cf-acceptance-tests-rc
-            - get: relint-envs
-            - get: cf-deployment-develop
-              passed: [ experimental-deploy ]
-            - get: cf-deployment-concourse-tasks
-        - task: update-integration-configs
-          file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
-          params:
-            BBL_STATE_DIR: environments/test/hermione/bbl-state
-            CATS_INTEGRATION_CONFIG_FILE: environments/test/hermione/cflinuxfs4_integration_config.json
-          input_mapping:
-            bbl-state: relint-envs
-            integration-configs: relint-envs
-        - task: run-cats
-          input_mapping:
-            integration-config: updated-integration-configs
-            cf-acceptance-tests: cf-acceptance-tests-rc
-          file: cf-deployment-concourse-tasks/run-cats/task.yml
-          params:
-            CONFIG_FILE_PATH: environments/test/hermione/cflinuxfs4_integration_config.json
-            REPORTER_CONFIG_FILE_PATH: environments/test/hermione/reporter_config.json
-            RELINT_VERBOSE_AUTH: "true"
 
 - name: experimental-delete-deployment
   serial: true


### PR DESCRIPTION

### WHAT is this change about?
Remove experimental CATS cflinuxfs4 Job. All the logic related cflinuxfsf4 are inlined into cf-deplyment and now it is the default stack.

### Please provide any contextual information.
[#1047](https://github.com/cloudfoundry/cf-deployment/issues/1047)
### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?
N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?
cf-deployment pipline stays green.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!