### PR TITLE
Remove legacy_md5_buildpack_paths_enabled

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -950,7 +950,6 @@ instance_groups:
             encryption_key_0: "((cc_db_encryption_key))"
         staging_upload_user: staging_user
         staging_upload_password: "((cc_staging_upload_password))"
-        legacy_md5_buildpack_paths_enabled: false
         temporary_use_logcache: true
         logcache:
           host: log-cache.service.cf.internal


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

> Remove `legacy_md5_buildpack_paths_enabled: false` from `cf-deployment.yml` as [CAPI 1.182.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.182.0) changed the default value for this property to `false`.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

> One line less in `cf-deployment.yml`...

### Please provide any contextual information.

> [PR #415](https://github.com/cloudfoundry/capi-release/pull/415) in capi-release.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES (the effective value was `false` for quite some time now)
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

> Not at all...

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

> n/a

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> I guess this is not required for this small change...
