### PR TITLE
Add missing EKU values to end certs

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2047,6 +2047,8 @@ variables:
     common_name: blobstore.service.cf.internal
     alternative_names:
     - blobstore.service.cf.internal
+    extended_key_usage:
+    - server_auth
 - name: blobstore_public
   type: certificate
   update_mode: converge
@@ -2055,6 +2057,8 @@ variables:
     alternative_names:
     - "blobstore.((system_domain))"
     ca: service_cf_internal_ca
+    extended_key_usage:
+    - server_auth
 - name: diego_auctioneer_client
   type: certificate
   update_mode: converge
@@ -2257,6 +2261,8 @@ variables:
     - log-cache
     - log-cache.((system_domain))
     - "*.log-cache.((system_domain))"
+    extended_key_usage:
+    - server_auth
 - name: log_cache_proxy_tls
   type: certificate
   update_mode: converge
@@ -2265,6 +2271,9 @@ variables:
     common_name: localhost
     alternative_names:
     - localhost
+    extended_key_usage:
+    - client_auth
+    - server_auth
 - name: syslog_agent_log_cache_tls
   type: certificate
   update_mode: converge
@@ -2298,6 +2307,8 @@ variables:
     alternative_names:
     - "((system_domain))"
     - "*.((system_domain))"
+    extended_key_usage:
+    - server_auth
 - name: routing_api_ca
   type: certificate
   options:
@@ -2335,6 +2346,8 @@ variables:
     common_name: uaa.service.cf.internal
     alternative_names:
     - uaa.service.cf.internal
+    extended_key_usage:
+    - server_auth
 - name: uaa_login_saml
   type: certificate
   update_mode: converge
@@ -2370,6 +2383,8 @@ variables:
     alternative_names:
     - "api.((system_domain))"
     - cloud-controller-ng.service.cf.internal
+    extended_key_usage:
+    - server_auth
 - name: cc_bridge_tps
   type: certificate
   update_mode: converge
@@ -2459,6 +2474,8 @@ variables:
     common_name: gorouter_lb_health_tls
     alternative_names:
     - gorouter.service.cf.internal
+    extended_key_usage:
+    - server_auth
 - name: tcp_router_backend_tls
   type: certificate
   options:
@@ -2475,6 +2492,8 @@ variables:
     common_name: tcp_router_lb_health_tls
     alternative_names:
     - tcp-router.service.cf.internal
+    extended_key_usage:
+    - server_auth
 - name: credhub_ca
   type: certificate
   options:
@@ -2488,6 +2507,8 @@ variables:
     alternative_names:
     - credhub.service.cf.internal
     - credhub.((system_domain))
+    extended_key_usage:
+    - server_auth
 - name: ssh_proxy_backends_tls
   type: certificate
   options:
@@ -2526,6 +2547,8 @@ variables:
     common_name: sql-db.service.cf.internal
     alternative_names:
     - sql-db.service.cf.internal
+    extended_key_usage:
+    - server_auth
 
 - name: loggregator_rlp_gateway_tls
   type: certificate
@@ -2536,6 +2559,8 @@ variables:
     alternative_names:
     - log-stream.((system_domain))
     - log-api.service.cf.internal
+    extended_key_usage:
+    - server_auth
 
 - name: loggregator_trafficcontroller_tls
   type: certificate
@@ -2546,6 +2571,8 @@ variables:
     alternative_names:
     - doppler.((system_domain))
     - log-api.service.cf.internal
+    extended_key_usage:
+    - server_auth
 
 - name: metric_scraper_ca
   type: certificate

--- a/operations/test/add-oidc-provider.yml
+++ b/operations/test/add-oidc-provider.yml
@@ -203,3 +203,5 @@
       common_name: uaa-oidc.service.cf.internal
       alternative_names:
       - uaa-oidc.service.cf.internal
+      extended_key_usage:
+      - server_auth

--- a/operations/test/enable-nfs-test-ldapserver.yml
+++ b/operations/test/enable-nfs-test-ldapserver.yml
@@ -46,3 +46,5 @@
       common_name: nfstestldapserver.service.cf.internal
       alternative_names:
       - nfstestldapserver.service.cf.internal
+      extended_key_usage:
+      - server_auth

--- a/operations/use-haproxy.yml
+++ b/operations/use-haproxy.yml
@@ -52,4 +52,6 @@
       - '*.((system_domain))'
       ca: haproxy_ca
       common_name: haproxySSL
+      extended_key_usage:
+      - server_auth
     type: certificate

--- a/operations/use-metric-store.yml
+++ b/operations/use-metric-store.yml
@@ -227,6 +227,8 @@
       - '*.metric-store.((system_domain))'
       ca: service_cf_internal_ca
       common_name: metric-store
+      extended_key_usage:
+      - server_auth
     type: certificate
 - type: replace
   path: /variables/name=metric_store_internode?
@@ -250,6 +252,8 @@
       - localhost
       ca: metric_store_ca
       common_name: localhost
+      extended_key_usage:
+      - server_auth
     type: certificate
     update_mode: converge
 - type: replace
@@ -261,6 +265,8 @@
       - metric-store
       ca: metric_scraper_ca
       common_name: metric-store
+      extended_key_usage:
+      - server_auth
     type: certificate
     update_mode: converge
 - type: replace
@@ -272,5 +278,7 @@
       - metric-store-client
       ca: metric_scraper_ca
       common_name: metric-store-client
+      extended_key_usage:
+      - client_auth
     type: certificate
     update_mode: converge


### PR DESCRIPTION
### WHAT is this change about?

Add missing EKU values for leaf certificates in order to be compliant with x509 standards.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to make sure that the end certificates are compliant and should have correct EKU values where if not present it might behave unexpected behavior with strict security environments or clients.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/1287

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [X] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

No downtime and Vanilla CF should deploy without any issue.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
