### PR TITLE
Add 4h timeout to pool acquire jobs

### DIFF
--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -991,6 +991,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-bosh-dns-aliases
   public: true
   serial: true
@@ -1275,6 +1276,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-bpm
   public: true
   serial: true
@@ -1559,6 +1561,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-capi
   public: true
   serial: true
@@ -1843,6 +1846,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-cf-networking
   public: true
   serial: true
@@ -2127,6 +2131,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-cf-smoke-tests
   public: true
   serial: true
@@ -2411,6 +2416,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-cflinuxfs4
   public: true
   serial: true
@@ -2695,6 +2701,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-diego
   public: true
   serial: true
@@ -2979,6 +2986,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-garden-runc
   public: true
   serial: true
@@ -3263,6 +3271,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-log-cache
   public: true
   serial: true
@@ -3547,6 +3556,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-loggregator
   public: true
   serial: true
@@ -3831,6 +3841,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-loggregator-agent
   public: true
   serial: true
@@ -4115,6 +4126,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-nats
   public: true
   serial: true
@@ -4399,6 +4411,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-pxc
   public: true
   serial: true
@@ -4683,6 +4696,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-routing
   public: true
   serial: true
@@ -4967,6 +4981,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-silk
   public: true
   serial: true
@@ -5251,6 +5266,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-statsd-injector
   public: true
   serial: true
@@ -5535,6 +5551,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-uaa
   public: true
   serial: true
@@ -5819,6 +5836,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-credhub
   public: true
   serial: true
@@ -6103,6 +6121,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-cf-cli
   public: true
   serial: true
@@ -6387,6 +6406,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-binary-buildpack
   public: true
   serial: true
@@ -6671,6 +6691,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-dotnet-core-buildpack
   public: true
   serial: true
@@ -6955,6 +6976,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-go-buildpack
   public: true
   serial: true
@@ -7239,6 +7261,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-java-buildpack
   public: true
   serial: true
@@ -7523,6 +7546,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-nginx-buildpack
   public: true
   serial: true
@@ -7807,6 +7831,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-nodejs-buildpack
   public: true
   serial: true
@@ -8091,6 +8116,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-php-buildpack
   public: true
   serial: true
@@ -8375,6 +8401,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-python-buildpack
   public: true
   serial: true
@@ -8659,6 +8686,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-r-buildpack
   public: true
   serial: true
@@ -8943,6 +8971,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-ruby-buildpack
   public: true
   serial: true
@@ -9227,6 +9256,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-staticfile-buildpack
   public: true
   serial: true
@@ -9511,6 +9541,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-backup-and-restore-sdk
   public: true
   serial: true
@@ -9747,6 +9778,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-cflinuxfs4-compat
   public: true
   serial: true
@@ -9983,6 +10015,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-haproxy
   public: true
   serial: true
@@ -10205,6 +10238,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-mapfs
   public: true
   serial: true
@@ -10441,6 +10475,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-nfs-volume
   public: true
   serial: true
@@ -10677,6 +10712,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-smb-volume
   public: true
   serial: true
@@ -10913,6 +10949,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-postgres
   public: true
   serial: true
@@ -11149,6 +11186,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-syslog
   public: true
   serial: true
@@ -11386,6 +11424,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-windows-syslog
   public: true
   serial: true
@@ -11623,6 +11662,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-hwc-buildpack
   public: true
   serial: true
@@ -11861,6 +11901,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-windows-utilities
   public: true
   serial: true
@@ -12099,6 +12140,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-winc
   public: true
   serial: true
@@ -12337,6 +12379,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-windowsfs
   public: true
   serial: true
@@ -12574,6 +12617,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-node-exporter
   public: true
   serial: true
@@ -12810,6 +12854,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-system-metrics
   public: true
   serial: true
@@ -13046,6 +13091,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-system-metrics-scraper
   public: true
   serial: true
@@ -13282,6 +13328,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-metric-store
   public: true
   serial: true
@@ -13518,6 +13565,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-envoy-nginx
   public: true
   serial: true
@@ -13756,6 +13804,7 @@ jobs:
   - put: pre-dev-pool
     params:
       acquire: true
+    timeout: 4h
 - name: update-otel-collector
   public: true
   serial: true

--- a/ci/template/update-releases.yml
+++ b/ci/template/update-releases.yml
@@ -331,6 +331,7 @@ jobs:
         tarball: false
   - put: pre-dev-pool
     params: {acquire: true}
+    timeout: 4h
 
 - name: #@ "update-" + r.name
   public: true
@@ -528,6 +529,7 @@ jobs:
         tarball: false
   - put: pre-dev-pool
     params: {acquire: true}
+    timeout: 4h
 
 - name: #@ "update-" + r.name
   public: true


### PR DESCRIPTION
### WHAT is this change about?

Add timeout to pool acquire jobs in "update-releases" pipeline.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

If an instance from the pool cannot be acquired over a longer time, something is broken and we should get notified.

### Please provide any contextual information.

The 4 instances from the update-releases pool were acquired for a longer time because some Concourse jobs were not properly triggered, e.g.: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/update-releases/jobs/acquire-nats-pre-dev-lock/builds/20

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

(not relevant)

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Update-releases pipeline is green (or acquire jobs turn red if there is a problem). Pipeline has already been uploaded.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

