### PR TITLE
feat(operations/experimental): add new ops files for the OTel Collector

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -15,6 +15,8 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 |:---  |:---     |:---   |:---   |
 | [`add-cflinuxfs4.yml`](add-cflinuxfs4.yml) | Add [cflinuxfs4](https://github.com/cloudfoundry/cflinuxfs4) stack. | ***Deprecated as we integrate cflinuxfs4 directly into cf-deployment.yml*** | **NO** |
 | [`add-metric-store.yml`](add-metric-store.yml) | **PROMOTED: use `../use-metric-store.yml`** | | **NO** |
+| [`add-otel-collector.yml`](add-otel-collector.yml) | Adds an OTel Collector to all Linux VMs to egress metrics through the provided exporters. | `metric_exporters` must be filled in with valid OTel Collector Exporter configuration. | **NO** |
+| [`add-otel-collector-windows.yml`](add-otel-collector-windows.yml) | Adds an OTel Collector to all Windows 2019 VMs to egress metrics through the provided exporters. | `metric_exporters` must be filled in with valid OTel Collector Exporter configuration.. Requires `./add-otel-collector.yml` and `../windows2019-cell.yml`.  | **NO** |
 | [`add-system-metrics-agent.yml`](add-system-metrics-agent.yml) | **PROMOTED: use `../addons/add-system-metrics-agent.yml`** | | **NO** |
 | [`add-system-metrics-agent-windows2019.yml`](add-system-metrics-agent-windows2019.yml) | **PROMOTED: use `../addons/add-system-metrics-agent-windows2019.yml`** | | **NO** |
 | [`colocate-smoke-tests-on-cc-worker.yml`](colocate-smoke-tests-on-cc-worker.yml) | Colocate the smoke_tests job on the cc-worker instance | A number of other operations files reference this instance group and may be incompatible with this operations file.  Use `find ./operations/ -name "*.yml" | xargs grep "/instance_groups/name=smoke-tests"` to locate said files. | **YES** |

--- a/operations/experimental/add-otel-collector-windows.yml
+++ b/operations/experimental/add-otel-collector-windows.yml
@@ -1,0 +1,24 @@
+- type: replace
+  path: /addons?/name=otel-collector-windows2019
+  value:
+    name: otel-collector-windows2019
+    include:
+      stemcell:
+      - os: windows2019
+    jobs:
+    - name: otel-collector-windows
+      release: loggregator-agent
+      properties:
+        metric_exporters:
+          # Insert OTel Collector Exporter configuration
+          # See https://opentelemetry.io/docs/collector/configuration/#exporters
+          # For example:
+          #   otlp:
+          #     endpoint: otelcol2:4317
+        ingress:
+          grpc:
+            port: 4319
+            tls:
+              ca_cert: ((otel_collector_tls.ca))
+              cert: ((otel_collector_tls.certificate))
+              key: ((otel_collector_tls.private_key))

--- a/operations/experimental/add-otel-collector-windows.yml
+++ b/operations/experimental/add-otel-collector-windows.yml
@@ -17,7 +17,6 @@
           #     endpoint: otelcol2:4317
         ingress:
           grpc:
-            port: 4319
             tls:
               ca_cert: ((otel_collector_tls.ca))
               cert: ((otel_collector_tls.certificate))

--- a/operations/experimental/add-otel-collector.yml
+++ b/operations/experimental/add-otel-collector.yml
@@ -1,0 +1,42 @@
+- type: replace
+  path: /addons?/name=otel-collector
+  value:
+    name: otel-collector
+    include:
+      stemcell:
+      - os: ubuntu-jammy
+    exclude:
+      jobs:
+      - name: smoke_tests
+        release: cf-smoke-tests
+    jobs:
+    - name: otel-collector
+      release: loggregator-agent
+      properties:
+        metric_exporters:
+          # Insert OTel Collector Exporter configuration
+          # See https://opentelemetry.io/docs/collector/configuration/#exporters
+          # For example:
+          #   otlp:
+          #     endpoint: otelcol2:4317
+        ingress:
+          grpc:
+            port: 4319
+            tls:
+              ca_cert: ((otel_collector_tls.ca))
+              cert: ((otel_collector_tls.certificate))
+              key: ((otel_collector_tls.private_key))
+- type: replace
+  path: /variables/name=otel_collector_tls?
+  value:
+    name: otel_collector_tls
+    type: certificate
+    update_mode: converge
+    options:
+      alternative_names:
+      - otel-collector
+      ca: loggregator_ca
+      common_name: otel-collector
+      extended_key_usage:
+      - client_auth
+      - server_auth

--- a/operations/experimental/add-otel-collector.yml
+++ b/operations/experimental/add-otel-collector.yml
@@ -21,7 +21,6 @@
           #     endpoint: otelcol2:4317
         ingress:
           grpc:
-            port: 4319
             tls:
               ca_cert: ((otel_collector_tls.ca))
               cert: ((otel_collector_tls.certificate))

--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -1,6 +1,11 @@
 ---
 add-cflinuxfs4.yml: {}
 add-metric-store.yml: {}
+add-otel-collector-windows.yml:
+  ops:
+  - ../windows2019-cell.yml
+  - add-otel-collector.yml
+add-otel-collector.yml: {}
 add-system-metrics-agent-windows2019.yml:
   ops:
   - ../windows2019-cell.yml


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

Makes the `otel-collector` and `otel-collector-windows` jobs in `loggregator-agent` release available via experimental ops files.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana is unable to egress metrics without using the firehose.

### Please provide any contextual information.

RFC: https://github.com/cloudfoundry/community/pull/641

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

CF-D deployed with these ops files successfully egresses metrics through the provided metric exporters to metric destinations.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@rroberts2222 