### PR TITLE
Add additional gorouter LB health endpoint with TLS

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1469,6 +1469,10 @@ instance_groups:
         status:
           password: "((router_status_password))"
           user: router-status
+          tls:
+            port: 8443
+            certificate: ((gorouter_lb_health_tls.certificate))
+            key: ((gorouter_lb_health_tls.private_key))
         route_services_secret: "((router_route_services_secret))"
         tracing:
           enable_zipkin: true
@@ -2510,6 +2514,13 @@ variables:
     - gorouter.service.cf.internal
     extended_key_usage:
     - client_auth
+- name: gorouter_lb_health_tls
+  type: certificate
+  options:
+    ca: service_cf_internal_ca
+    common_name: gorouter_lb_health_tls
+    alternative_names:
+    - gorouter.service.cf.internal
 - name: credhub_ca
   type: certificate
   options:


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫
✅

### WHAT is this change about?

Adds a cert + properties gorouter to enable an endpoint for LB health checks using TLS.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Being able to ensure all non-localhost endpoints in CF are protected by TLS encryption.

### Please provide any contextual information.

https://www.pivotaltracker.com/story/show/186470212
https://github.com/cloudfoundry/gorouter/pull/374

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

Gorouter now supports a TLS health check for loadbalancers on port `8443`.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Gorouter responds to `https://<ip>:8443/health` in the same way it responds to `http://<ip>:8080/health`

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
