### PR TITLE
Add trusted_certs for windows filesystem opsfiles

### DIFF
--- a/operations/use-offline-windows2019fs.yml
+++ b/operations/use-offline-windows2019fs.yml
@@ -3,6 +3,12 @@
   value:
     name: windows2019fs
     release: windows2019fs
+    properties:
+      windows-rootfs:
+        trusted_certs: |
+          ((diego_instance_identity_ca.ca))
+          ((credhub_tls.ca))
+          ((uaa_ssl.ca))
 - type: replace
   path: /releases/name=windows2019fs?
   value:

--- a/operations/use-online-windows2019fs.yml
+++ b/operations/use-online-windows2019fs.yml
@@ -3,6 +3,12 @@
   value:
     name: windows2019fs
     release: windowsfs
+    properties:
+      windows-rootfs:
+        trusted_certs: |
+          ((diego_instance_identity_ca.ca))
+          ((credhub_tls.ca))
+          ((uaa_ssl.ca))
 - type: replace
   path: /releases/name=windowsfs?
   value:


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Uses the same trusted certs as diego cells. Without these present, we missed catching the problem with winc-release 2.17.0 and the windows2019fs pre-start scripts.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

CI missed catching a problem if this property is set to add custom trusted certs on the filesystem image.

### Please provide any contextual information.


### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The windows deployments with winc-release 2.17.0 should fail on the windowsfs pre-start job. 2.16.0 (and below) and 2.18.0+ should succeed.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
