### PR TITLE
Use otel-collector-release for otel-collector

### DIFF
--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -25,6 +25,8 @@ baseReleases:
   repository: cloudfoundry/loggregator-agent-release
 - name: nats
   repository: cloudfoundry/nats-release
+- name: otel-collector
+  repository: cloudfoundry/otel-collector-release
 - name: pxc
   repository: cloudfoundry/pxc-release
 - name: routing

--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -36,6 +36,8 @@ groups:
   - update-loggregator-agent
   - acquire-nats-pre-dev-lock
   - update-nats
+  - acquire-otel-collector-pre-dev-lock
+  - update-otel-collector
   - acquire-pxc-pre-dev-lock
   - update-pxc
   - acquire-routing-pre-dev-lock
@@ -289,6 +291,10 @@ resources:
   type: bosh-io-release
   source:
     repository: cloudfoundry/nats-release
+- name: otel-collector-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry/otel-collector-release
 - name: pxc-release
   type: bosh-io-release
   source:
@@ -581,6 +587,18 @@ resources:
     bucket: component-bump-logs
     json_key: ((greengrass_gcp_service_account_json))
     regexp: nats/cf-(\d+)-(\d+)-(\d+)\.tgz
+- name: otel-collector-release-gcs
+  type: gcs-resource
+  source:
+    bucket: cf-deployment-compiled-releases
+    json_key: ((ci_dev_gcp_service_account_json))
+    regexp: otel-collector-[^-]+-ubuntu-jammy-[^-]+-(\d+)-(\d+)-(\d+).*\.tgz
+- name: otel-collector-component-bump-logs-gcs
+  type: gcs-resource
+  source:
+    bucket: component-bump-logs
+    json_key: ((greengrass_gcp_service_account_json))
+    regexp: otel-collector/cf-(\d+)-(\d+)-(\d+)\.tgz
 - name: pxc-release-gcs
   type: gcs-resource
   source:
@@ -4310,6 +4328,290 @@ jobs:
             file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
             params:
               RELEASE_REPOSITORY: cloudfoundry/nats-release
+          - put: slack-alert
+            params:
+              channel_file: slack-channel/channel.txt
+              icon_emoji: ':cloudfoundrylogo:'
+              text: |
+                $TEXT_FILE_CONTENT
+
+                CI job: https://concourse.wg-ard.ci.cloudfoundry.org/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+                If you're unfamiliar with the update-release pre-validation, please review the following FAQ: https://docs.google.com/document/d/1dUIk2HWbUzdxWs-pNZ-cCqH7CuSNDBixIUoXIFkFpz0
+              text_file: slack-message/message.txt
+              username: Release Integration
+      ensure:
+        do:
+        - task: delete-deployment
+          file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+            IGNORE_ERRORS: true
+          attempts: 3
+        - task: remove-gcp-dns
+          file: runtime-ci/tasks/manage-gcp-dns/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+            GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
+            GCP_DNS_ZONE_NAME: wg-ard
+            ACTION: remove
+        - task: bbl-down
+          file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+          on_failure:
+            do:
+            - task: bbl-cleanup-leftovers
+              file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
+              input_mapping:
+                bbl-state: updated-bbl-state
+                pool-lock: pre-dev-pool
+              output_mapping:
+                updated-bbl-state: clean-bbl-state
+              params:
+                BBL_JSON_CONFIG: pool-lock/metadata
+            ensure:
+              put: relint-envs
+              params:
+                repository: clean-bbl-state
+                rebase: true
+          on_success:
+            put: relint-envs
+            params:
+              repository: updated-bbl-state
+              rebase: true
+    ensure:
+      do:
+      - put: pre-dev-pool
+        params:
+          release: pre-dev-pool
+- name: acquire-otel-collector-pre-dev-lock
+  public: true
+  plan:
+  - in_parallel:
+    - get: otel-collector-release
+      trigger: true
+      params:
+        tarball: false
+  - put: pre-dev-pool
+    params:
+      acquire: true
+- name: update-otel-collector
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: pre-dev-pool
+      passed:
+      - acquire-otel-collector-pre-dev-lock
+      trigger: true
+    - get: otel-collector-release
+      params:
+        tarball: false
+      passed:
+      - acquire-otel-collector-pre-dev-lock
+    - get: cf-deployment-release-candidate
+    - get: cf-deployment-develop
+    - get: stemcell
+      params:
+        tarball: false
+      passed:
+      - update-stemcell-and-recompile-releases
+    - get: cf-deployment-concourse-tasks
+    - get: runtime-ci
+    - get: relint-envs
+    - get: relint-team
+  - task: update-release-otel-collector-release-candidate
+    file: runtime-ci/tasks/update-single-manifest-release/task.yml
+    input_mapping:
+      cf-deployment: cf-deployment-release-candidate
+      release: otel-collector-release
+    output_mapping:
+      updated-cf-deployment: updated-cf-deployment-otel-collector-release-candidate
+    params:
+      RELEASE_NAME: otel-collector
+  - task: update-additional-ops-files-otel-collector-release-candidate
+    file: runtime-ci/tasks/update-single-opsfile-release/task.yml
+    input_mapping:
+      original-ops-file: updated-cf-deployment-otel-collector-release-candidate
+      release: otel-collector-release
+    output_mapping:
+      updated-ops-file: updated-cf-deployment-otel-collector-release-candidate
+    params:
+      RELEASE_NAME: otel-collector
+  - do:
+    - task: bbl-up
+      file: cf-deployment-concourse-tasks/bbl-up/task.yml
+      params:
+        BBL_JSON_CONFIG: pool-lock/metadata
+      input_mapping:
+        bbl-state: relint-envs
+        bbl-config: relint-envs
+        pool-lock: pre-dev-pool
+      on_failure:
+        do:
+        - task: bbl-cleanup-leftovers
+          file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
+          input_mapping:
+            bbl-state: updated-bbl-state
+            pool-lock: pre-dev-pool
+          output_mapping:
+            updated-bbl-state: clean-bbl-state
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+        ensure:
+          put: relint-envs
+          params:
+            repository: clean-bbl-state
+            rebase: true
+      on_success:
+        put: relint-envs
+        params:
+          repository: updated-bbl-state
+          rebase: true
+    - task: add-gcp-dns
+      file: runtime-ci/tasks/manage-gcp-dns/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+        pool-lock: pre-dev-pool
+      params:
+        BBL_JSON_CONFIG: pool-lock/metadata
+        GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
+        GCP_DNS_ZONE_NAME: wg-ard
+        ACTION: add
+    - do:
+      - task: combine-vars-files
+        file: runtime-ci/tasks/combine-inputs/task.yml
+        input_mapping:
+          first-input: cf-deployment-release-candidate
+          second-input: relint-envs
+        output_mapping:
+          combined-inputs: combined-vars-files
+      - task: update-stemcell-for-deploy
+        file: runtime-ci/tasks/update-base-manifest-stemcell/task.yml
+        input_mapping:
+          cf-deployment: updated-cf-deployment-otel-collector-release-candidate
+        output_mapping:
+          updated-cf-deployment: updated-cf-deployment-otel-collector-release-candidate-with-stemcell
+      - task: deploy-cf
+        file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          cf-deployment: updated-cf-deployment-otel-collector-release-candidate-with-stemcell
+          ops-files: updated-cf-deployment-otel-collector-release-candidate-with-stemcell
+          vars-files: combined-vars-files
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          OPS_FILES: |
+            operations/scale-to-one-az.yml
+          REGENERATE_CREDENTIALS: false
+          BOSH_DEPLOY_ARGS: --parallel 50
+      - task: ensure-api-healthy
+        file: runtime-ci/tasks/ensure-api-healthy/task.yml
+        input_mapping:
+          pool-lock: pre-dev-pool
+          cats-integration-config: relint-envs
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+      - task: run-errand-smoke-tests
+        file: cf-deployment-concourse-tasks/run-errand/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          ERRAND_NAME: smoke_tests
+      - task: export-compiled-release-otel-collector
+        file: runtime-ci/tasks/export-compiled-release-tarball/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          manifest: updated-cf-deployment-otel-collector-release-candidate-with-stemcell
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          RELEASE_NAME: otel-collector
+      on_success:
+        do:
+        - task: update-release-otel-collector-develop
+          file: runtime-ci/tasks/update-single-manifest-release/task.yml
+          input_mapping:
+            cf-deployment: cf-deployment-develop
+            release: otel-collector-release
+          output_mapping:
+            updated-cf-deployment: updated-cf-deployment-otel-collector-develop
+          params:
+            RELEASE_NAME: otel-collector
+        - task: update-additional-ops-files-otel-collector-develop
+          file: runtime-ci/tasks/update-single-opsfile-release/task.yml
+          input_mapping:
+            original-ops-file: updated-cf-deployment-otel-collector-develop
+            release: otel-collector-release
+          output_mapping:
+            updated-ops-file: updated-cf-deployment-otel-collector-develop
+          params:
+            RELEASE_NAME: otel-collector
+        - task: update-compiled-releases-ops-file-otel-collector-develop
+          file: runtime-ci/tasks/update-single-compiled-release/task.yml
+          input_mapping:
+            original-compiled-releases-ops-file: updated-cf-deployment-otel-collector-develop
+            release: otel-collector-release
+          output_mapping:
+            updated-compiled-releases-ops-file: updated-cf-deployment-otel-collector-develop
+          params:
+            RELEASE_NAME: otel-collector
+            ORIGINAL_OPS_FILE_PATH: operations/use-compiled-releases.yml
+            UPDATED_OPS_FILE_PATH: operations/use-compiled-releases.yml
+        - put: otel-collector-release-gcs
+          params:
+            file: compiled-release-tarball/*.tgz
+            predefined_acl: publicRead
+        - put: cf-deployment-develop
+          params:
+            rebase: true
+            repository: updated-cf-deployment-otel-collector-develop
+      on_failure:
+        do:
+        - task: push-to-release-branch
+          file: runtime-ci/tasks/push-to-release-branch/task.yml
+          input_mapping:
+            updated-cf-deployment: updated-cf-deployment-otel-collector-release-candidate
+            release: otel-collector-release
+          params:
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
+            RELEASE_NAME: otel-collector
+        - task: retrieve-bosh-logs
+          file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+        - put: otel-collector-component-bump-logs-gcs
+          params:
+            file: bosh-logs/cf-*.tgz
+        ensure:
+          do:
+          - task: create-slack-message
+            file: runtime-ci/tasks/create-slack-message/task.yml
+            input_mapping:
+              release: otel-collector-release
+            params:
+              BOSH_LOGS_PREFIX: https://storage.cloud.google.com/component-bump-logs/otel-collector
+              RELEASE_NAME: otel-collector
+          - task: lookup-slack-channel-for-release-owner
+            file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
+            params:
+              RELEASE_REPOSITORY: cloudfoundry/otel-collector-release
           - put: slack-alert
             params:
               channel_file: slack-channel/channel.txt
@@ -13989,6 +14291,13 @@ jobs:
       - put: nats-release-gcs
         params:
           file: compiled-releases/nats-[0-9]*.tgz
+          predefined_acl: publicRead
+        get_params:
+          skip_download: "true"
+        attempts: 3
+      - put: otel-collector-release-gcs
+        params:
+          file: compiled-releases/otel-collector-[0-9]*.tgz
           predefined_acl: publicRead
         get_params:
           skip_download: "true"

--- a/operations/experimental/add-otel-collector-windows.yml
+++ b/operations/experimental/add-otel-collector-windows.yml
@@ -7,7 +7,7 @@
       - os: windows2019
     jobs:
     - name: otel-collector-windows
-      release: loggregator-agent
+      release: otel-collector
       properties:
         # Insert OTel Collector Exporter configuration
         # See https://opentelemetry.io/docs/collector/configuration/#exporters

--- a/operations/experimental/add-otel-collector.yml
+++ b/operations/experimental/add-otel-collector.yml
@@ -11,7 +11,7 @@
         release: cf-smoke-tests
     jobs:
     - name: otel-collector
-      release: loggregator-agent
+      release: otel-collector
       properties:
         # Insert OTel Collector Exporter configuration
         # See https://opentelemetry.io/docs/collector/configuration/#exporters
@@ -39,3 +39,10 @@
       extended_key_usage:
       - client_auth
       - server_auth
+- type: replace
+  path: /releases/name=otel-collector?
+  value:
+    name: "otel-collector"
+    version: "0.3.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/otel-collector-release?v=0.3.0"
+    sha1: "5f6f1aca2712e9de0b4049a51ece99a6c70938fe"

--- a/operations/experimental/example-vars-files/vars-override-otel-collector-exporters.yml
+++ b/operations/experimental/example-vars-files/vars-override-otel-collector-exporters.yml
@@ -1,6 +1,6 @@
 ---
 otel_collector_metric_exporters:
   file/test:
-    path: /var/vcap/sys/log/otel-collector/file.log
+    path: /tmp/otel-collector-file.log
   otlp/test:
     endpoint: otelcol:4317


### PR DESCRIPTION
Also changing sample vars file path to be compatible with both windows and linux jobs

### WHAT is this change about?

Moving otel-collector out to its own release.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Other deployments may wish to use otel-collector without using loggregator-agent.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

otel-collector now comes from the otel-collector-release

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [X] YES - otel-collector-release
- [ ] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

`bosh releases` should show otel-collector-release is deployed

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@ctlong 
