### PR TITLE
ci(pull-requests): Don't require reviews to fail PRs made against main

### DIFF
--- a/ci/pipelines/pull-requests.yml
+++ b/ci/pipelines/pull-requests.yml
@@ -37,7 +37,6 @@ resources:
       access_token: ((ard_wg_gitbot_token))
       repository: cloudfoundry/cf-deployment
       base_branch: main
-      required_review_approvals: 1
   - name: cf-deployment-rc
     type: pull-request
     source:
@@ -65,7 +64,6 @@ resources:
       access_token: ((ard_wg_gitbot_token))
       repository: cloudfoundry/cf-acceptance-tests
       base_branch: main
-      required_review_approvals: 1
   - name: cats-develop
     type: pull-request
     source:


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

We currently only use these PR resources to error if the main branch is the base branch of the PR. Since presence of a PR to main is all that we care about, and the contents of the PR are never examined, let alone run, we should be able to disregard the requirements for reviews in this case.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

The two CI jobs using these resources exist for the sole purpose of alerting PR creators and approvers that a PR has been incorrectly made against main instead of develop. Currently, a PR approval is required to trigger the two jobs, which means that it's initially on approvers to catch the incorrect base branch. I've missed that mistake two or three times in the past two weeks, and it's been causing me frustration because, after approving a PR, I then have to go back and explain that the base branch is wrong, which usually requires a rebase to fix, which requires a new PR approval...

### Please provide any contextual information.

Ever since we changed the default branch of CATs and CF-D from develop to main (for branch protection reasons IIRC), probably 50% of new PRs have been accidentally made against main. That's despite clear messages in the PR templates to only create PRs against develop.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO - just a CI change

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

When a PR is made against CF-D or CATs' `main` branch, the fail-prs-to-cats-main / fail-prs-to-cf-deployment-main job will immediately run and mark the PR as failing this check.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None