### PR TITLE
[Issue 1176] Fix uptimer setup

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -879,7 +879,7 @@ jobs:
         environments/test/trelawney/add-external-ips-for-cloud-sql-db.yml
         environments/test/trelawney/scale-log-api-to-4.yml
   - task: bosh-deploy-cf-develop
-    attempts: 2
+    attempts: 1
     file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
     input_mapping:
       bbl-state: relint-envs
@@ -914,6 +914,7 @@ jobs:
       APP_PUSHABILITY_THRESHOLD: 10
       RECENT_LOGS_THRESHOLD: 10000
       STREAMING_LOGS_THRESHOLD: 10000
+      APP_STATS_THRESHOLD: 5
   - in_parallel:
     - task: open-asgs-for-credhub
       file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
@@ -1157,7 +1158,7 @@ jobs:
         environments/test/hermione/increase-doppler-vm-type-from-minimal-to-small.yml
         environments/test/hermione/scale-diego-cell-to-8.yml
   - task: bosh-deploy-cf-develop
-    attempts: 2
+    attempts: 1
     file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
     input_mapping:
       bbl-state: relint-envs
@@ -1192,6 +1193,7 @@ jobs:
       APP_PUSHABILITY_THRESHOLD: 10
       RECENT_LOGS_THRESHOLD: 10000
       STREAMING_LOGS_THRESHOLD: 10000
+      APP_STATS_THRESHOLD: 5
   - in_parallel:
     - task: open-asgs-for-credhub
       file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml


### PR DESCRIPTION
### WHAT is this change about?

* don't run the upgrade jobs two times as the second attempt is a BOSH no-op and will not measure anything meaningful
* configure stats check threshold (see https://github.com/cloudfoundry/uptimer/pull/115)

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have a downtime validation when upgrading the cf-deployment version.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/1176

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

N/A

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The "bosh-deploy-cf-develop" tasks in the "upgrade-deploy" and "experimental-deploy" jobs are green and produce meaningful uptimer reports.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

