### PR TITLE
Trigger cf-deployment pipeline only once daily

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -384,8 +384,9 @@ jobs:
   serial: true
   public: true
   plan:
-  - get: cf-deployment-develop
+  - get: daily
     trigger: true
+  - get: cf-deployment-develop
   - task: unit-test-ops-files
     config:
       platform: linux
@@ -425,8 +426,9 @@ jobs:
   serial: true
   public: true
   plan:
-  - get: cf-deployment-develop
+  - get: daily
     trigger: true
+  - get: cf-deployment-develop
   - task: unit-test-golang-ops-files
     config:
       platform: linux
@@ -449,8 +451,9 @@ jobs:
   serial: true
   public: true
   plan:
-  - get: cf-deployment-develop
+  - get: daily
     trigger: true
+  - get: cf-deployment-develop
   - get: runtime-ci
   - task: unit-test-update-releases-coverage
     config:
@@ -470,8 +473,9 @@ jobs:
   serial: false
   public: true
   plan:
-  - get: cf-deployment-develop
+  - get: daily
     trigger: true
+  - get: cf-deployment-develop
   - task: lint-manifest
     config:
       platform: linux


### PR DESCRIPTION
### WHAT is this change about?

Proposal for cost saving efforts: Trigger the pipeline only once per day and validate all new commits in one batch. If there are no new commits on the "develop" branch, only the first pipeline jobs will be triggered.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to reduce the cost of the ARD WG.

### Please provide any contextual information.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

N/A

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The "cf-deployment" pipeline runs once per day and validates all new commits on the "develop" branch.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
