### PR TITLE
CI: Recreate snitch on success

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1410,34 +1410,34 @@ jobs:
         bbl-state: relint-envs
       params:
         BBL_STATE_DIR: environments/test/snitch/bbl-state
-    # - task: combine-bbl-configs
-    #   file: runtime-ci/tasks/combine-inputs/task.yml
-    #   input_mapping:
-    #     first-input: bosh-bootloader
-    #     second-input: relint-envs
-    #   params:
-    #     FIRST_DIR: plan-patches/bosh-lite-gcp
-    #     SECOND_DIR: environments/test/snitch/bbl-config
-    # - task: update-infrastructure
-    #   file: cf-deployment-concourse-tasks/bbl-up/task.yml
-    #   params:
-    #     BBL_CONFIG_DIR: .
-    #     BBL_ENV_NAME: snitch-lite
-    #     BBL_GCP_REGION: europe-west3
-    #     BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/snitch/snitch-lite.key.json
-    #     BBL_IAAS: gcp
-    #     BBL_STATE_DIR: environments/test/snitch/bbl-state
-    #     GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
-    #     GIT_COMMIT_USERNAME: "ARD WG Bot"
-    #     SKIP_LB_CREATION: true
-    #   input_mapping:
-    #     bbl-state: relint-envs
-    #     bbl-config: combined-inputs
-    #   ensure:
-    #     put: relint-envs
-    #     params:
-    #       repository: updated-bbl-state
-    #       rebase: true
+    - task: combine-bbl-configs
+      file: runtime-ci/tasks/combine-inputs/task.yml
+      input_mapping:
+        first-input: bosh-bootloader
+        second-input: relint-envs
+      params:
+        FIRST_DIR: plan-patches/bosh-lite-gcp
+        SECOND_DIR: environments/test/snitch/bbl-config
+    - task: update-infrastructure
+      file: cf-deployment-concourse-tasks/bbl-up/task.yml
+      params:
+        BBL_CONFIG_DIR: .
+        BBL_ENV_NAME: snitch-lite
+        BBL_GCP_REGION: europe-west3
+        BBL_GCP_SERVICE_ACCOUNT_KEY: environments/test/snitch/snitch-lite.key.json
+        BBL_IAAS: gcp
+        BBL_STATE_DIR: environments/test/snitch/bbl-state
+        GIT_COMMIT_EMAIL: "app-deployments@cloudfoundry.org"
+        GIT_COMMIT_USERNAME: "ARD WG Bot"
+        SKIP_LB_CREATION: true
+      input_mapping:
+        bbl-state: relint-envs
+        bbl-config: combined-inputs
+      ensure:
+        put: relint-envs
+        params:
+          repository: updated-bbl-state
+          rebase: true
     - put: lite-pool
       params: {release: lite-pool}
 


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

Yes

### WHAT is this change about?

The cf-deployment pipeline runs `bbl-up` again after snitch passes all the other jobs. bosh-bootloader v9.0.1 was released which includes the changes we need to recreate snitch regularly.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

N/A

### Please provide any contextual information.

#1084

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The snitch fanout in the cf-deployment pipeline goes green.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None