### PR TITLE
Increase default NATS vm size to medium

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -328,7 +328,7 @@ instance_groups:
   - z1
   - z2
   instances: 2
-  vm_type: minimal
+  vm_type: medium
   stemcell: default
   networks:
   - name: default


### PR DESCRIPTION
### WHAT is this change about?

Due to the NATS v2 upgrade, the default size of the NATS vm should be increased.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Multiple customers have had issues with resource constraints since the NATS v2 upgrade.  Scaling up has been the recommendation for these issues.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [x] YES - `2. increases VM footprint of cf-deployment`
- [ ] NO

### How should this change be described in cf-deployment release notes?

Increase the default NATS vm size from `minimal` to `medium`

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

`bosh vms` should show `medium` under `VM Type` for the `nats` vm

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cloudfoundry/wg-app-runtime-platform 
