### PR TITLE
CI: Fix baba-yaga-bbr env

### DIFF
--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -434,7 +434,7 @@ jobs:
     output_mapping:
       pool-resource: bbr-pool
   - put: bbr-pool
-    params: {add_claimed: bbr-pool}
+    params: {acquire: true}
 
 - name: add-claimed-lock-lite
   serial: true
@@ -1202,7 +1202,7 @@ jobs:
     output_mapping:
       pool-resource: bbr-pool
   - put: bbr-pool
-    params: {remove: bbr-pool}
+    params: {release: bbr-pool}
 
 - name: remove-claimed-lock-lite
   serial: true

--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -145,7 +145,7 @@ bbr-bbl-up-task: &bbr-bbl-up-task-config
   file: cf-deployment-concourse-tasks/bbl-up/task.yml
   input_mapping:
     bbl-state: relint-envs
-    bbl-config: combined-inputs
+    bbl-config: relint-envs
   params:
     BBL_STATE_DIR: environments/test/bbr/bbl-state
     BBL_IAAS: gcp
@@ -157,7 +157,7 @@ bbr-bbl-up-task: &bbr-bbl-up-task-config
     GIT_COMMIT_USERNAME: "ARD WG Bot"
     LB_DOMAIN: cf.baba-yaga.env.wg-ard.ci.cloudfoundry.org
     BBL_ENV_NAME: baba-yaga-bbr
-    BBL_CONFIG_DIR: .
+    BBL_CONFIG_DIR: environments/test/bbr/bbl-config
   ensure:
     put: relint-envs
     params:
@@ -549,16 +549,6 @@ jobs:
   - in_parallel:
     - get: cf-deployment-concourse-tasks
     - get: relint-envs
-    - get: bosh-bootloader
-    - get: runtime-ci
-  - task: combine-bbl-configs
-    file: runtime-ci/tasks/combine-inputs/task.yml
-    input_mapping:
-      first-input: bosh-bootloader
-      second-input: relint-envs
-    params:
-      FIRST_DIR: plan-patches/network-lb-gcp
-      SECOND_DIR: environments/test/bbr/bbl-config
   - task: setup-infrastructure
     <<: *bbr-bbl-up-task-config
   - put: bbr-pool
@@ -744,18 +734,8 @@ jobs:
         params: {acquire: true}
       - get: relint-envs
       - get: cf-deployment-concourse-tasks
-      - get: bosh-bootloader
       - get: every-tuesday-morning
         trigger: true
-      - get: runtime-ci
-    - task: combine-bbl-configs
-      file: runtime-ci/tasks/combine-inputs/task.yml
-      input_mapping:
-        first-input: bosh-bootloader
-        second-input: relint-envs
-      params:
-        FIRST_DIR: plan-patches/network-lb-gcp
-        SECOND_DIR: environments/test/bbr/bbl-config
     - task: update-infrastructure
       <<: *bbr-bbl-up-task-config
     - put: bbr-pool

--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -158,6 +158,7 @@ bbr-bbl-up-task: &bbr-bbl-up-task-config
     LB_DOMAIN: cf.baba-yaga.env.wg-ard.ci.cloudfoundry.org
     BBL_ENV_NAME: baba-yaga-bbr
     BBL_CONFIG_DIR: environments/test/bbr/bbl-config
+    DELETE_TERRAFORM_PLUGINS: false
   ensure:
     put: relint-envs
     params:


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

Yes

### WHAT is this change about?

Updates the BBR group of the infrastructure pipeline:
* Removes the network-lb-gcp plan patch from baba-yaga-bbr.
* Updates the params passed to bbr-pool when acquiring the lock for setting up the env.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

N/A

### Please provide any contextual information.

* https://cloudfoundry.slack.com/archives/C033ALST37V/p1683068678454979?thread_ts=1682676648.184329&cid=C033ALST37V
* https://github.com/cloudfoundry/relint-envs/issues/13

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

BBR fanout in cf-deployment pipeline succeeds.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None