### PR TITLE
Remove experimental-cats-cflinuxfs4 job

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -22,7 +22,6 @@ groups:
   - experimental-deploy
   - experimental-smoke-tests
   - experimental-cats
-  - experimental-cats-cflinuxfs4
   - experimental-delete-deployment
   - lite-acquire-pool
   - lite-deploy
@@ -76,7 +75,6 @@ groups:
   - lint-cf-deployment-manifest
   - experimental-acquire-pool
   - experimental-cats
-  - experimental-cats-cflinuxfs4
   - experimental-deploy
   - experimental-delete-deployment
   - experimental-release-pool-manual
@@ -1026,7 +1024,7 @@ jobs:
       params: {release: experimental-pool}
 
 - name: experimental-deploy
-  serial_groups: [ experimental-cats, experimental-cats-cflinuxfs4, experimental-smokes ]
+  serial_groups: [ experimental-cats, experimental-smokes ]
   public: true
   plan:
   - get: experimental-pool
@@ -1129,7 +1127,6 @@ jobs:
         operations/scale-database-cluster.yml
         operations/stop-skipping-tls-validation.yml
         operations/use-operator-provided-router-tls-certificates.yml
-        operations/experimental/add-cflinuxfs4.yml
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
         operations/experimental/enable-oci-phase-1.yml
         operations/experimental/enable-containerd-for-processes.yml
@@ -1249,39 +1246,6 @@ jobs:
         CONFIG_FILE_PATH: environments/test/hermione/integration_config.json
         REPORTER_CONFIG_FILE_PATH: environments/test/hermione/reporter_config.json
         RELINT_VERBOSE_AUTH: "true"
-
-- name: experimental-cats-cflinuxfs4
-  serial_groups: [ experimental-cats-cflinuxfs4 ]
-  public: true
-  plan:
-    - timeout: 4h
-      do:
-        - get: experimental-pool
-          trigger: true
-          passed: [ experimental-deploy ]
-        - in_parallel:
-            - get: cf-acceptance-tests-rc
-            - get: relint-envs
-            - get: cf-deployment-develop
-              passed: [ experimental-deploy ]
-            - get: cf-deployment-concourse-tasks
-        - task: update-integration-configs
-          file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
-          params:
-            BBL_STATE_DIR: environments/test/hermione/bbl-state
-            CATS_INTEGRATION_CONFIG_FILE: environments/test/hermione/cflinuxfs4_integration_config.json
-          input_mapping:
-            bbl-state: relint-envs
-            integration-configs: relint-envs
-        - task: run-cats
-          input_mapping:
-            integration-config: updated-integration-configs
-            cf-acceptance-tests: cf-acceptance-tests-rc
-          file: cf-deployment-concourse-tasks/run-cats/task.yml
-          params:
-            CONFIG_FILE_PATH: environments/test/hermione/cflinuxfs4_integration_config.json
-            REPORTER_CONFIG_FILE_PATH: environments/test/hermione/reporter_config.json
-            RELINT_VERBOSE_AUTH: "true"
 
 - name: experimental-delete-deployment
   serial: true


### PR DESCRIPTION
### WHAT is this change about?

Remove "experimental-cats-cflinuxfs4" job from "cf-deployment" pipeline. "cflinuxfs4" is now the default and a separate run of CATs is not necessary anymore.

(already done in https://github.com/cloudfoundry/cf-deployment/pull/1074, this PR just removes the obsolete "add-cflinuxfs4.yml" ops file)

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Rollout of cflinuxfs4, step 1: https://github.com/cloudfoundry/cf-deployment/issues/1047

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/989

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Not relevant for release notes.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Job "experimental-cats-cflinuxfs4" is removed from https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

