### PR TITLE
Fix "envoy-nginx-proxy" update job

### DIFF
--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -117,6 +117,7 @@ opsReleases:
   repository: cloudfoundry-incubator/envoy-nginx-release
   requiredOpsFiles:
   - operations/use-online-windows2019fs.yml
+  prependOpsFileToList: true
 - name: otel-collector
   repository: cloudfoundry/otel-collector-release
   varsFiles: "operations/experimental/example-vars-files/vars-override-otel-collector-exporters.yml"

--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -13430,6 +13430,7 @@ jobs:
             operations/use-online-windows2019fs.yml
           REGENERATE_CREDENTIALS: false
           BOSH_DEPLOY_ARGS: --parallel 50
+          PREPEND_OPS_FILE_TO_LIST: true
       - task: ensure-api-healthy
         file: runtime-ci/tasks/ensure-api-healthy/task.yml
         input_mapping:


### PR DESCRIPTION
### WHAT is this change about?

Fix failing update job: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/update-releases/jobs/update-envoy-nginx/builds/40

The release has been moved from "operations/experimental/enable-nginx-routing-integrity-windows2019.yml" to "operations/windows2019-cell.yml", so we don't need to list the latter ops file anymore.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have automatic version updates for the "envoy-nginx-proxy" BOSH release.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/pull/1281

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

N/A

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The "update-release" job works again: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/update-releases/jobs/update-envoy-nginx

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
