### PR TITLE
Remove deprecated "Windows Server 2016" stack

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -877,11 +877,9 @@ instance_groups:
           droplet_destinations:
             cflinuxfs4: /home/vcap
             windows: /Users/vcap
-            windows2016: /Users/vcap
           lifecycle_bundles:
             buildpack/cflinuxfs4: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
             buildpack/windows: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
-            buildpack/windows2016: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
             docker: docker_app_lifecycle/docker_app_lifecycle.tgz
         default_stack: cflinuxfs4
         stacks:
@@ -1165,11 +1163,9 @@ instance_groups:
           droplet_destinations:
             cflinuxfs4: /home/vcap
             windows: /Users/vcap
-            windows2016: /Users/vcap
           lifecycle_bundles:
             buildpack/cflinuxfs4: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
             buildpack/windows: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
-            buildpack/windows2016: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
             docker: docker_app_lifecycle/docker_app_lifecycle.tgz
         database_encryption: *cc-database-encryption
         staging_upload_user: staging_user
@@ -1249,11 +1245,9 @@ instance_groups:
           droplet_destinations:
             cflinuxfs4: /home/vcap
             windows: /Users/vcap
-            windows2016: /Users/vcap
           lifecycle_bundles:
             buildpack/cflinuxfs4: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
             buildpack/windows: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
-            buildpack/windows2016: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
             docker: docker_app_lifecycle/docker_app_lifecycle.tgz
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"
@@ -1286,11 +1280,9 @@ instance_groups:
           droplet_destinations:
             cflinuxfs4: /home/vcap
             windows: /Users/vcap
-            windows2016: /Users/vcap
           lifecycle_bundles:
             buildpack/cflinuxfs4: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
             buildpack/windows: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
-            buildpack/windows2016: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
             docker: docker_app_lifecycle/docker_app_lifecycle.tgz
         mutual_tls:
           ca_cert: "((cc_tls.ca))"

--- a/operations/windows2019-cell.yml
+++ b/operations/windows2019-cell.yml
@@ -51,7 +51,6 @@
           rep:
             open_bindmounts_acl: true
             preloaded_rootfses:
-            - windows2016:oci:///C:/var/vcap/packages/windows2019fs
             - windows:oci:///C:/var/vcap/packages/windows2019fs
         enable_consul_service_registration: false
         enable_declarative_healthcheck: true
@@ -174,21 +173,11 @@
     alias: windows2019
     os: windows2019
     version: "2019.69"
-- path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks/name=windows2016?
-  type: replace
-  value:
-    description: Windows Server 2016
-    name: windows2016
 - path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks/name=windows?
   type: replace
   value:
     description: Windows Server
     name: windows
-- path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=hwc-buildpack-windows2016?
-  type: replace
-  value:
-    name: hwc_buildpack
-    package: hwc-buildpack-windows2016
 - path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=hwc-buildpack-windows?
   type: replace
   value:
@@ -199,11 +188,6 @@
   value:
     name: hwc-buildpack
     release: hwc-buildpack
-- path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=binary-buildpack-windows2016?
-  type: replace
-  value:
-    name: binary_buildpack
-    package: binary-buildpack-windows2016
 - path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/package=binary-buildpack-windows?
   type: replace
   value:


### PR DESCRIPTION
### WHAT is this change about?

Remove the deprecated "Windows Server 2016" stack.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana doesn't want to use a stack that has reached the mainstream end date.

### Please provide any contextual information.

https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2016
https://github.com/cloudfoundry/cf-deployment/issues/1124

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO (will be tested in "windows-cedric" environment)

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [x] YES - please choose the category from below. Feel free to provide additional details.
- [ ] NO

> 6. requires out-of-band manual intervention on the part of the operator

### How should this change be described in cf-deployment release notes?

Removed deprecated "Windows Server 2016" stack. Apps must be migrated to the "Windows Server 2019" stack.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The "windows-cedric" validation must pass.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
