### PR TITLE
Fix(iaas support/bosh lite): Add medium VM type to cloud-config

### DIFF
--- a/iaas-support/bosh-lite/cloud-config.yml
+++ b/iaas-support/bosh-lite/cloud-config.yml
@@ -58,6 +58,7 @@ vm_types:
 - name: minimal
 - name: small
 - name: small-highmem
+- name: medium
 # Note: the "default" vm type is not used in cf-deployment.
 # it is included for compatibility with the bosh-deployment
 # cloud-config.


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

Adds a medium VM type to the cloud-config so that base CF-D can deploy successfully. VM types in BOSH Lite don't matter, so this is trivial to add.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana is unable to deploy CF-D onto a BOSH Lite.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/1202

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Add `medium` VM type to BOSH Lite cloud-config.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Run through the [BOSH Lite deploy steps](https://github.com/cloudfoundry/cf-deployment/blob/main/iaas-support/bosh-lite/README.md) and see it succeed.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@tcdowney