### PR TITLE
Fix ops file path for "upgrade-deploy" job

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -799,7 +799,7 @@ jobs:
         operations/use-external-blobstore.yml
         operations/use-gcs-blobstore-service-account.yml
         operations/enable-service-discovery.yml
-        operations/test/add-persistent-isolation-segment-diego-cell.yml
+        operations/add-persistent-isolation-segment-diego-cell.yml
         operations/scale-log-api-to-4.yml
         operations/use-internal-lookup-for-route-services.yml
       VARS_FILES: |


### PR DESCRIPTION
### WHAT is this change about?

Fix ops file path for ops file `add-persistent-isolation-segment-diego-cell.yml`.

### Please provide any contextual information.

PR which introduced the ops files relocation: https://github.com/cloudfoundry/cf-deployment/pull/1109

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Please provide Acceptance Criteria for this change?

Job "upgrade-deploy" must succeed. It's currently failing: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/upgrade-deploy/builds/710

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
