### PR TITLE
Set "fresh" smoke-tests timeout scale to 3.0

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -514,6 +514,7 @@ jobs:
       NEW_OPS_FILES: |
         environments/test/luna/rename-isolation-segment-network.yml
         environments/test/luna/change-postgres-max-connections.yml
+        environments/test/luna/smoke-tests-timeout-scale.yml
   - task: bosh-deploy-cf
     file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
     input_mapping:

--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -541,6 +541,7 @@ jobs:
         operations/enable-tls-on-file-server.yml
         operations/test/speed-up-dynamic-asgs.yml
         operations/use-cflinuxfs4-compat.yml
+        operations/smoke-tests-timeout-scale.yml
       VARS_FILES: |
         environments/test/luna/deployment-name.yml
         environments/test/luna/network-name.yml


### PR DESCRIPTION
### WHAT is this change about?

The upcoming bbl release will contain a change that disables ephemeral external IPs in the GCP cloud config by default. Since v9.0.11, bbl deploys a cloud NAT gateway on GCP for outgoing traffic.

I've tested the change by manually disabling external IPs in the "fresh" and "upgrade" cloud-configs. For unknown reasons, the "fresh" isolation segment smoke tests now take longer and fail repeatedly. It's unclear why exactly. CATs succeed. Smoke tests and CATs on the "upgrade" environment succeed, too.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Using a NAT gateway avoids allocation of external IPs and the risk of leaving orphaned IPs behind (which incur additional cost).

### Please provide any contextual information.

Smoke test ops file: https://github.com/cloudfoundry/relint-envs/blob/main/environments/test/luna/smoke-tests-timeout-scale.yml
bbl PR: https://github.com/cloudfoundry/bosh-bootloader/pull/590
smoke-tests-release PR: https://github.com/cloudfoundry/cf-smoke-tests-release/pull/25

Pipelines has already been updated with this change: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

When a new bbl version including https://github.com/cloudfoundry/bosh-bootloader/pull/590 has been released and the "fresh" environment has been updated with that version, the "fresh-smoke-tests" job must still succeed.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
