### PR TITLE
Fix cflinuxfs4-compat-release for fresh-deploy

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -528,6 +528,7 @@ jobs:
         operations/rename-network-and-deployment.yml
         operations/set-bbs-active-key.yml
         operations/test/add-persistent-isolation-segment-diego-cell.yml
+        operations/test/use-cflinuxfs4-compat-isolation-segment-diego-cell.yml
         operations/test/add-persistent-isolation-segment-router.yml
         operations/rename-isolation-segment-network.yml
         operations/addons/enable-component-syslog.yml

--- a/operations/test/use-cflinuxfs4-compat-isolation-segment-diego-cell.yml
+++ b/operations/test/use-cflinuxfs4-compat-isolation-segment-diego-cell.yml
@@ -1,0 +1,11 @@
+- type: replace
+  path: /instance_groups/name=isolated-diego-cell/jobs/name=cflinuxfs4-rootfs-setup?
+  value:
+    name: cflinuxfs4-rootfs-setup
+    properties:
+      cflinuxfs4-rootfs:
+        trusted_certs:
+        - ((diego_instance_identity_ca.ca))
+        - ((credhub_tls.ca))
+        - ((uaa_ssl.ca))
+    release: cflinuxfs4-compat

--- a/units/tests/test_test/operations.yml
+++ b/units/tests/test_test/operations.yml
@@ -9,9 +9,10 @@ add-persistent-isolation-segment-diego-cell-bosh-lite.yml:
   ops:
   - add-persistent-isolation-segment-diego-cell.yml
   - add-persistent-isolation-segment-diego-cell-bosh-lite.yml
-add-persistent-isolation-segment-diego-cell.yml:
+add-persistent-isolation-segment-diego-cell.yml: {}
+use-cflinuxfs4-compat-isolation-segment-diego-cell.yml:
   ops:
-  - use-cflinuxfs4-compat-isolation-segment-diego-cell.yml
+  - add-persistent-isolation-segment-diego-cell.yml
 add-persistent-isolation-segment-router.yml: {}
 alter-ssh-proxy-redirect-uri.yml: {}
 enable-nfs-test-ldapserver.yml:

--- a/units/tests/test_test/operations.yml
+++ b/units/tests/test_test/operations.yml
@@ -9,7 +9,9 @@ add-persistent-isolation-segment-diego-cell-bosh-lite.yml:
   ops:
   - add-persistent-isolation-segment-diego-cell.yml
   - add-persistent-isolation-segment-diego-cell-bosh-lite.yml
-add-persistent-isolation-segment-diego-cell.yml: {}
+add-persistent-isolation-segment-diego-cell.yml:
+  ops:
+  - use-cflinuxfs4-compat-isolation-segment-diego-cell.yml
 add-persistent-isolation-segment-router.yml: {}
 alter-ssh-proxy-redirect-uri.yml: {}
 enable-nfs-test-ldapserver.yml:


### PR DESCRIPTION
### WHAT is this change about?

Fix "fresh-deploy" validation setup. The test ops file `add-persistent-isolation-segment-diego-cell.yml` uses the "cflinuxfs4" release, so we must overwrite that with another ops file.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

https://github.com/cloudfoundry/cflinuxfs4-compat-release/issues/1

### Please provide any contextual information.

https://github.com/cloudfoundry/cflinuxfs4-compat-release/issues/1

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Not relevant for release notes.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

CI job https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/fresh-deploy must pass.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

