### PR TITLE
Fixing typo in disk_types help documentation

### DIFF
--- a/texts/on-cloud-configs.md
+++ b/texts/on-cloud-configs.md
@@ -83,7 +83,7 @@ disk_types:
   name: 5GB
 - disk_size: 10240
   name: 10GB
-- disk_size: 100240
+- disk_size: 102400
   name: 100GB
 ```
 


### PR DESCRIPTION
Reviewed the questions, but not going to answer each one  as this is a docs change.   the cloud configs are by defualt as follows, someone just put a zero in the wrong spot while writing the docs.

Checked the normal cloud configs my change matches the config.
```
- cloud_properties:
    type: thin
  disk_size: 102400
  name: "102400"
```