### PR TITLE
Revert windows stemcell v2019.88.32

### DIFF
--- a/operations/windows2019-cell.yml
+++ b/operations/windows2019-cell.yml
@@ -175,7 +175,7 @@
   value:
     alias: windows2019
     os: windows2019
-    version: 2019.88.32
+    version: 2019.88
 - path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks/name=windows?
   type: replace
   value:


### PR DESCRIPTION
### WHAT is this change about?

windows2019.88.32 is not found on Bosh.io This PR aim to revert it to v2019.88 to unblock the pipeline.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana is unable to deploy windows stemcell using the latest bumped version as it is not found on bosh.io.


### Please provide any contextual information.

https://cloudfoundry.slack.com/archives/C02PW344Y/p1753682617062539

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The [windows-deploy](https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/windows-deploy/builds/2285) job should be green

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
