### PR TITLE
Fix vxlan-policy-agent job configuration

### DIFF
--- a/operations/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/add-persistent-isolation-segment-diego-cell.yml
@@ -147,13 +147,13 @@
         ca_cert: ((network_policy_client.ca))
         client_cert: ((network_policy_client.certificate))
         client_key: ((network_policy_client.private_key))
+        loggregator:
+          use_v2_api: true
+          ca_cert: "((loggregator_tls_agent.ca))"
+          cert: "((loggregator_tls_agent.certificate))"
+          key: "((loggregator_tls_agent.private_key))"
       provides:
         vpa: nil
-      loggregator: 
-        use_v2_api: true
-        ca_cert: "((loggregator_tls_agent.ca))"
-        cert: "((loggregator_tls_agent.certificate))"
-        key: "((loggregator_tls_agent.private_key))"
     - name: silk-daemon
       release: silk
       properties:


### PR DESCRIPTION
### WHAT is this change about?

Fix ops file `add-persistent-isolation-segment-diego-cell.yml`. The "loggregator" config properties are in the wrong place, resulting in "Failed to find variable" CredHub errors, see:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/fresh-deploy/builds/696

### Please provide any contextual information.

Error was introduced with https://github.com/cloudfoundry/cf-deployment/pull/1109
For config parameter specification, see https://github.com/cloudfoundry/silk-release/blob/develop/jobs/vxlan-policy-agent/spec

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

See https://github.com/cloudfoundry/cf-deployment/pull/1109

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Job "fresh-deploy" must succeed.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
