### PR TITLE
Allow additional CIDR for the internal blobstore allow rules.

### DIFF
--- a/operations/community/README.md
+++ b/operations/community/README.md
@@ -13,5 +13,6 @@ Included in this directory is a collection of ops files submitted by the CF comm
 
 | File | Maintainer | Purpose |
 | --- | --- | --- |
+| [`add-blobstore-internal-network-allow-rule.yml`](add-blobstore-internal-network-allow-rule.yml) | [A2Geek](https://github.com/a2geek) | Allows an additonal internal network to the blobstore allow rules. |
 | [`change-metron-agent-deployment.yml`](change-metron-agent-deployment.yml) | [SAP SE](https://www.sap.com/) - submitted by [jsievers](https://github.com/jsievers) | Adds an ops file for changing the metron agent deployment property in all jobs |
 | [`use-haproxy.yml`](use-haproxy.yml) | [Stark & Wayne](https://www.starkandwayne.com/) - submitted by [rkoster](https://github.com/rkoster) | Adds https://github.com/cloudfoundry-incubator/haproxy-boshrelease as a load balancer for environments without IaaS provided load blancers. |

--- a/operations/community/add-blobstore-internal-network-allow-rule.yml
+++ b/operations/community/add-blobstore-internal-network-allow-rule.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /instance_groups/name=singleton-blobstore/jobs/name=blobstore/properties/blobstore/internal_access_rules?
+  value:
+  - "allow 10.0.0.0/8;"
+  - "allow 172.16.0.0/12;"
+  - "allow 192.168.0.0/16;"
+  - "allow ((blobstore_internal_access_network));"


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

> _Please describe the change._

Per ticket #1216. An ops file to add custom internal network to the singleton blobstore allow list.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

> _Understanding why this change is being made is fantastically helpful. Please do tell..._

I'm developing a CPI that uses LXD. If people try this out in a clustered environment, it is very possible that they will be using the Ubuntu fan. The fan uses 240.0.0.0/8 as the default overlay network ("Future Use" range). It is possible that other people/organizations have other subnets as well.

### Please provide any contextual information.

> _Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

#1216 

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

> _Something brief that conveys the change and is written with the **persona (Alana, Cody...)** in mind. See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

> _Please specify either bosh cli or cf cli commands for our team (and cf operators) to verify the changes._

> _Few examples_
> 1. For a PR with a new job in the manifest, `bosh instances` can verify the job is running after upgrade. You can provide additional commands to verify the job is running as specified.
> 2. For a PR with new variables, `bosh variables | grep <var-name>` command can verify the variable exists. This is the simplest varification but you can also provide additional commands to test that the variable holds the desired value.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
