### PR TITLE
Update tcp-router to run serially

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1444,6 +1444,8 @@ instance_groups:
   instances: 2
   vm_type: minimal
   stemcell: default
+  update:
+    serial: true
   vm_extensions:
   - cf-tcp-router-network-properties
   networks:


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Updates tcp-router VMs to deploy serially, immediately after gorouters, so that they can finish being updated before the parallel block containing diego-cells run.

This allows us to ensure that all tcp-router related code + features are deployed and configured prior to updating diego-cells with code requesting those features via route-emitter.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

We want tcp-router to deploy serially immediately after gorouter. This is a required pre-requisite before we can have users do a one stage deploy with no downtime to turn on a future TCP-router feature.

### Please provide any contextual information.

Currently during a deploy the tcp-router is updated in parallel to diego-cells. We think it deploys in this order because TCP-router is often an after thought and it was just shoved in at the end. 

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Not sure if this is needed? But "tcp-router now updates serially after gorouter, instead of in parallel to diego-cells"

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

- Fresh deploys of cf-deployment succeed (we tested this)
- Upgrades to cf-deployment succeed with no change to uptimer results (we tested this)
- Upgrades to cf-deployment when using ops files for single AZ + fast deploys with downtime + danger succeed (we tested this)

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cloudfoundry/wg-app-runtime-platform-networking-approvers