### PR TITLE
Remediate automatic stemcell update race condition

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -793,6 +793,34 @@ jobs:
     - get: cf-deployment-develop
       passed: [upgrade-acquire-pool]
     - get: relint-envs
+  - task: check-stemcell-versions
+    config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: cloudfoundry/cf-deployment-concourse-tasks
+        inputs:
+          - name: cf-deployment-main
+          - name: cf-deployment-develop
+        run:
+          path: bash
+          dir: ""
+          args:
+            - -c
+            - |
+              #!/bin/bash
+              version_from_develop_branch="$(yq '.stemcells[] | select(.alias == "default") | .version' < cf-deployment-develop/cf-deployment.yml)"
+              version_from_main_branch="$(yq '.stemcells[] | select(.alias == "default") | .version' < cf-deployment-main/cf-deployment.yml)"
+
+              if [ "$version_from_develop_branch" = "$version_from_main_branch" ]; then
+                echo "Version ${version_from_develop_branch} from develop branch matches version from main branch. Proceeding."
+              else
+                echo "Version ${version_from_develop_branch} from develop branch differs from version ${version_from_main_branch} from main branch."
+                echo "This can happen if two stemcell versions are released at short intervals. Aborting."
+                echo "Solution: Release lock for this group manually and triggered it with the latest "develop" commit (that also contains the latest stemcell version)"
+                exit 1
+              fi
   - task: guarantee-no-existing-cf-deployment
     file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
     input_mapping:
@@ -1108,6 +1136,34 @@ jobs:
     - get: cf-deployment-develop
       passed: [ experimental-acquire-pool ]
     - get: relint-envs
+  - task: check-stemcell-versions
+    config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: cloudfoundry/cf-deployment-concourse-tasks
+        inputs:
+          - name: cf-deployment-main
+          - name: cf-deployment-develop
+        run:
+          path: bash
+          dir: ""
+          args:
+            - -c
+            - |
+              #!/bin/bash
+              version_from_develop_branch="$(yq '.stemcells[] | select(.alias == "default") | .version' < cf-deployment-develop/cf-deployment.yml)"
+              version_from_main_branch="$(yq '.stemcells[] | select(.alias == "default") | .version' < cf-deployment-main/cf-deployment.yml)"
+
+              if [ "$version_from_develop_branch" = "$version_from_main_branch" ]; then
+                echo "Version ${version_from_develop_branch} from develop branch matches version from main branch. Proceeding."
+              else
+                echo "Version ${version_from_develop_branch} from develop branch differs from version ${version_from_main_branch} from main branch."
+                echo "This can happen if two stemcell versions are released at short intervals. Aborting."
+                echo "Solution: Release lock for this group manually and triggered it with the latest "develop" commit (that also contains the latest stemcell version)"
+                exit 1
+              fi
   - task: guarantee-no-existing-cf-deployment
     file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
     input_mapping:


### PR DESCRIPTION

## Please take a moment to review the questions before submitting the PR


### WHAT is this change about?

Both jobs (expermintal/upgrade deploy) does a stemcell downgrade plus the regular changes from the "develop" branch. Due to the stemcell changes, VM updates take longer and the uptimer checks fail.


### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

N/A

### Please provide any contextual information.

We have an "automatic stemcell update race condition": 
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-deploy/builds/1663
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/upgrade-deploy/builds/1665

The cf-deployment manifest is already been updated automagically to v44.8.0 and it contains a new stemcell. As the "experimental-deploy" and "upgrade-deploy" jobs were hanging during release time, they are still seeing the old manifest version v44.7.0:
  stemcells:
```
+ - alias: default
+   os: ubuntu-jammy
+   version: '1.631'
- - alias: default
-   os: ubuntu-jammy
-   version: '1.639'
(...)
- manifest_version: v44.8.0
  
+ manifest_version: v44.7.0
Task 69938
```
Both jobs do a stemcell downgrade plus the regular changes from the "develop" branch. Due to the stemcell change, VM updates take longer and the uptimer checks fail.

We can detect this issue early on and fail the task and print a message how to resolve it: 
```
Solution: Release both locks manually and make sure the jobs are triggered with the latest "develop" commit 
(that also contains the latest stemcell version).
```
### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

When there is an automatic stemcell update release and any of these two jobs("experimental-deploy" or "upgrade-deploy") if are stuck/failed then this task should fail.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
