### PR TITLE
Remove cflinuxfs3 from compiled releases ops file

### DIFF
--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -69,16 +69,6 @@
     url: https://storage.googleapis.com/cf-deployment-compiled-releases/cf-smoke-tests-42.0.71-ubuntu-jammy-1.80-20230519-205444-889931619.tgz
     version: 42.0.71
 - type: replace
-  path: /releases/name=cflinuxfs3?
-  value:
-    name: cflinuxfs3
-    sha1: f10bfaf815306be6cc08ce67a41526f2d79a925f
-    stemcell:
-      os: ubuntu-jammy
-      version: "1.80"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/cflinuxfs3-0.365.0-ubuntu-jammy-1.80-20230516-230833-387056487.tgz
-    version: 0.365.0
-- type: replace
   path: /releases/name=credhub
   value:
     name: credhub


### PR DESCRIPTION
### WHAT is this change about?

Remove cflinuxfs3 from compiled releases. Update job is currently failing: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/update-releases/jobs/update-cflinuxfs3/builds/18

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Part of cflinuxfs3 deprecation/removal story: https://github.com/cloudfoundry/cf-deployment/issues/1048

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/1048

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO (not relevant for CATs)

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [x] YES - please choose the category from below. Feel free to provide additional details.
- [ ] NO

### How should this change be described in cf-deployment release notes?

Not relevant.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Update job passes again: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/update-releases/jobs/update-cflinuxfs3

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

