### PR TITLE
Apply disable-v2-api ops file to all bbl envs used in cf-deployment validation

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -583,6 +583,7 @@ jobs:
         operations/addons/add-system-metrics-agent.yml
         operations/use-postgres.yml
         operations/experimental/enable-tls-cloud-controller-postgres.yml
+        operations/experimental/disable-v2-api.yml
         operations/change-postgres-max-connections.yml
         operations/use-internal-lookup-for-route-services.yml
         operations/enable-tls-on-file-server.yml
@@ -858,6 +859,7 @@ jobs:
         operations/use-external-dbs.yml
         operations/add-external-ips-for-cloud-sql-db.yml
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
+        operations/experimental/disable-v2-api.yml
         operations/set-cpu-weight.yml
         operations/enable-cpu-throttling.yml
         operations/use-external-blobstore.yml
@@ -913,6 +915,7 @@ jobs:
         operations/use-external-dbs.yml
         operations/add-external-ips-for-cloud-sql-db.yml
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
+        operations/experimental/disable-v2-api.yml
         operations/set-cpu-weight.yml
         operations/enable-cpu-throttling.yml
         operations/use-external-blobstore.yml
@@ -1146,6 +1149,7 @@ jobs:
         operations/experimental/enable-containerd-for-processes.yml
         operations/experimental/disable-cf-credhub.yml
         operations/experimental/disable-interpolate-service-bindings.yml
+        operations/experimental/disable-v2-api.yml
         operations/increase-doppler-vm-type-from-minimal-to-small.yml
         operations/scale-diego-cell-to-8.yml
         operations/test/speed-up-dynamic-asgs.yml
@@ -1413,6 +1417,7 @@ jobs:
           operations/bosh-lite.yml
           operations/use-internal-lookup-for-route-services.yml
           operations/experimental/colocate-smoke-tests-on-cc-worker.yml
+          operations/experimental/disable-v2-api.yml
         REGENERATE_CREDENTIALS: true
         BOSH_LITE: true
     - task: ensure-api-healthy
@@ -1566,6 +1571,7 @@ jobs:
         operations/backup-and-restore/enable-restore-nfs-broker.yml
         operations/enable-smb-volume-service.yml
         operations/backup-and-restore/enable-restore-smb-broker.yml
+        operations/experimental/disable-v2-api.yml
       REGENERATE_CREDENTIALS: true
   - in_parallel:
     - task: enable-docker
@@ -1730,6 +1736,7 @@ jobs:
         operations/windows2019-cell.yml
         operations/use-online-windows2019fs.yml
         operations/experimental/use-compiled-releases-windows.yml
+        operations/experimental/disable-v2-api.yml
         operations/use-internal-lookup-for-route-services.yml
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
         operations/addons/add-system-metrics-agent.yml
@@ -1974,6 +1981,7 @@ jobs:
           operations/use-postgres.yml
           operations/stop-skipping-tls-validation.yml
           operations/experimental/enable-tls-cloud-controller-postgres.yml
+          operations/experimental/disable-v2-api.yml
           operations/use-latest-stemcell.yml
         VARS_FILES: |
           environments/test/snape/syslog-vars.yml


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

> This change will  disable the v2 api for all bbl environments used in the cf deployment pipeline.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

> Alana want to safely remove CF API v2 from CAPI and cf-deployment.

### Please provide any contextual information.

> [Core of Phase 1 of RFC-00032: CF API v2 End of Life](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0032-cfapiv2-eol.md#proposal)

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

> _Something brief that conveys the change and is written with the **persona (Alana, Cody...)** in mind. See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

> _Please specify either bosh cli or cf cli commands for our team (and cf operators) to verify the changes._

> _Few examples_
> 1. For a PR with a new job in the manifest, `bosh instances` can verify the job is running after upgrade. You can provide additional commands to verify the job is running as specified.
> 2. For a PR with new variables, `bosh variables | grep <var-name>` command can verify the variable exists. This is the simplest varification but you can also provide additional commands to test that the variable holds the desired value.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
