### PR TITLE
Change deployment name for NFS test server

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -559,6 +559,7 @@ jobs:
         environments/test/luna/change-postgres-max-connections.yml
         environments/test/luna/smoke-tests-timeout-scale.yml
         environments/test/luna/use-operator-provided-router-tls-certificate.yml
+        environments/test/luna/change-deployment-name-for-nfs-test-server.yml
   - task: bosh-deploy-cf
     file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
     input_mapping:
@@ -592,6 +593,7 @@ jobs:
         operations/use-operator-provided-router-tls-certificate.yml
         operations/enable-nfs-volume-service.yml
         operations/test/enable-nfs-test-server.yml
+        operations/change-deployment-name-for-nfs-test-server.yml
       VARS_FILES: |
         environments/test/luna/deployment-name.yml
         environments/test/luna/network-name.yml


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR


### WHAT is this change about?
This PR aim to change the [hardcoded](https://github.com/cloudfoundry/cf-deployment/blob/4167e5601b86ee9807c5a66a7845b40f8e613070/operations/test/enable-nfs-test-server.yml#L23) deployment name for luna environment. 

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have the NFS service validated.

### Please provide any contextual information.

This PR aim to change the [hardcoded](https://github.com/cloudfoundry/cf-deployment/blob/4167e5601b86ee9807c5a66a7845b40f8e613070/operations/test/enable-nfs-test-server.yml#L23) deployment name for luna environment. The NFS service for "luna" was enabled using this [PR](https://github.com/cloudfoundry/cf-deployment/pull/1204), however as a result of a hardcoded deployment name, the fresh cats job was failing. The respective ops file to fix this issue is also contributed to https://github.com/cloudfoundry/relint-envs/pull/48.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

1. This current opened PR must be merged after this [PR](https://github.com/cloudfoundry/relint-envs/pull/48).
2. The cf deployment concourse pipeline must be updated.
3. The final step when this PR is in, is to enable the NFS Test server for [luna environment](https://github.com/cloudfoundry/relint-envs/blob/36f6b8c62f292418c039a7606f6ba307043dc713/environments/test/luna/integration_config.json#L55).
4. "fresh-cats" job must be green.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
