### PR TITLE
feat: Populate CAPI info

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -892,8 +892,8 @@ instance_groups:
       cloud_controller: {as: cloud_controller, shared: true}
     properties:
       name: cf-deployment
-      build: v32.8.0
-      version: 32
+      build: v32.10.0 # AUTO-POPULATED; DO NOT EDIT
+      version: 32 # AUTO-POPULATED; DO NOT EDIT
       router:
         route_services_secret: "((router_route_services_secret))"
       system_domain: "((system_domain))"

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -891,6 +891,9 @@ instance_groups:
     provides:
       cloud_controller: {as: cloud_controller, shared: true}
     properties:
+      name: cf-deployment
+      build: v32.8.0
+      version: 32
       router:
         route_services_secret: "((router_route_services_secret))"
       system_domain: "((system_domain))"


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

When the CAPI info fields are not set, the info endpoints (i.e. `API_URL/v2/info`, `API_URL/v3/info`) return empty results akin to the following:

```
$ cf curl /v3/info
{
   "name": "",
   "build": "",
   "version": 0,
...
}
```

This sets those properties to appropriate values.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Persons interacting with a CF-D environment who cannot access its manifest are unable to determine the CF-D build and version info.

### Please provide any contextual information.

Closes #813 

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

On a CF-D environment with this change deployed, run `cf curl /v3/info` and `cf curl /v2/info` and validate that the returned response has values associated with `name`, `build`, and `version` that match up with the manifest inputs.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None