### PR TITLE
Update tested and supported PostreSQL versions

### DIFF
--- a/texts/deployment-guide.md
+++ b/texts/deployment-guide.md
@@ -294,11 +294,11 @@ will require the use of the [`use-external-dbs.yml`](/operations/use-external-db
 
 The following databases are tested as part of the cf-deployment pipeline:
 - MySQL 8.0 using [pxc-release](https://github.com/cloudfoundry/pxc-release) as singleton and as Galera cluster
-- PostgreSQL 15 using [postgres-release](https://github.com/cloudfoundry/postgres-release)
+- PostgreSQL 16 using [postgres-release](https://github.com/cloudfoundry/postgres-release)
 - GCP Cloud SQL for MySQL 8.0 as external database
 
 The following databases should work (not tested):
-- PostgreSQL 12..14
+- PostgreSQL 12..15
 
 The following databases are not supported:
 - MySQL <8.0


### PR DESCRIPTION
- cf-deployment tests with PostgreSQL 16 sinse postgres-release v50
- versions that should work: 12..15  i.e. versions tested in the past that did not reach EOL

## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Added PostgreSQL 16 to documentation of tested and supported PostreSQL versions.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Fix outdated documentation.

### Please provide any contextual information.

https://github.com/cloudfoundry/postgres-release installs PostgreSQL 16 since v50 (if not otherwise configured).

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

cf-deployment is tested with PostgreSQL 16.
(actually since v40.11.0)

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

is just documentation

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

n/a