### PR TITLE
Remove old property: destroy_containers_on_start

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1594,7 +1594,6 @@ instance_groups:
         cleanup_process_dirs_on_wait: true
         debug_listen_address: 127.0.0.1:17019
         default_container_grace_time: 0
-        destroy_containers_on_start: true
         deny_networks:
         - 0.0.0.0/0
         network_plugin: /var/vcap/packages/runc-cni/bin/garden-external-networker

--- a/operations/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/add-persistent-isolation-segment-diego-cell.yml
@@ -40,7 +40,6 @@
           cleanup_process_dirs_on_wait: true
           debug_listen_address: 127.0.0.1:17019
           default_container_grace_time: 0
-          destroy_containers_on_start: true
           deny_networks:
           - 0.0.0.0/0
           network_plugin: /var/vcap/packages/runc-cni/bin/garden-external-networker

--- a/operations/windows2019-cell.yml
+++ b/operations/windows2019-cell.yml
@@ -23,7 +23,6 @@
     - name: garden-windows
       properties:
         garden:
-          destroy_containers_on_start: true
           image_plugin: /var/vcap/packages/groot/groot.exe
           image_plugin_extra_args:
           - --driver-store=/var/vcap/data/groot


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?


Removing the destroy_containers_on_start: true property as it will be set as true by default. 

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana is no need to manage the destroy_containers_on_start property as it is always true.

### Please provide any contextual information.


https://github.com/cloudfoundry/garden-runc-release/pull/381

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
-  [x] NO


### How should this change be described in cf-deployment release notes?

Alana is no need to manage the destroy_containers_on_start property as it is always true.


### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

NA. Just removing the unused require_tls property.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
@cloudfoundry/wg-app-runtime-platform-diego-approvers