### PR TITLE
rollback windows stemcell

### DIFF
--- a/operations/windows2019-cell.yml
+++ b/operations/windows2019-cell.yml
@@ -182,7 +182,7 @@
   value:
     alias: windows2019
     os: windows2019
-    version: "2019.79"
+    version: "2019.78"
 - path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks/name=windows?
   type: replace
   value:


### PR DESCRIPTION


## Please take a moment to review the questions before submitting the PR


### WHAT is this change about?

Windows2019 v2019.79 seems to be broken. This PR aim to revert it to v2019.78

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana is unable to deploy windows stemcell using the latest bumped version.
### Please provide any contextual information.

https://cloudfoundry.slack.com/archives/C02PW344Y/p1731604558431539

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The windows-deploy job should be green.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
