### PR TITLE
Add Jammy stemcell validation pipeline

### DIFF
--- a/ci/pipelines/jammy-stemcell.md
+++ b/ci/pipelines/jammy-stemcell.md
@@ -1,0 +1,15 @@
+# jammy-stemcell
+
+Test cf-d on the Ubuntu Jammy stemcell.
+
+## Triggers
+
+This pipeline is automatically triggered when new Jammy stemcells are published to https://bosh.io/stemcells/#ubuntu-jammy repository, or when a cf-d commit passes through the cf-deployment CI to be promoted to the `release-candidate` branch.
+
+## Cleanup
+
+If the pipeline succeeds, then it will clean up the CF BOSH deployment after itself.
+
+## Pipeline Management
+
+This pipeline is managed directly by the `ci/pipelines/jammy-stemcell.yml` file and the `ci/configure` script. To update the pipeline, run `ci/configure jammy-stemcell`.

--- a/ci/pipelines/jammy-stemcell.yml
+++ b/ci/pipelines/jammy-stemcell.yml
@@ -1,0 +1,241 @@
+jobs:
+  - name: stable-acquire-pool
+    plan:
+      - in_parallel:
+          steps:
+            - get: jammy-stemcell
+            - get: cf-deployment
+            - get: daily
+              trigger: true
+            - params:
+                acquire: true
+              put: stable-pool
+        timeout: 4h
+    serial: true
+  - name: deploy-cf
+    plan:
+      - in_parallel:
+          steps:
+            - get: stable-pool
+              passed:
+                - stable-acquire-pool
+              trigger: true
+            - get: jammy-stemcell
+              passed:
+                - stable-acquire-pool
+            - get: cf-deployment
+              passed:
+                - stable-acquire-pool
+            - get: cf-deployment-concourse-tasks
+            - get: runtime-ci
+            - get: relint-envs
+      - file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+        params:
+          BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+          IGNORE_ERRORS: "true"
+        task: guarantee-no-existing-cf-deployment
+      - file: runtime-ci/tasks/bosh-upload-stemcell/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          stemcell: jammy-stemcell
+        params:
+          BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+        task: upload-jammy-stemcell
+      - file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          ops-files: cf-deployment
+        params:
+          BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+          OPS_FILES: |
+            operations/stop-skipping-tls-validation.yml
+            operations/use-jammy-stemcell.yml
+            operations/use-internal-lookup-for-route-services.yml
+            operations/experimental/colocate-smoke-tests-on-cc-worker.yml
+            operations/use-postgres.yml
+          SYSTEM_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org
+          SKIP_STEMCELL_UPLOAD: true
+        task: deploy-cf
+      - in_parallel:
+          steps:
+            - file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
+              input_mapping:
+                bbl-state: relint-envs
+              params:
+                BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+                INSTANCE_GROUP_NAME: credhub
+                SECURITY_GROUP_NAME: credhub
+                SYSTEM_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org
+              task: open-asgs-for-credhub
+            - file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
+              input_mapping:
+                bbl-state: relint-envs
+              params:
+                BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+                INSTANCE_GROUP_NAME: uaa
+                SECURITY_GROUP_NAME: uaa
+                SYSTEM_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org
+              task: open-asgs-for-uaa
+            - file: cf-deployment-concourse-tasks/set-feature-flags/task.yml
+              input_mapping:
+                bbl-state: relint-envs
+              params:
+                BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+                ENABLED_FEATURE_FLAGS: |
+                  diego_docker
+                  task_creation
+                  service_instance_sharing
+                SYSTEM_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org
+              task: enable-docker-and-tasks
+    public: true
+    serial: true
+    serial_groups:
+      - stable-smokes
+      - stable-cats
+  - name: run-smoke-tests
+    plan:
+      - do:
+          - get: stable-pool
+            passed:
+              - deploy-cf
+            trigger: true
+          - in_parallel:
+              steps:
+                - get: relint-envs
+                - get: cf-deployment-concourse-tasks
+      - file: cf-deployment-concourse-tasks/run-errand/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+        params:
+          BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+          ERRAND_NAME: smoke_tests
+          INSTANCE: cc-worker/first
+        task: bosh-run-errand-smoke-tests
+    public: true
+    serial: true
+    serial_groups:
+      - stable-smokes
+  - name: run-cats
+    plan:
+      - do:
+          - get: stable-pool
+            passed:
+              - run-smoke-tests
+            trigger: true
+          - in_parallel:
+              steps:
+                - get: relint-envs
+                - get: cf-deployment-concourse-tasks
+                - get: cf-acceptance-tests-rc
+          - file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+            input_mapping:
+              bbl-state: relint-envs
+              cf-acceptance-tests: cf-acceptance-tests-rc
+              integration-configs: relint-envs
+            params:
+              BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+              CATS_INTEGRATION_CONFIG_FILE: environments/test/bellatrix/integration_config.json
+            task: update-integration-configs
+          - file: cf-deployment-concourse-tasks/run-cats/task.yml
+            input_mapping:
+              cf-acceptance-tests: cf-acceptance-tests-rc
+              integration-config: updated-integration-configs
+            params:
+              CAPTURE_LOGS: "true"
+              CONFIG_FILE_PATH: environments/test/bellatrix/integration_config.json
+              SKIP_REGEXP: "shows logs and metrics"
+              NODES: "12"
+            task: run-cats
+        timeout: 4h
+    public: true
+    serial: true
+    serial_groups:
+      - stable-cats
+  - name: stable-delete-deployment
+    plan:
+      - do:
+          - get: stable-pool
+            passed:
+              - run-cats
+            trigger: true
+          - in_parallel:
+              steps:
+                - get: cf-deployment-concourse-tasks
+                - get: relint-envs
+          - file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+            input_mapping:
+              bbl-state: relint-envs
+            params:
+              BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+              IGNORE_ERRORS: "true"
+            task: delete-deployment-cf
+          - file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
+            input_mapping:
+              bbl-state: relint-envs
+            params:
+              BBL_STATE_DIR: environments/test/bellatrix/bbl-state
+            task: run-bosh-cleanup
+          - params:
+              release: stable-pool
+            put: stable-pool
+        timeout: 4h
+    public: true
+    serial: true
+  - ensure:
+      try:
+        params:
+          release: stable-pool
+        put: stable-pool
+    name: stable-release-pool-manual
+    plan:
+      - get: stable-pool
+resources:
+  - name: daily
+    type: time
+    icon: clock-outline
+    source:
+      interval: 24h
+  - icon: dna
+    name: jammy-stemcell
+    source:
+      name: bosh-google-kvm-ubuntu-jammy
+    type: bosh-io-stemcell
+  - icon: github
+    name: cf-acceptance-tests-rc
+    source:
+      branch: release-candidate
+      uri: https://github.com/cloudfoundry/cf-acceptance-tests.git
+    type: git
+  - icon: github
+    name: cf-deployment
+    source:
+      branch: release-candidate
+      uri: https://github.com/cloudfoundry/cf-deployment.git
+    type: git
+  - icon: github
+    name: cf-deployment-concourse-tasks
+    source:
+      uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
+    type: git
+  - name: relint-envs
+    type: git
+    icon: github
+    source:
+      branch: main
+      uri: git@github.com:cloudfoundry/relint-envs.git
+      private_key: ((ard_wg_gitbot_ssh_key.private_key))
+  - icon: github
+    name: runtime-ci
+    source:
+      uri: https://github.com/cloudfoundry/runtime-ci.git
+    type: git
+  - name: stable-pool
+    type: pool
+    icon: pool
+    source:
+      uri: git@github.com:cloudfoundry/relint-ci-pools
+      branch: main
+      pool: cf-deployment/stable
+      private_key: ((ard_wg_gitbot_ssh_key.private_key))


### PR DESCRIPTION

### WHAT is this change about?

This PR adds a validation pipeline to deploy & then run tests against the Jammy stemcell, in the same way as is currently done for Noble.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Validation pipeline for the usage of the Jammy ops file needs to be available.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

Adds a validation pipeline for testing the Jammy stemcell

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Pipeline can be uploaded and executed: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/jammy-stemcell

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**
