### PR TITLE
Enable NFS service for "luna"

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -590,6 +590,8 @@ jobs:
         operations/smoke-tests-timeout-scale.yml
         operations/stop-skipping-tls-validation.yml
         operations/use-operator-provided-router-tls-certificate.yml
+        operations/enable-nfs-volume-service.yml
+        operations/test/enable-nfs-test-server.yml
       VARS_FILES: |
         environments/test/luna/deployment-name.yml
         environments/test/luna/network-name.yml
@@ -651,6 +653,13 @@ jobs:
           diego_cnb
           diego_docker
           task_creation
+    - task: run-nfs-broker-push-errand
+      file: cf-deployment-concourse-tasks/run-errand/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+      params:
+        BBL_STATE_DIR: environments/test/bbr/bbl-state
+        ERRAND_NAME: nfs-broker-push
 
 - name: fresh-smoke-tests
   public: true


### PR DESCRIPTION
### WHAT is this change about?

Enable the NFS service for the "luna"/"fresh" environment.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have the NFS service validated.

### Please provide any contextual information.

Related CATs PR: https://github.com/cloudfoundry/cf-acceptance-tests/pull/1257
CATs config update: https://github.com/cloudfoundry/relint-envs/pull/46
⚠️ Prerequisite for this PR is a new nfs-volume-release with https://github.com/cloudfoundry/nfs-volume-release/pull/1038

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

"fresh-deploy" job must be green.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
