### PR TITLE
stop skipping tls validation for fresh-deploy and skip decprecated do…

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -585,6 +585,7 @@ jobs:
         operations/test/speed-up-dynamic-asgs.yml
         operations/use-cflinuxfs4-compat.yml
         operations/smoke-tests-timeout-scale.yml
+        operations/stop-skipping-tls-validation.yml
       VARS_FILES: |
         environments/test/luna/deployment-name.yml
         environments/test/luna/network-name.yml
@@ -702,6 +703,7 @@ jobs:
         CONFIG_FILE_PATH: environments/test/luna/integration_config.json
         CAPTURE_LOGS: true
         RELINT_VERBOSE_AUTH: "true"
+        SKIP_REGEXP: "shows logs and metrics"
         NODES: 12
 
 - name: fresh-delete-deployment


### PR DESCRIPTION
 ## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

> Stop skipping TLS validation for fresh-deploy job and skip deprecated doppler tests.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

> Alana wants to have validation scenario with enabled certificate validation  

### Please provide any contextual information.

> 

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

> N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

> fresh-cats job with enabled TLS validation is green


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team! 

> 
