### PR TITLE
Switch Redis to Valkey

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -841,7 +841,7 @@ instance_groups:
   networks:
   - name: default
   jobs:
-  - name: redis
+  - name: valkey
     release: capi
   - name: cloud_controller_ng
     release: capi


### PR DESCRIPTION
### WHAT is this change about?

CAPI Release will switch Redis to Valkey as part of https://github.com/cloudfoundry/capi-release/pull/428 . This is due to Licensing changes in Redis.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [x] YES - please choose the category from below. Feel free to provide additional details.
- [ ] NO

> **Types of breaking changes:**
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest

### How should this change be described in cf-deployment release notes?

Replace Redis with Valkey in API instance group

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

```console
bosh ssh api/123

ps -ef | grep valkey

/var/vcap/packages/valkey/valkey-cli -s /var/vcap/data/valkey/valkey.sock

valkey /var/vcap/data/valkey/valkey.sock> keys *
1) "metrics:cc.requests.outstanding.gauge"
```
### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
