### PR TITLE
Set cflinuxfs3 as default for Bionic validation pipeline

### DIFF
--- a/ci/pipelines/bionic-stemcell.yml
+++ b/ci/pipelines/bionic-stemcell.yml
@@ -84,6 +84,7 @@ jobs:
       BBL_STATE_DIR: environments/test/bellatrix/bbl-state
       OPS_FILES: |
         operations/use-bionic-stemcell.yml
+        operations/set-cflinuxfs3-default-stack.yml
         operations/use-internal-lookup-for-route-services.yml
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
       SYSTEM_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org


### PR DESCRIPTION
### WHAT is this change about?

Set "cflinuxfs3" as the default stack for the Bionic validation pipeline:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/bionic-stemcell-validation

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Validate new ops file `operations/set-cflinuxfs3-default-stack.yml`.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/1047

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Not relevant for release.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/bionic-stemcell-validation/jobs/deploy-cf passes and deploys CF with "cflinuxfs3" as default stack.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
