### PR TITLE
Use "spot" instances for luna/fresh

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -601,6 +601,7 @@ jobs:
         operations/enable-nfs-volume-service.yml
         operations/test/enable-nfs-test-server.yml
         operations/change-deployment-name-for-nfs-test-server.yml
+        operations/experimental/use-spot-instances.yml
       VARS_FILES: |
         environments/test/luna/deployment-name.yml
         environments/test/luna/network-name.yml


### PR DESCRIPTION
### WHAT is this change about?

Cost saving: Use "spot" VMs on luna/fresh. Pipeline has already been updated.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have an up to 91% discount for VM provisioning.

### Please provide any contextual information.

https://cloud.google.com/compute/docs/instances/spot

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The luna/fresh deployment and CATs validation should show no problems caused by stopped/deprovisioned VMs for about a month.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
