### PR TITLE
cleanup time format property

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -515,9 +515,6 @@ instance_groups:
         app_metric_exclusion_filter:
         - absolute_entitlement
         - absolute_usage
-      logging:
-        format:
-          timestamp: "rfc3339"
   - name: silk-controller
     release: silk
     properties:
@@ -563,9 +560,6 @@ instance_groups:
         ca_cert: "((loggregator_tls_agent.ca))"
         cert: "((loggregator_tls_agent.certificate))"
         key: "((loggregator_tls_agent.private_key))"
-      logging:
-        format:
-          timestamp: "rfc3339"
   - name: loggr-udp-forwarder
     release: loggregator-agent
     properties: &loggr-udp-forwarder-properties
@@ -1065,9 +1059,6 @@ instance_groups:
       bpm:
         enabled: true
       enable_consul_service_registration: false
-      logging:
-        format:
-          timestamp: "rfc3339"
       loggregator: *diego_loggregator_client_properties
   - name: routing-api
     release: routing
@@ -1243,9 +1234,6 @@ instance_groups:
           skip_consul_lock: true
       enable_consul_service_registration: false
       loggregator: *diego_loggregator_client_properties
-      logging:
-        format:
-          timestamp: "rfc3339"
   - name: cloud_controller_clock
     release: capi
     properties:
@@ -1354,9 +1342,6 @@ instance_groups:
           client_private_key: ((ssh_proxy_backends_tls.private_key))
       enable_consul_service_registration: false
       loggregator: *diego_loggregator_client_properties
-      logging:
-        format:
-          timestamp: "rfc3339"
   - name: loggr-syslog-binding-cache
     release: loggregator-agent
     properties:
@@ -1665,9 +1650,6 @@ instance_groups:
         ca_cert: "((diego_rep_agent_v2.ca))"
         cert: "((diego_rep_agent_v2.certificate))"
         key: "((diego_rep_agent_v2.private_key))"
-      logging:
-        format:
-          timestamp: "rfc3339"
   - name: cfdot
     release: diego
     properties:
@@ -1696,9 +1678,6 @@ instance_groups:
       uaa:
         ca_cert: "((uaa_ssl.ca))"
         client_secret: "((uaa_clients_tcp_emitter_secret))"
-      logging:
-        format:
-          timestamp: "rfc3339"
       internal_routes:
         enabled: true
   - name: garden-cni

--- a/operations/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/add-persistent-isolation-segment-diego-cell.yml
@@ -98,9 +98,6 @@
           ca_cert: "((diego_rep_agent_v2.ca))"
           cert: "((diego_rep_agent_v2.certificate))"
           key: "((diego_rep_agent_v2.private_key))"
-        logging:
-          format:
-            timestamp: "rfc3339"
     - name: cfdot
       release: diego
       properties:
@@ -132,9 +129,6 @@
                 client_key: "((nats_client_cert.private_key))"
         internal_routes:
           enabled: true
-        logging:
-          format:
-            timestamp: "rfc3339"
         tcp:
           enabled: true
           enable_tls: true

--- a/operations/bosh-lite.yml
+++ b/operations/bosh-lite.yml
@@ -56,9 +56,6 @@
           client_certificate: ((ssh_proxy_backends_tls.certificate))
           client_private_key: ((ssh_proxy_backends_tls.private_key))
       enable_consul_service_registration: false
-      logging:
-        format:
-          timestamp: "rfc3339"
       loggregator: &diego_loggregator_client_properties
         ca_cert: "((loggregator_tls_agent.ca))"
         cert: "((loggregator_tls_agent.certificate))"

--- a/operations/windows2019-cell.yml
+++ b/operations/windows2019-cell.yml
@@ -54,9 +54,6 @@
             - windows:oci:///C:/var/vcap/packages/windows2019fs
         enable_consul_service_registration: false
         enable_declarative_healthcheck: true
-        logging:
-          format:
-            timestamp: rfc3339
         loggregator:
           app_metric_exclusion_filter:
           - absolute_entitlement
@@ -88,9 +85,6 @@
                 enabled: true
         internal_routes:
           enabled: true
-        logging:
-          format:
-            timestamp: rfc3339
         loggregator:
           ca_cert: ((loggregator_tls_agent.ca))
           cert: ((loggregator_tls_agent.certificate))


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Removing the obsolete logging timestamp format property

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana no need to manage the logging timestamp format property as it is always rfc3339.

### Please provide any contextual information.

https://github.com/cloudfoundry/diego-release/pull/1016

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Removing the obsolete logging timestamp format property

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

NA. Just removing the logging timestamp format property

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@cloudfoundry/wg-app-runtime-platform-diego-approvers 
