### PR TITLE
Add TLS settings for isolated gorouter status checks

### DIFF
--- a/operations/add-persistent-isolation-segment-router.yml
+++ b/operations/add-persistent-isolation-segment-router.yml
@@ -54,6 +54,10 @@
           status:
             password: "((router_status_password))"
             user: router-status
+            tls:
+              port: 8443
+              certificate: ((gorouter_lb_health_tls.certificate))
+              key: ((gorouter_lb_health_tls.private_key))
           route_services_secret: "((router_route_services_secret))"
           tracing:
             enable_zipkin: true


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Adds TLS settings for gorouter loadbalancer status checks on isolated gorouters.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Divergence of gorouter configs between cf-deployment.yml + the iso-seg-router VM.

### Please provide any contextual information.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Isolated gorouters now support TLS status checks from loadbalancers.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

When the add-persistent-isolation-segment-router.yml ops file is deployed, gorouter responds to https://<ip>:8443/health

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [] **Slightly Less than Urgent**

Will unblock the routing-release pipeline.

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
