### PR TITLE
Fix: Use MySQL version 8.0 by default

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -427,7 +427,7 @@ instance_groups:
   - name: pxc-mysql
     release: pxc
     properties:
-      mysql_version: "5.7"
+      mysql_version: "8.0"
       admin_password: ((cf_mysql_mysql_admin_password))
       engine_config:
         binlog:

--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -44,5 +44,5 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 | [`disable-logs-in-firehose.yml`](disable-logs-in-firehose.yml) | Logs are not sent to dopplers, only metrics | | **NO** |
 | [`disable-logs-in-firehose-windows2019.yml`](disable-logs-in-firehose-windows-2019.yml) | Logs are not sent to dopplers, only metrics | | **NO** |
 | [`use-native-garden-runc-runner.yml`](use-native-garden-runc-runner.yml) | Configure Garden to **not** create containers via containerd, using the native runner instead. | | **NO** |
-| [`use-mysql-version-8.0.yml`](use-mysql-version-8.0.yml) | Deploys or upgrades Percona 8.0 as the internal database. | When used in conjunction with [pxc-release](https://github.com/cloudfoundry/pxc-release) v1.0.0 or greater will deploy Percona 8.0 or upgrade Percona 5.7 to Percona 8.0| **YES** |
+| [`use-mysql-version-8.0.yml`](use-mysql-version-8.0.yml) | Deploys or upgrades Percona 8.0 as the internal database. | ***Deprecated as we now use MySQL version 8.0 by default.*** | **NO** |
 | [`use-trusted-ca-cert-for-apps-cflinuxfs4.yml`](use-trusted-ca-cert-for-apps-cflinuxfs4.yml) | Same as [`use-trusted-ca-cert-for-apps.yml`](../use-trusted-ca-cert-for-apps.yml), but for cflinuxfs4 stack | ***Deprecated as we integrate cflinuxfs4 directly into cf-deployment.yml*** | **NO** |

--- a/operations/experimental/use-mysql-version-8.0.yml
+++ b/operations/experimental/use-mysql-version-8.0.yml
@@ -1,4 +1,4 @@
 ---
-- type: replace
-  path: /instance_groups/name=database/jobs/name=pxc-mysql/properties/mysql_version?
-  value: "8.0"
+###
+# Deprecated as we now use MySQL version 8.0 by default.
+###

--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -71,7 +71,3 @@ use-trusted-ca-cert-for-apps-cflinuxfs4.yml:
     - add-cflinuxfs4.yml
   varsfiles:
     - ../example-vars-files/vars-use-trusted-ca-cert-for-apps.yml
-use-mysql-version-8.0.yml:
-  pathvalidator:
-    path: /instance_groups/name=database/jobs/name=pxc-mysql/properties/mysql_version?
-    expectedvalue: "8.0"

--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -71,3 +71,7 @@ use-trusted-ca-cert-for-apps-cflinuxfs4.yml:
     - add-cflinuxfs4.yml
   varsfiles:
     - ../example-vars-files/vars-use-trusted-ca-cert-for-apps.yml
+use-mysql-version-8.0.yml:
+  pathvalidator:
+    path: /instance_groups/name=database/jobs/name=pxc-mysql/properties/mysql_version?
+    expectedvalue: "8.0"


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

Promote the ops file to use MySQL version 8.0, inlining its contents into `cf-deployment.yml`.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana expects the default MySQL version used to be in-support.

### Please provide any contextual information.

* MySQL version 5.7 is EOL.
* https://github.com/cloudfoundry/cf-deployment/issues/1137

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [x] YES - Operators who have not already used the ops file to upgrade to MySQL version 8.0 will find their CF Deployment forcibly upgraded.
- [ ] NO

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

* The pxc release uses MySQL version 8.0 under-the-hood.
* New deployments work as expected.
* Old deployments upgrade seamlessly.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None