### PR TITLE
Remove leftovers from  metrics-discovery-release

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2560,17 +2560,6 @@ variables:
     extended_key_usage:
     - server_auth
 
-- name: scrape_config_generator_metrics_tls
-  type: certificate
-  update_mode: converge
-  options:
-    ca: metric_scraper_ca
-    common_name: scrape_config_generator_metrics
-    alternative_names:
-    - scrape_config_generator_metrics
-    extended_key_usage:
-    - server_auth
-
 - name: log_cache_metrics_tls
   type: certificate
   update_mode: converge


### PR DESCRIPTION
The removal of the `metrics-discovery-release` was announced with [RFC-0022](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0022-deprecate-metrics-agent.md) and the job configuration was removed with [PR 1139](https://github.com/cloudfoundry/cf-deployment/pull/1139/files). This change removes the things we have missed in the previous one.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?
 It is already mentioned in the v35.0.0 release

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

None. The certificate is not used anywhere

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

#wg-app-runtime-platform-logging-and-metrics-approvers
