### PR TITLE
Remove "try" block from fips-cats job

### DIFF
--- a/ci/pipelines/fips-stemcell.yml
+++ b/ci/pipelines/fips-stemcell.yml
@@ -257,8 +257,6 @@ jobs:
               - get: relint-envs
               - get: cf-deployment-release-candidate
                 passed: [ fips-deploy ]
-      - try:
-          do:
           - task: update-integration-configs
             file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
             params:


### PR DESCRIPTION
### WHAT is this change about?

Remove "try" block from fips-cats Concourse job. We had the first passing job and from now on we want to make failures visible:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/fips-stemcell/jobs/fips-cats/builds/57

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to ensure that cf-deployment is FIPS compliant.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/1140

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Change has already been uploaded to Concourse.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
