### PR TITLE
s3 custom blobstore ops

### DIFF
--- a/operations/use-s3-custom-blobstore.yml
+++ b/operations/use-s3-custom-blobstore.yml
@@ -1,0 +1,66 @@
+---
+## api / cloud_controller_ng
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/fog_connection
+  error: "Please apply 'use-external-blobstore.yml' before applying 'use-s3-blobstore.yml'."
+  value: &blobstore-properties
+    # https://docs.cloudfoundry.org/deploying/common/cc-blobstore-config.html#fog-s3-other
+    provider: AWS
+    aws_access_key_id: ((blobstore_access_key_id))
+    aws_secret_access_key: ((blobstore_secret_access_key))
+    region: ((aws_region))
+    aws_signature_version: ((blobstore_signature_version))
+    endpoint: ((blobstore_endpoint))
+    path_style: ((blobstore_path_style))
+
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/fog_connection
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/fog_connection
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/fog_connection
+  value: *blobstore-properties
+
+
+## cc-worker / cloud_controller_worker
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/fog_connection
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/fog_connection
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/fog_connection
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/fog_connection
+  value: *blobstore-properties
+
+
+## scheduler / cloud_controller_clock
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/fog_connection
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/fog_connection
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/fog_connection
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/fog_connection
+  value: *blobstore-properties


### PR DESCRIPTION
### WHAT is this change about?

Implement a new ops-file, `operations/use-s3-custom-blobstore.yml`, which adds an ops stanza that lets operators select and configure any S3-compatible blobstore (per the Fog S3 “other” settings in Cloud Foundry docs).

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to deploy CF on an environment with the private S3 compatible Blobstore (e.g. MinIO), but she needs to configure: `endpoint`, `aws_signature_version` and `path_style`

### Please provide any contextual information.

* Adds `operations/use-s3-custom-blobstore.yml`
* References official S3-other configuration docs: [fog-s3-other](https://docs.cloudfoundry.org/deploying/common/cc-blobstore-config.html#fog-s3-other)
* No existing PRs depend on this; it’s purely additive.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

* [ ] YES
* [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

* [ ] YES
* [x] NO

### How should this change be described in cf-deployment release notes?

We can now use `operations/use-s3-custom-blobstore.yml` to point any S3-compatible blobstore.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

* [ ] YES
* [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

* [ ] experimental feature/component
* [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

```bash
bosh interpolate cf-deployment.yml \
-o operations/use-external-blobstore.yml \
-o operations/use-s3-custom-blobstore.yml \
-v blobstore_access_key_id="my-access-key-id" \
-v blobstore_secret_access_key="my-access-key" \
-v aws_region="default" \
-v blobstore_signature_version="2" \
-v blobstore_endpoint="https://my-blobstore" \
-v blobstore_path_style=true
```

Verify settings in the rendered manifest (`bosh interpolate`) match the provided values.

### What is the level of urgency for publishing this change?

* [ ] **Urgent** - unblocks current or future work
* [x] **Slightly Less than Urgent**

