### PR TITLE
ci(pull-requests): Add `version: every` to CATs unit tests job

### DIFF
--- a/ci/pipelines/pull-requests.yml
+++ b/ci/pipelines/pull-requests.yml
@@ -260,6 +260,7 @@ jobs:
         - get: runtime-ci
         - get: cats-all-branches
           trigger: true
+          version: every
       - put: cats-all-branches
         params:
           path: cats-all-branches


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

This should ensure that all approved PRs to CATs are run through unit tests, even if multiple were approved at once. Currently, if multiple are approved at once, only the latest PR will trigger the job.

Also, it's what we do for every other trigger resource in this pipeline.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

ARD approvers might have to go re-run the pipeline manually after approving multiple CATs PRs at once.

### Please provide any contextual information.

None

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO - not necessary for a CI change

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Pipeline remains green. 

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None