### PR TITLE
Remove PostgreSQL 12 from supported DBs

### DIFF
--- a/texts/deployment-guide.md
+++ b/texts/deployment-guide.md
@@ -298,11 +298,11 @@ The following databases are tested as part of the cf-deployment pipeline:
 - GCP Cloud SQL for MySQL 8.0 as external database
 
 The following databases should work (not tested):
-- PostgreSQL 12..15
+- PostgreSQL 13..15
 
 The following databases are not supported:
 - MySQL <8.0
-- PostgreSQL <12
+- PostgreSQL <13
 - MariaDB
 - any other database system
 


### PR DESCRIPTION
Postgres 12 is out of maintenance: https://www.postgresql.org/support/versioning/

### WHAT is this change about?

Documentation of supported PostgreSQL versions. PostgreSQL 12 is out of support.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

### Please provide any contextual information.

https://cloudfoundry.slack.com/archives/C033ALST37V/p1741703433565859

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Removed PostgreSQL 12 from the list of supported databases for CF.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

n/a

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@johha 
