### PR TITLE
Add redis job to api vms

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -879,6 +879,8 @@ instance_groups:
   networks:
   - name: default
   jobs:
+  - name: redis
+    release: capi
   - name: cloud_controller_ng
     release: capi
     provides:


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

> Redis will be used for rate limiting and (at a later point in time) also for metrics. The `monit` process will only be started if either the Puma webserver is used or `cc.experimental.use_redis` is set to `true` (defaults to `false`). If Redis is used, the cloud controller config `redis.socket` is set; this switches the rate limit implementation from using in-memory counters to Redis.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

> This is a prerequisite to eventually make Puma the default webserver used by cloud controller. And with Puma the overall request throughput will increase.

### Please provide any contextual information.

> Related PR in capi-release: https://github.com/cloudfoundry/capi-release/pull/322

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

❗ I'm going for a NO, although a new job will be added to the api VMs. Unless explicitly configured, this job will not run (i.e. `monit` file is empty) and thus not consuming any resources.

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

> Probably not at all... It's experimental on its own (i.e. `cc.experimental.use_redis`) or changes another experimental feature (i.e. `cc.experimental.use_puma_webserver`). Furthermore it changes the implementation of the rate limiter without changing its behavior.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [n] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

> _Please specify either bosh cli or cf cli commands for our team (and cf operators) to verify the changes._

> _Few examples_
> 1. For a PR with a new job in the manifest, `bosh instances` can verify the job is running after upgrade. You can provide additional commands to verify the job is running as specified.
> 2. For a PR with new variables, `bosh variables | grep <var-name>` command can verify the variable exists. This is the simplest varification but you can also provide additional commands to test that the variable holds the desired value.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _@johha_

✅ This PR requires a new capi-release (>= CAPI 1.155.0) to be used in cf-deployment.
