### PR TITLE
Remove old property: bpm.enabled in diego-release

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -475,8 +475,6 @@ instance_groups:
   - name: bbs
     release: diego
     properties:
-      bpm:
-        enabled: true
       diego:
         bbs:
           active_key_label: key-2016-06
@@ -540,8 +538,6 @@ instance_groups:
   - name: locket
     release: diego
     properties:
-      bpm:
-        enabled: true
       tls:
         ca_cert: "((diego_locket_server.ca))"
         cert: "((diego_locket_server.certificate))"
@@ -1062,8 +1058,6 @@ instance_groups:
   - name: file_server
     release: diego
     properties:
-      bpm:
-        enabled: true
       enable_consul_service_registration: false
       logging:
         format:
@@ -1224,8 +1218,6 @@ instance_groups:
   - name: auctioneer
     release: diego
     properties:
-      bpm:
-        enabled: true
       diego:
         auctioneer:
           bbs: &diego_bbs_client_properties
@@ -1334,8 +1326,6 @@ instance_groups:
   - name: ssh_proxy
     release: diego
     properties:
-      bpm:
-        enabled: true
       diego:
         ssh_proxy:
           enable_cf_auth: true
@@ -1632,8 +1622,6 @@ instance_groups:
   - name: rep
     release: diego
     properties:
-      bpm:
-        enabled: true
       diego:
         executor:
           instance_identity_ca_cert: ((diego_instance_identity_ca.certificate))
@@ -1675,8 +1663,6 @@ instance_groups:
   - name: route_emitter
     release: diego
     properties:
-      bpm:
-        enabled: true
       loggregator: *diego_loggregator_client_properties
       diego:
         route_emitter:

--- a/operations/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/add-persistent-isolation-segment-diego-cell.yml
@@ -52,8 +52,6 @@
     - name: rep
       release: diego
       properties:
-        bpm:
-          enabled: true
         diego:
           executor:
             instance_identity_ca_cert: ((diego_instance_identity_ca.certificate))
@@ -111,8 +109,6 @@
     - name: route_emitter
       release: diego
       properties:
-        bpm:
-          enabled: true
         loggregator:
           use_v2_api: true
           ca_cert: "((loggregator_tls_agent.ca))"


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Removing the unused `bpm.enabled: true` property.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana is no need to manage the bpm.enabled property as it is always true.

### Please provide any contextual information.

https://github.com/cloudfoundry/diego-release/pull/1020

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Alana is no need to manage the bpm.enabled property as it is always true.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

NA. Just removing the unused `bpm.enabled: true` property. 

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cloudfoundry/wg-app-runtime-platform-diego-approvers
