### PR TITLE
Use generic stemcell versions task

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -793,6 +793,10 @@ jobs:
     - get: cf-deployment-develop
       passed: [upgrade-acquire-pool]
     - get: relint-envs
+  - task: check-stemcell-versions
+    file: runtime-ci/tasks/check-stemcell-versions/task.yml
+    params:
+      BRANCH_TO_COMPARE: develop
   - task: guarantee-no-existing-cf-deployment
     file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
     input_mapping:
@@ -1108,6 +1112,10 @@ jobs:
     - get: cf-deployment-develop
       passed: [ experimental-acquire-pool ]
     - get: relint-envs
+  - task: check-stemcell-versions
+    file: runtime-ci/tasks/check-stemcell-versions/task.yml
+    params:
+      BRANCH_TO_COMPARE: develop
   - task: guarantee-no-existing-cf-deployment
     file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
     input_mapping:
@@ -2155,7 +2163,7 @@ jobs:
     - get: cf-deployment-release-candidate
       passed: [bless-manifest]
   - task: check-stemcell-versions
-    file: runtime-ci/tasks/check-stemcell-versions-for-ship-it/task.yml
+    file: runtime-ci/tasks/check-stemcell-versions/task.yml
   - task: update-cf-deployment-manifest-version
     file: runtime-ci/tasks/record-cfd-version-in-manifest/task.yml
   - put: cf-deployment-main
@@ -2182,7 +2190,7 @@ jobs:
     - get: cf-deployment-release-candidate
       passed: [bless-manifest]
   - task: check-stemcell-versions
-    file: runtime-ci/tasks/check-stemcell-versions-for-ship-it/task.yml
+    file: runtime-ci/tasks/check-stemcell-versions/task.yml
   - task: update-cf-deployment-manifest-version
     file: runtime-ci/tasks/record-cfd-version-in-manifest/task.yml
   - put: cf-deployment-main
@@ -2209,7 +2217,7 @@ jobs:
     - get: cf-deployment-release-candidate
       passed: [bless-manifest]
   - task: check-stemcell-versions
-    file: runtime-ci/tasks/check-stemcell-versions-for-ship-it/task.yml
+    file: runtime-ci/tasks/check-stemcell-versions/task.yml
   - task: update-cf-deployment-manifest-version
     file: runtime-ci/tasks/record-cfd-version-in-manifest/task.yml
   - put: cf-deployment-main


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR



### WHAT is this change about?

A race condition occurs during the stemcell updates via the automatic "[fast-lane](https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/update-releases?group=update-linux-stemcell)" stemcell release. This pipeline validates new stemcell versions and automatically creates releases, such as, [v44.6.0](https://github.com/cloudfoundry/cf-deployment/releases/tag/v44.6.0).

After a release, this stemcell update is merged back from the "main" to the "develop" branch. If the cf-deployment pipeline validates older "develop" revisions (e.g. if previous builds failed and new "develop" commits didn't make it past the "acquire-lock" jobs), it can happen that CF is deployed from the "main" branch (with a new stemcell version) and then upgraded to "develop" (still with the old stemcell version).  A major symptom is that the uptimer reports too many "App pushability" and "Stats availability" failures because of this stemcell change, where VM updates take longer and uptime checks fail. This happen for the upgrade scenarios like the hermione or trelawney environments, where both of them, in this failed case, does a stemcell downgrade with regular changes from develop branch.

As a solution, with this PR we want to integrate the check stemcell version task at the beginning of these deploy jobs that would abort the builds early, if there is stemcell downgrade. Additionally, the check stemcell version task, which is used at the beginning of the ship-it-{minor, major, patch} jobs, is also refactored. By default, this task will compare the stemcell versions between the rc and main branches. For develop and main branch comparison, we have to pass the parameter.

### Please provide any contextual information.

https://github.com/cloudfoundry/runtime-ci/pull/450

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

> _Something brief that conveys the change and is written with the **persona (Alana, Cody...)** in mind. See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

When there is an automatic stemcell update release and any of these two jobs("experimental-deploy" or "upgrade-deploy") are stuck with old manifest version then this task should fail and as a solution, release the locks manually and make sure the jobs are triggered with the latest "develop" commits.


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
