### PR TITLE
Merge mapfs into nfs-volume-release

### DIFF
--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -73,8 +73,6 @@ opsReleases:
   repository: cloudfoundry-incubator/haproxy-boshrelease
   varsFiles: "environments/test/pre-dev/haproxy-vars.yml"
   skipSmokeTests: true
-- name: mapfs
-  repository: cloudfoundry/mapfs-release
 - name: nfs-volume
   repository: cloudfoundry/nfs-volume-release
 - name: smb-volume

--- a/operations/enable-nfs-volume-service.yml
+++ b/operations/enable-nfs-volume-service.yml
@@ -86,11 +86,6 @@
           server_key: ((nfsv3driver_cert.private_key))
     release: nfs-volume
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=mapfs?
-  value:
-    name: mapfs
-    release: mapfs
-- type: replace
   path: /variables/-
   value:
     name: nfs-broker-password
@@ -150,10 +145,3 @@
     sha1: 170faddc63497ae1000e3c3520bd379aa7b7f814
     url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=7.18.0
     version: 7.18.0
-- type: replace
-  path: /releases/name=mapfs?
-  value:
-    name: mapfs
-    sha1: 08616375070ca5196cb9119891e13bb94886fe7d
-    url: https://bosh.io/d/github.com/cloudfoundry/mapfs-release?v=1.18.0
-    version: 1.18.0


### PR DESCRIPTION

## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

As of nfs-volume-release 7.18.0, map-fs job is included when nfsv3driver job is turned on. No need for the extra release to carry the code for mapfs.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

As a developer, I'd like to consolidate my releases so that it consumes less resources and easier to manage

### Please provide any contextual information.

https://github.com/cloudfoundry/nfs-volume-release/pull/1046

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO


### How should this change be described in cf-deployment release notes?

> As a developer, I'd like to consolidate NFS-Volume-Release and Mapfs-Release into a single release so that it consumes less resources and easier to manage

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO (It removes depency on a bosh-release)

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Can be verified when running CATS with volume-services tag

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

