### PR TITLE
Cost saving: Trigger IPv6 and Noble validation only once per day

### DIFF
--- a/ci/pipelines/ipv6-dual-stack-validation.yml
+++ b/ci/pipelines/ipv6-dual-stack-validation.yml
@@ -4,6 +4,7 @@ jobs:
       - in_parallel:
           steps:
             - get: cf-deployment
+            - get: daily
               trigger: true
             - params:
                 acquire: true
@@ -177,6 +178,11 @@ jobs:
     plan:
       - get: ipv6-pool
 resources:
+  - name: daily
+    type: time
+    icon: clock-outline
+    source:
+      interval: 24h
   - icon: github
     name: cf-acceptance-tests-rc
     source:

--- a/ci/pipelines/noble-stemcell.yml
+++ b/ci/pipelines/noble-stemcell.yml
@@ -4,8 +4,8 @@ jobs:
       - in_parallel:
           steps:
             - get: noble-stemcell
-              trigger: true
             - get: cf-deployment
+            - get: daily
               trigger: true
             - params:
                 acquire: true
@@ -192,6 +192,11 @@ jobs:
     plan:
       - get: stable-pool
 resources:
+  - name: daily
+    type: time
+    icon: clock-outline
+    source:
+      interval: 24h
   - icon: dna
     name: noble-stemcell
     source:


### PR DESCRIPTION
### WHAT is this change about?

Cost saving: Trigger validation pipelines only once per day.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to reduce the infrastructure cost.

### Please provide any contextual information.

https://github.com/cloudfoundry/community/issues/1186

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

N/A

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Pipelines run only once per day:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/ipv6-dual-stack-validation
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/noble-stemcell-validation

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
