### PR TITLE
Enable TLS validation for "luna"/"fresh" env

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -558,6 +558,7 @@ jobs:
         environments/test/luna/rename-isolation-segment-network.yml
         environments/test/luna/change-postgres-max-connections.yml
         environments/test/luna/smoke-tests-timeout-scale.yml
+        environments/test/luna/use-operator-provided-router-tls-certificate.yml
   - task: bosh-deploy-cf
     file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
     input_mapping:
@@ -568,6 +569,8 @@ jobs:
     params:
       BBL_STATE_DIR: environments/test/luna/bbl-state
       SYSTEM_DOMAIN: cf.luna.env.wg-ard.ci.cloudfoundry.org
+      BOSHENV_iso_seg_tls_cert: ((luna-iso_lb))
+      BOSH_DEPLOY_ARGS: "--vars-env=BOSHENV"
       OPS_FILES: |
         operations/rename-network-and-deployment.yml
         operations/set-bbs-active-key.yml
@@ -586,6 +589,7 @@ jobs:
         operations/use-cflinuxfs4-compat.yml
         operations/smoke-tests-timeout-scale.yml
         operations/stop-skipping-tls-validation.yml
+        operations/use-operator-provided-router-tls-certificate.yml
       VARS_FILES: |
         environments/test/luna/deployment-name.yml
         environments/test/luna/network-name.yml


### PR DESCRIPTION
* isolation segment needs separate certificate for gorouter

### WHAT is this change about?

Enable TLS validation for "luna" environment.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have proper TLS validation for a cf-d setup with isolation segments.

### Please provide any contextual information.

https://github.com/cloudfoundry/relint-envs/blob/main/environments/test/luna/README.md

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Pipeline has already been uploaded and changes have been validated.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
