### PR TITLE
Enable the "diego_cnb" flag for "luna"

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -643,6 +643,7 @@ jobs:
         BBL_STATE_DIR: environments/test/luna/bbl-state
         SYSTEM_DOMAIN: cf.luna.env.wg-ard.ci.cloudfoundry.org
         ENABLED_FEATURE_FLAGS: |
+          diego_cnb
           diego_docker
           task_creation
 


### PR DESCRIPTION
### WHAT is this change about?

Enable the Cloud Native Buildpack flag on the fresh/luna environment. The CNB CATs suite is already enabled.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have the CNB feature validated in the cf-deployment pipeline.

### Please provide any contextual information.

https://github.com/cloudfoundry/community/pull/591

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES (pipeline has already been uploaded to Concourse)
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Feature is already released, this is just a configuration / feature flag update for the test environment.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The "fresh-cats" job must be green.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
