### PR TITLE
Add variables and certs to support Blobstore TLS

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -805,6 +805,9 @@ instance_groups:
         tls:
           cert: "((blobstore_tls.certificate))"
           private_key: "((blobstore_tls.private_key))"
+        public_tls:
+          cert: "((blobstore_public.certificate))"
+          private_key: "((blobstore_public.private_key))"
   - name: route_registrar
     release: routing
     properties:
@@ -2067,6 +2070,14 @@ variables:
     common_name: blobstore.service.cf.internal
     alternative_names:
     - blobstore.service.cf.internal
+- name: blobstore_public
+  type: certificate
+  update_mode: converge
+  options:
+    common_name: "blobstore.((system_domain))"
+    alternative_names:
+    - "blobstore.((system_domain))"
+    ca: service_cf_internal_ca
 - name: diego_auctioneer_client
   type: certificate
   update_mode: converge

--- a/operations/use-external-blobstore.yml
+++ b/operations/use-external-blobstore.yml
@@ -135,3 +135,6 @@
 
 - type: remove
   path: /variables/name=blobstore_tls
+
+- type: remove
+  path: /variables/name=blobstore_public


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

This PR will add variables and certs to support Blobstore TLS.  TLS will not be registered until #1155 is merged.  We'd like to merge this first, so that when the new version of CAPI is released, this variables will already exist.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants all of her traffic to be encrypted.

### Please provide any contextual information.

#1155 
https://github.com/cloudfoundry/capi-release/pull/377

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

No release note.  We can add a release note when #1155 is merged

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component
- [x] neither

### Please provide Acceptance Criteria for this change?

N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@ameowlia @dalvarado 
