### PR TITLE
Fix CATs bbl env

### DIFF
--- a/ci/pipelines/infrastructure.yml
+++ b/ci/pipelines/infrastructure.yml
@@ -235,9 +235,8 @@ cats-bbl-up-task: &cats-bbl-up-task-config
   file: cf-deployment-concourse-tasks/bbl-up/task.yml
   input_mapping:
     bbl-state: relint-envs
-    bbl-config: bosh-bootloader
+    bbl-config: relint-envs
   params:
-    BBL_CONFIG_DIR: plan-patches/network-lb-gcp
     BBL_ENV_NAME: cats
     BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/cats/ard-cats.key.json
     BBL_GCP_REGION: europe-west3
@@ -626,7 +625,6 @@ jobs:
   - in_parallel:
     - get: cf-deployment-concourse-tasks
     - get: relint-envs
-    - get: bosh-bootloader
   - task: setup-infrastructure
     <<: *cats-bbl-up-task-config
   - put: cats-pool
@@ -806,7 +804,6 @@ jobs:
         params: {acquire: true}
       - get: relint-envs
       - get: cf-deployment-concourse-tasks
-      - get: bosh-bootloader
       - get: every-tuesday-morning
         trigger: true
     - task: update-infrastructure


### PR DESCRIPTION
* remove https://github.com/cloudfoundry/bosh-bootloader/tree/main/plan-patches/network-lb-gcp (seems to be broken after Terraform v1.4.6 upgrade)

### WHAT is this change about?

Fix CATs bbl env.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Fixes CATs validation/release pipeline.

### Please provide any contextual information.

https://github.com/cloudfoundry/relint-envs/issues/13

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

(not relevant, CI pipeline fix)

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Pipeline https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cats is running again.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

