### PR TITLE
Use fips-compliance ops file for FIPS validation

### DIFF
--- a/ci/pipelines/fips-stemcell.yml
+++ b/ci/pipelines/fips-stemcell.yml
@@ -167,6 +167,7 @@ jobs:
             operations/addons/add-system-metrics-agent.yml
             operations/use-postgres.yml
             operations/experimental/enable-tls-cloud-controller-postgres.yml
+            operations/experimental/fips-compliance.yml
             operations/use-latest-stemcell.yml
           VARS_FILES: |
             environments/test/snape/syslog-vars.yml
@@ -233,15 +234,13 @@ jobs:
                 passed: [ fips-deploy ]
               - get: cf-deployment-concourse-tasks
         timeout: 1h
-      - try:
-          do:
-          - task: bosh-run-errand-smoke-tests
-            file: cf-deployment-concourse-tasks/run-errand/task.yml
-            params:
-              BBL_STATE_DIR: environments/test/snape/bbl-state
-              ERRAND_NAME: smoke_tests
-            input_mapping:
-              bbl-state: relint-envs
+      - task: bosh-run-errand-smoke-tests
+        file: cf-deployment-concourse-tasks/run-errand/task.yml
+        params:
+          BBL_STATE_DIR: environments/test/snape/bbl-state
+          ERRAND_NAME: smoke_tests
+        input_mapping:
+          bbl-state: relint-envs
 
   - name: fips-cats
     public: true


### PR DESCRIPTION
### WHAT is this change about?

Use the new fips-compliance ops file for the FIPS validation: https://github.com/cloudfoundry/cf-deployment/blob/develop/operations/experimental/fips-compliance.yml

Remove the "try" block for the smoke tests. They have turned green and now we want to make regressions visible in the Concourse pipeline.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants a FIPS-compliant cf-deployment.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/1140

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

FIPS validation pipeline stays green: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/fips-stemcell

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

