### PR TITLE
Remove "open-asgs-for-credhub" task for hermione/experimental

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1199,15 +1199,6 @@ jobs:
       STREAMING_LOGS_THRESHOLD: 10000
       APP_STATS_THRESHOLD: 10
   - in_parallel:
-    - task: open-asgs-for-credhub
-      file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
-      input_mapping:
-        bbl-state: relint-envs
-      params:
-        BBL_STATE_DIR: environments/test/hermione/bbl-state
-        INSTANCE_GROUP_NAME: credhub
-        SYSTEM_DOMAIN: cf.hermione.env.wg-ard.ci.cloudfoundry.org
-        SECURITY_GROUP_NAME: credhub
     - task: open-asgs-for-uaa
       file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
       input_mapping:


### PR DESCRIPTION
### WHAT is this change about?

CF CredHub deployment has been disabled for this environment, so we don't need the task that opens application security groups to CredHub.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

See https://github.com/cloudfoundry/cf-deployment/pull/1179

### Please provide any contextual information.

See https://github.com/cloudfoundry/cf-deployment/pull/1179

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Job "experimental-deploy" is green: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-deploy

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

**Note**: Pipeline has already been updated with this change.