### PR TITLE
Replace disable-v2-api it with an empty ops interpolate test

### DIFF
--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -23,10 +23,7 @@ disable-logs-in-firehose.yml: {}
 disable-logs-in-firehose-windows2019.yml:
   ops:
   - ../windows2019-cell.yml
-disable-v2-api.yml:
-  pathvalidator:
-    path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/temporary_enable_v2
-    expectedvalue: false
+disable-v2-api.yml: {}
 enable-app-log-rate-limiting.yml:
   vars:
   - app_log_rate_limit=100


### PR DESCRIPTION

### WHAT is this change about?

After removing the experimental ops file /operations/experimental/disable-v2-api.yml the unit tests started to fail.
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/unit-test-golang-tests/builds/2360

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

> _Understanding why this change is being made is fantastically helpful. Please do tell..._

### Please provide any contextual information.

unit tests are failing: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/unit-test-golang-tests/builds/2360 

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO


### Please provide Acceptance Criteria for this change?

unit-test-golang-tests in cf-deployment concourse pipeline should be green.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
