### PR TITLE
cleanup time format property for garden

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1626,9 +1626,6 @@ instance_groups:
         network_plugin: /var/vcap/packages/runc-cni/bin/garden-external-networker
         network_plugin_extra_args:
         - --configFile=/var/vcap/jobs/garden-cni/config/adapter.json
-      logging:
-        format:
-          timestamp: "rfc3339"
   - name: rep
     release: diego
     properties:


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Removing the obsolete logging timestamp format property

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana no need to manage the logging timestamp format property as it is always rfc3339.

### Please provide any contextual information.

https://github.com/cloudfoundry/garden-runc-release/pull/377

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Alana no need to manage the logging timestamp format property as it is always rfc3339.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

NA. Just removing the logging timestamp format property

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cloudfoundry/wg-app-runtime-platform-diego-approvers 
