### PR TITLE
Bump cf-cli from v7 to v8

### DIFF
--- a/operations/enable-nfs-volume-service.yml
+++ b/operations/enable-nfs-volume-service.yml
@@ -64,7 +64,7 @@
         nfsbrokerpush:
           as: ignore-me
       release: nfs-volume
-    - name: cf-cli-7-linux
+    - name: cf-cli-8-linux
       release: cf-cli
     lifecycle: errand
     name: nfs-broker-push

--- a/operations/enable-smb-volume-service.yml
+++ b/operations/enable-smb-volume-service.yml
@@ -57,7 +57,7 @@
         syslog_url: ""
         username: smb-broker
       release: smb-volume
-    - name: cf-cli-7-linux
+    - name: cf-cli-8-linux
       release: cf-cli
     lifecycle: errand
     name: smb-broker-push


### PR DESCRIPTION

### WHAT is this change about?

Update cf cli for volume-services from v7 to v8

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Unable to consume latest changes in CAPI (https://github.com/cloudfoundry/capi-release/releases/tag/1.183.0) 

### Please provide any contextual information.

We need to use the latest CF cli so that is supports `CF_BROKER_PASSWORD`. The reason we had to do this change in the first place was because of CAPI JSON output that was updated as of `1.183.0`

PRs that are being blocked:

- https://github.com/cloudfoundry/smb-volume-release/pull/424
- https://github.com/cloudfoundry/nfs-volume-release/pull/972


### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Users can consume latest nfs-volume-release or smb-volume-release

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

I can deploy these opsfiles with latest release for volume-services

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
