### PR TITLE
Remove "pxc" release if Postgres is used

### DIFF
--- a/operations/use-postgres.yml
+++ b/operations/use-postgres.yml
@@ -6,6 +6,8 @@
     url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=53.0.3
     version: 53.0.3
 - type: remove
+  path: /releases/name=pxc
+- type: remove
   path: /instance_groups/name=database/jobs/name=route_registrar
 - type: remove
   path: /instance_groups/name=database/jobs/name=pxc-mysql


### PR DESCRIPTION
### WHAT is this change about?

Remove "pxc-release" when "use-postgres.yml" ops file is used.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana does not want to create all the packages of the pxc-release when using Postgres.

### Please provide any contextual information.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

Remove "pxc-release" in "use-postgres.yml" ops file. This saves compilation time.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

"cf-deployment" validation pipeline must be green.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
