### PR TITLE
Fix: Remove otel-collector from base cf-deployment.yml manifest

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2894,10 +2894,6 @@ releases:
   url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.56.0
   version: 1.56.0
   sha1: d6278637373c15a1ed2c469758837e54cf81356a
-- name: otel-collector
-  url: https://bosh.io/d/github.com/cloudfoundry/otel-collector-release?v=0.3.0
-  version: 0.3.0
-  sha1: 5f6f1aca2712e9de0b4049a51ece99a6c70938fe
 stemcells:
 - alias: default
   os: ubuntu-jammy

--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -25,8 +25,6 @@ baseReleases:
   repository: cloudfoundry/loggregator-agent-release
 - name: nats
   repository: cloudfoundry/nats-release
-- name: otel-collector
-  repository: cloudfoundry/otel-collector-release
 - name: pxc
   repository: cloudfoundry/pxc-release
 - name: routing
@@ -122,6 +120,9 @@ opsReleases:
   requiredOpsFiles:
   - operations/windows2019-cell.yml
   - operations/use-online-windows2019fs.yml
+- name: otel-collector
+  repository: cloudfoundry/otel-collector-release
+  varsFiles: "operations/experimental/example-vars-files/vars-override-otel-collector-exporters.yml"
 
 untestedOpsReleases:
 - name: datadog-firehose-nozzle

--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -36,8 +36,6 @@ groups:
   - update-loggregator-agent
   - acquire-nats-pre-dev-lock
   - update-nats
-  - acquire-otel-collector-pre-dev-lock
-  - update-otel-collector
   - acquire-pxc-pre-dev-lock
   - update-pxc
   - acquire-routing-pre-dev-lock
@@ -114,6 +112,8 @@ groups:
   - update-metric-store
   - acquire-envoy-nginx-pre-dev-lock
   - update-envoy-nginx
+  - acquire-otel-collector-pre-dev-lock
+  - update-otel-collector
   - update-datadog-firehose-nozzle
 - name: update-windows-stemcells-and-releases
   jobs:
@@ -291,10 +291,6 @@ resources:
   type: bosh-io-release
   source:
     repository: cloudfoundry/nats-release
-- name: otel-collector-release
-  type: bosh-io-release
-  source:
-    repository: cloudfoundry/otel-collector-release
 - name: pxc-release
   type: bosh-io-release
   source:
@@ -439,6 +435,10 @@ resources:
   type: bosh-io-release
   source:
     repository: cloudfoundry-incubator/envoy-nginx-release
+- name: otel-collector-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry/otel-collector-release
 - name: datadog-firehose-nozzle-release
   type: bosh-io-release
   source:
@@ -587,18 +587,6 @@ resources:
     bucket: component-bump-logs
     json_key: ((greengrass_gcp_service_account_json))
     regexp: nats/cf-(\d+)-(\d+)-(\d+)\.tgz
-- name: otel-collector-release-gcs
-  type: gcs-resource
-  source:
-    bucket: cf-deployment-compiled-releases
-    json_key: ((ci_dev_gcp_service_account_json))
-    regexp: otel-collector-[^-]+-ubuntu-jammy-[^-]+-(\d+)-(\d+)-(\d+).*\.tgz
-- name: otel-collector-component-bump-logs-gcs
-  type: gcs-resource
-  source:
-    bucket: component-bump-logs
-    json_key: ((greengrass_gcp_service_account_json))
-    regexp: otel-collector/cf-(\d+)-(\d+)-(\d+)\.tgz
 - name: pxc-release-gcs
   type: gcs-resource
   source:
@@ -923,6 +911,12 @@ resources:
     bucket: component-bump-logs
     json_key: ((greengrass_gcp_service_account_json))
     regexp: envoy-nginx/cf-(\d+)-(\d+)-(\d+)\.tgz
+- name: otel-collector-component-bump-logs-gcs
+  type: gcs-resource
+  source:
+    bucket: component-bump-logs
+    json_key: ((greengrass_gcp_service_account_json))
+    regexp: otel-collector/cf-(\d+)-(\d+)-(\d+)\.tgz
 - name: windows2019-stemcell
   type: bosh-io-stemcell
   icon: dna
@@ -4328,290 +4322,6 @@ jobs:
             file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
             params:
               RELEASE_REPOSITORY: cloudfoundry/nats-release
-          - put: slack-alert
-            params:
-              channel_file: slack-channel/channel.txt
-              icon_emoji: ':cloudfoundrylogo:'
-              text: |
-                $TEXT_FILE_CONTENT
-
-                CI job: https://concourse.wg-ard.ci.cloudfoundry.org/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
-
-                If you're unfamiliar with the update-release pre-validation, please review the following FAQ: https://docs.google.com/document/d/1dUIk2HWbUzdxWs-pNZ-cCqH7CuSNDBixIUoXIFkFpz0
-              text_file: slack-message/message.txt
-              username: Release Integration
-      ensure:
-        do:
-        - task: delete-deployment
-          file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
-          input_mapping:
-            bbl-state: relint-envs
-            pool-lock: pre-dev-pool
-          params:
-            BBL_JSON_CONFIG: pool-lock/metadata
-            IGNORE_ERRORS: true
-          attempts: 3
-        - task: remove-gcp-dns
-          file: runtime-ci/tasks/manage-gcp-dns/task.yml
-          input_mapping:
-            bbl-state: relint-envs
-            pool-lock: pre-dev-pool
-          params:
-            BBL_JSON_CONFIG: pool-lock/metadata
-            GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
-            GCP_DNS_ZONE_NAME: wg-ard
-            ACTION: remove
-        - task: bbl-down
-          file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
-          input_mapping:
-            bbl-state: relint-envs
-            pool-lock: pre-dev-pool
-          params:
-            BBL_JSON_CONFIG: pool-lock/metadata
-          on_failure:
-            do:
-            - task: bbl-cleanup-leftovers
-              file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
-              input_mapping:
-                bbl-state: updated-bbl-state
-                pool-lock: pre-dev-pool
-              output_mapping:
-                updated-bbl-state: clean-bbl-state
-              params:
-                BBL_JSON_CONFIG: pool-lock/metadata
-            ensure:
-              put: relint-envs
-              params:
-                repository: clean-bbl-state
-                rebase: true
-          on_success:
-            put: relint-envs
-            params:
-              repository: updated-bbl-state
-              rebase: true
-    ensure:
-      do:
-      - put: pre-dev-pool
-        params:
-          release: pre-dev-pool
-- name: acquire-otel-collector-pre-dev-lock
-  public: true
-  plan:
-  - in_parallel:
-    - get: otel-collector-release
-      trigger: true
-      params:
-        tarball: false
-  - put: pre-dev-pool
-    params:
-      acquire: true
-- name: update-otel-collector
-  public: true
-  serial: true
-  plan:
-  - in_parallel:
-    - get: pre-dev-pool
-      passed:
-      - acquire-otel-collector-pre-dev-lock
-      trigger: true
-    - get: otel-collector-release
-      params:
-        tarball: false
-      passed:
-      - acquire-otel-collector-pre-dev-lock
-    - get: cf-deployment-release-candidate
-    - get: cf-deployment-develop
-    - get: stemcell
-      params:
-        tarball: false
-      passed:
-      - update-stemcell-and-recompile-releases
-    - get: cf-deployment-concourse-tasks
-    - get: runtime-ci
-    - get: relint-envs
-    - get: relint-team
-  - task: update-release-otel-collector-release-candidate
-    file: runtime-ci/tasks/update-single-manifest-release/task.yml
-    input_mapping:
-      cf-deployment: cf-deployment-release-candidate
-      release: otel-collector-release
-    output_mapping:
-      updated-cf-deployment: updated-cf-deployment-otel-collector-release-candidate
-    params:
-      RELEASE_NAME: otel-collector
-  - task: update-additional-ops-files-otel-collector-release-candidate
-    file: runtime-ci/tasks/update-single-opsfile-release/task.yml
-    input_mapping:
-      original-ops-file: updated-cf-deployment-otel-collector-release-candidate
-      release: otel-collector-release
-    output_mapping:
-      updated-ops-file: updated-cf-deployment-otel-collector-release-candidate
-    params:
-      RELEASE_NAME: otel-collector
-  - do:
-    - task: bbl-up
-      file: cf-deployment-concourse-tasks/bbl-up/task.yml
-      params:
-        BBL_JSON_CONFIG: pool-lock/metadata
-      input_mapping:
-        bbl-state: relint-envs
-        bbl-config: relint-envs
-        pool-lock: pre-dev-pool
-      on_failure:
-        do:
-        - task: bbl-cleanup-leftovers
-          file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
-          input_mapping:
-            bbl-state: updated-bbl-state
-            pool-lock: pre-dev-pool
-          output_mapping:
-            updated-bbl-state: clean-bbl-state
-          params:
-            BBL_JSON_CONFIG: pool-lock/metadata
-        ensure:
-          put: relint-envs
-          params:
-            repository: clean-bbl-state
-            rebase: true
-      on_success:
-        put: relint-envs
-        params:
-          repository: updated-bbl-state
-          rebase: true
-    - task: add-gcp-dns
-      file: runtime-ci/tasks/manage-gcp-dns/task.yml
-      input_mapping:
-        bbl-state: relint-envs
-        pool-lock: pre-dev-pool
-      params:
-        BBL_JSON_CONFIG: pool-lock/metadata
-        GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
-        GCP_DNS_ZONE_NAME: wg-ard
-        ACTION: add
-    - do:
-      - task: combine-vars-files
-        file: runtime-ci/tasks/combine-inputs/task.yml
-        input_mapping:
-          first-input: cf-deployment-release-candidate
-          second-input: relint-envs
-        output_mapping:
-          combined-inputs: combined-vars-files
-      - task: update-stemcell-for-deploy
-        file: runtime-ci/tasks/update-base-manifest-stemcell/task.yml
-        input_mapping:
-          cf-deployment: updated-cf-deployment-otel-collector-release-candidate
-        output_mapping:
-          updated-cf-deployment: updated-cf-deployment-otel-collector-release-candidate-with-stemcell
-      - task: deploy-cf
-        file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
-        input_mapping:
-          bbl-state: relint-envs
-          cf-deployment: updated-cf-deployment-otel-collector-release-candidate-with-stemcell
-          ops-files: updated-cf-deployment-otel-collector-release-candidate-with-stemcell
-          vars-files: combined-vars-files
-          pool-lock: pre-dev-pool
-        params:
-          BBL_JSON_CONFIG: pool-lock/metadata
-          OPS_FILES: |
-            operations/scale-to-one-az.yml
-          REGENERATE_CREDENTIALS: false
-          BOSH_DEPLOY_ARGS: --parallel 50
-      - task: ensure-api-healthy
-        file: runtime-ci/tasks/ensure-api-healthy/task.yml
-        input_mapping:
-          pool-lock: pre-dev-pool
-          cats-integration-config: relint-envs
-        params:
-          BBL_JSON_CONFIG: pool-lock/metadata
-      - task: run-errand-smoke-tests
-        file: cf-deployment-concourse-tasks/run-errand/task.yml
-        input_mapping:
-          bbl-state: relint-envs
-          pool-lock: pre-dev-pool
-        params:
-          BBL_JSON_CONFIG: pool-lock/metadata
-          ERRAND_NAME: smoke_tests
-      - task: export-compiled-release-otel-collector
-        file: runtime-ci/tasks/export-compiled-release-tarball/task.yml
-        input_mapping:
-          bbl-state: relint-envs
-          manifest: updated-cf-deployment-otel-collector-release-candidate-with-stemcell
-          pool-lock: pre-dev-pool
-        params:
-          BBL_JSON_CONFIG: pool-lock/metadata
-          RELEASE_NAME: otel-collector
-      on_success:
-        do:
-        - task: update-release-otel-collector-develop
-          file: runtime-ci/tasks/update-single-manifest-release/task.yml
-          input_mapping:
-            cf-deployment: cf-deployment-develop
-            release: otel-collector-release
-          output_mapping:
-            updated-cf-deployment: updated-cf-deployment-otel-collector-develop
-          params:
-            RELEASE_NAME: otel-collector
-        - task: update-additional-ops-files-otel-collector-develop
-          file: runtime-ci/tasks/update-single-opsfile-release/task.yml
-          input_mapping:
-            original-ops-file: updated-cf-deployment-otel-collector-develop
-            release: otel-collector-release
-          output_mapping:
-            updated-ops-file: updated-cf-deployment-otel-collector-develop
-          params:
-            RELEASE_NAME: otel-collector
-        - task: update-compiled-releases-ops-file-otel-collector-develop
-          file: runtime-ci/tasks/update-single-compiled-release/task.yml
-          input_mapping:
-            original-compiled-releases-ops-file: updated-cf-deployment-otel-collector-develop
-            release: otel-collector-release
-          output_mapping:
-            updated-compiled-releases-ops-file: updated-cf-deployment-otel-collector-develop
-          params:
-            RELEASE_NAME: otel-collector
-            ORIGINAL_OPS_FILE_PATH: operations/use-compiled-releases.yml
-            UPDATED_OPS_FILE_PATH: operations/use-compiled-releases.yml
-        - put: otel-collector-release-gcs
-          params:
-            file: compiled-release-tarball/*.tgz
-            predefined_acl: publicRead
-        - put: cf-deployment-develop
-          params:
-            rebase: true
-            repository: updated-cf-deployment-otel-collector-develop
-      on_failure:
-        do:
-        - task: push-to-release-branch
-          file: runtime-ci/tasks/push-to-release-branch/task.yml
-          input_mapping:
-            updated-cf-deployment: updated-cf-deployment-otel-collector-release-candidate
-            release: otel-collector-release
-          params:
-            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
-            RELEASE_NAME: otel-collector
-        - task: retrieve-bosh-logs
-          file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
-          input_mapping:
-            bbl-state: relint-envs
-            pool-lock: pre-dev-pool
-          params:
-            BBL_JSON_CONFIG: pool-lock/metadata
-        - put: otel-collector-component-bump-logs-gcs
-          params:
-            file: bosh-logs/cf-*.tgz
-        ensure:
-          do:
-          - task: create-slack-message
-            file: runtime-ci/tasks/create-slack-message/task.yml
-            input_mapping:
-              release: otel-collector-release
-            params:
-              BOSH_LOGS_PREFIX: https://storage.cloud.google.com/component-bump-logs/otel-collector
-              RELEASE_NAME: otel-collector
-          - task: lookup-slack-channel-for-release-owner
-            file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
-            params:
-              RELEASE_REPOSITORY: cloudfoundry/otel-collector-release
           - put: slack-alert
             params:
               channel_file: slack-channel/channel.txt
@@ -14035,6 +13745,243 @@ jobs:
       - put: pre-dev-pool
         params:
           release: pre-dev-pool
+- name: acquire-otel-collector-pre-dev-lock
+  public: true
+  plan:
+  - in_parallel:
+    - get: otel-collector-release
+      trigger: true
+      params:
+        tarball: false
+  - put: pre-dev-pool
+    params:
+      acquire: true
+- name: update-otel-collector
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: pre-dev-pool
+      passed:
+      - acquire-otel-collector-pre-dev-lock
+      trigger: true
+    - get: otel-collector-release
+      params:
+        tarball: false
+      passed:
+      - acquire-otel-collector-pre-dev-lock
+    - get: cf-deployment-release-candidate
+    - get: cf-deployment-develop
+    - get: stemcell
+      params:
+        tarball: false
+    - get: cf-deployment-concourse-tasks
+    - get: runtime-ci
+    - get: relint-envs
+    - get: relint-team
+  - task: update-additional-ops-files-otel-collector-release-candidate
+    file: runtime-ci/tasks/update-single-opsfile-release/task.yml
+    input_mapping:
+      original-ops-file: cf-deployment-release-candidate
+      release: otel-collector-release
+    output_mapping:
+      updated-ops-file: updated-cf-deployment-otel-collector-release-candidate
+    params:
+      RELEASE_NAME: otel-collector
+  - do:
+    - task: bbl-up
+      file: cf-deployment-concourse-tasks/bbl-up/task.yml
+      params:
+        BBL_JSON_CONFIG: pool-lock/metadata
+      input_mapping:
+        bbl-state: relint-envs
+        bbl-config: relint-envs
+        pool-lock: pre-dev-pool
+      on_failure:
+        do:
+        - task: bbl-cleanup-leftovers
+          file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
+          input_mapping:
+            bbl-state: updated-bbl-state
+            pool-lock: pre-dev-pool
+          output_mapping:
+            updated-bbl-state: clean-bbl-state
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+        ensure:
+          put: relint-envs
+          params:
+            repository: clean-bbl-state
+            rebase: true
+      on_success:
+        put: relint-envs
+        params:
+          repository: updated-bbl-state
+          rebase: true
+    - task: add-gcp-dns
+      file: runtime-ci/tasks/manage-gcp-dns/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+        pool-lock: pre-dev-pool
+      params:
+        BBL_JSON_CONFIG: pool-lock/metadata
+        GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
+        GCP_DNS_ZONE_NAME: wg-ard
+        ACTION: add
+    - do:
+      - task: combine-vars-files
+        file: runtime-ci/tasks/combine-inputs/task.yml
+        input_mapping:
+          first-input: cf-deployment-release-candidate
+          second-input: relint-envs
+        output_mapping:
+          combined-inputs: combined-vars-files
+      - task: deploy-cf
+        file: runtime-ci/tasks/bosh-deploy-with-first-ops/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          cf-deployment: updated-cf-deployment-otel-collector-release-candidate
+          ops-files: updated-cf-deployment-otel-collector-release-candidate
+          vars-files: combined-vars-files
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          OPS_FILES: |
+            operations/scale-to-one-az.yml
+            operations/use-compiled-releases.yml
+            operations/experimental/use-compiled-releases-windows.yml
+          REGENERATE_CREDENTIALS: false
+          BOSH_DEPLOY_ARGS: --parallel 50
+          VARS_FILES: operations/experimental/example-vars-files/vars-override-otel-collector-exporters.yml
+      - task: ensure-api-healthy
+        file: runtime-ci/tasks/ensure-api-healthy/task.yml
+        input_mapping:
+          cats-integration-config: relint-envs
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+      - task: run-errand-smoke-tests
+        file: cf-deployment-concourse-tasks/run-errand/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          ERRAND_NAME: smoke_tests
+      on_success:
+        do:
+        - task: update-additional-ops-files-otel-collector-develop
+          file: runtime-ci/tasks/update-single-opsfile-release/task.yml
+          input_mapping:
+            original-ops-file: cf-deployment-develop
+            release: otel-collector-release
+          output_mapping:
+            updated-ops-file: updated-cf-deployment-otel-collector-develop
+          params:
+            RELEASE_NAME: otel-collector
+        - put: cf-deployment-develop
+          params:
+            rebase: true
+            repository: updated-cf-deployment-otel-collector-develop
+      on_failure:
+        do:
+        - task: push-to-release-branch
+          file: runtime-ci/tasks/push-to-release-branch/task.yml
+          input_mapping:
+            updated-cf-deployment: updated-cf-deployment-otel-collector-release-candidate
+            release: otel-collector-release
+          params:
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
+            RELEASE_NAME: otel-collector
+        - task: retrieve-bosh-logs
+          file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+        - put: otel-collector-component-bump-logs-gcs
+          params:
+            file: bosh-logs/cf-*.tgz
+        ensure:
+          do:
+          - task: create-slack-message
+            file: runtime-ci/tasks/create-slack-message/task.yml
+            input_mapping:
+              release: otel-collector-release
+            params:
+              BOSH_LOGS_PREFIX: https://storage.cloud.google.com/component-bump-logs/otel-collector
+              RELEASE_NAME: otel-collector
+          - task: lookup-slack-channel-for-release-owner
+            file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
+            params:
+              RELEASE_REPOSITORY: cloudfoundry/otel-collector-release
+          - put: slack-alert
+            params:
+              channel_file: slack-channel/channel.txt
+              icon_emoji: ':cloudfoundrylogo:'
+              text: |
+                $TEXT_FILE_CONTENT
+
+                CI job: https://concourse.wg-ard.ci.cloudfoundry.org/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+                If you're unfamiliar with the update-release pre-validation, please review the following FAQ: https://docs.google.com/document/d/1dUIk2HWbUzdxWs-pNZ-cCqH7CuSNDBixIUoXIFkFpz0
+              text_file: slack-message/message.txt
+              username: Release Integration
+      ensure:
+        do:
+        - task: delete-deployment
+          file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+            IGNORE_ERRORS: true
+          attempts: 3
+        - task: remove-gcp-dns
+          file: runtime-ci/tasks/manage-gcp-dns/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+            GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
+            GCP_DNS_ZONE_NAME: wg-ard
+            ACTION: remove
+        - task: bbl-down
+          file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+          on_failure:
+            do:
+            - task: bbl-cleanup-leftovers
+              file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
+              input_mapping:
+                bbl-state: updated-bbl-state
+                pool-lock: pre-dev-pool
+              output_mapping:
+                updated-bbl-state: clean-bbl-state
+              params:
+                BBL_JSON_CONFIG: pool-lock/metadata
+            ensure:
+              put: relint-envs
+              params:
+                repository: clean-bbl-state
+                rebase: true
+          on_success:
+            put: relint-envs
+            params:
+              repository: updated-bbl-state
+              rebase: true
+    ensure:
+      do:
+      - put: pre-dev-pool
+        params:
+          release: pre-dev-pool
 - name: update-datadog-firehose-nozzle
   public: true
   serial: true
@@ -14291,13 +14238,6 @@ jobs:
       - put: nats-release-gcs
         params:
           file: compiled-releases/nats-[0-9]*.tgz
-          predefined_acl: publicRead
-        get_params:
-          skip_download: "true"
-        attempts: 3
-      - put: otel-collector-release-gcs
-        params:
-          file: compiled-releases/otel-collector-[0-9]*.tgz
           predefined_acl: publicRead
         get_params:
           skip_download: "true"

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -298,13 +298,3 @@
       version: "1.80"
     url: https://storage.googleapis.com/cf-deployment-compiled-releases/cflinuxfs4-1.62.0-ubuntu-jammy-1.80-20231219-202309-242418869.tgz
     version: 1.62.0
-- type: replace
-  path: /releases/name=otel-collector
-  value:
-    name: otel-collector
-    sha1: 15235d6dfdec5c4ad07c02ce66f429418676a8ae
-    stemcell:
-      os: ubuntu-jammy
-      version: "1.80"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/otel-collector-0.3.0-ubuntu-jammy-1.80-20231218-113307-675226232.tgz
-    version: 0.3.0


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

The `otel-collector` release was mistakenly added to the base releases section of the `update-releases` CI, causing it to be incorrectly added to `cf-deployment.yml` and `operations/use-compiled-releases.yml`.

This PR reverts those changes and corrects the `update-releases` CI.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

N/A

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/pull/1145

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

- CF-D no longer uploads `otel-collector` release by default
- CF-D with compiled releases still deploys correctly
- `update-otel-collector` job in `update-releases` pipeline is listed in the `update-ops-releases` group

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None