### PR TITLE
ci: Fix lint-cf-deployment-manifest job

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -486,7 +486,7 @@ jobs:
         args:
         - -exc
         - |
-          ruby -e "require 'yaml'; YAML.load_file('./cf-deployment-develop/cf-deployment.yml')"
+          ruby -e "require 'yaml'; YAML.load_file('./cf-deployment-develop/cf-deployment.yml', aliases: true)"
 
 - name: branch-freshness
   public: true


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

Add `aliases: true` to the `lint-cf-deployment-manifest` job in the cf-deployment pipeline. This allows that job to succeed when using the latest cf-d-c-t image, which now has ruby 3.1.x rather than ruby 2.7.x.

In ruby 2.7.x, the yaml library ran an unsafe load by default, which was okay with aliases, but in ruby 3.1.x it runs a safe load by default. We need to tell the safe load to explicitly allow aliases.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

None.

### Please provide any contextual information.

- https://github.com/cloudfoundry/cf-deployment-concourse-tasks/pull/197
- https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/lint-cf-deployment-manifest/builds/2075

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] N/A
- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

See the `lint-cf-deployment-manifest` job in the cf-deployment pipeline go green.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None