### PR TITLE
Add extended-key-usage for the cc_logcache_tls

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2303,6 +2303,8 @@ variables:
     alternative_names:
     - "api.((system_domain))"
     - cloud-controller-ng.service.cf.internal
+    extended_key_usage:
+    - client_auth
 - name: logcache_ssl
   type: certificate
   update_mode: converge


### PR DESCRIPTION

## Please take a moment to review the questions before submitting the PR
### WHAT is this change about?

It is a fix for #1106 


### Please provide any contextual information.

In the current version of `cf-deployment` the `extended_key_usage` configuration is missing in the `cc_logcache_tls` certificate's options. Because of that, when the certificate is generated with BOSH interpolate, the `extended_key_usage` option was automatically added with `TLS Web Server Authentication` value only which is wrong in this case, as the certificate is used for client authentication. Therefore, it cannot be used for mutual TLS authentication between the cloud controller and log-cache. When one uses CredHub for managing the certificates, the `X509v3 Extended Key Usage` SSL extension is not configured at all an the certificate can be used without any problems.
This change defines the `extended_key_usage` option and adds `client_auth` value, so that the `X509v3 Extended Key Usage` SSL extension is properly configured. 

Please check the GitHub issue for more details.


### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO


### How should this change be described in cf-deployment release notes?

Fixed extended key usage for the `cc_logcache_tls` certificate which used for mutial TLS authentication between Cloud Controller and Log Cache.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

After deploying Cloud Foundry:

```
bosh ssh -d cf api/0

openssl x509 -in /var/vcap/jobs/cloud_controller_ng/config/certs/logcache_tls.crt -text | grep -A1 Extended
        X509v3 Extended Key Usage:
            TLS Web Client Authentication
```

The output of the above command should have the `TLS Web Client Authentication` string in it.


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@amhuber, @philippthun


Fixes #1106
