### PR TITLE
Fix NATs VM type for BOSH Lite

### DIFF
--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -106,6 +106,11 @@
   path: /instance_groups/name=credhub/instances
   value: 1
 
+# ----- Change VM type "medium" to "small" ------
+- type: replace
+  path: /instance_groups/name=nats/vm_type?
+  value: small
+
 # ----- Reduce default app memory to 256M ------
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_app_memory?


### PR DESCRIPTION
### WHAT is this change about?

Fix VM type for BOSH Lite. Known VM types are: "minimal", "small" and "small-highmem".

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Make sure that NATs v2 runs stable on BOSH Lite.

### Please provide any contextual information.

Initial PR is https://github.com/cloudfoundry/cf-deployment/pull/1196

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Increase the default NATS vm size from "minimal" to "medium" (on BOSH Lite, to "small").

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The "lite-deploy" job succeeds: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/lite-deploy

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
