### PR TITLE
Make pxc-release optional in use-compiled-releases ops file

### DIFF
--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -209,7 +209,7 @@
     url: https://storage.googleapis.com/cf-deployment-compiled-releases/php-buildpack-4.6.28-ubuntu-jammy-1.423-20250529-233103-946990261.tgz
     version: 4.6.28
 - type: replace
-  path: /releases/name=pxc
+  path: /releases/name=pxc?
   value:
     name: pxc
     sha1: sha256:3522c33df1b98437e14009edd11b04fa94d404f6af85f45805f1b4bb96804f7a


### PR DESCRIPTION
### WHAT is this change about?

In the [use-postgres.yml](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/use-postgres.yml) ops file, we've removed the pxc-release: https://github.com/cloudfoundry/cf-deployment/pull/1297. This has however the side-effect that [use-compiled-releases.yml](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/use-compiled-releases.yml) has to be applied *before* "use-postgres.yml". Otherwise, bosh-interpolate will fail.

This commit makes the pxc-release optional. **Note that this change requires an enhancement in the runtime-ci "update" tasks**: https://github.com/cloudfoundry/runtime-ci/pull/613

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to apply the "use-compiled-releases.yml" ops file in any order with other ops files.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/pull/1297 (remove pxc-release in "use-postgres.yml" ops file)

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

The "pxc-release" is now marked as optional in the [use-compiled-releases.yml](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/use-compiled-releases.yml) ops file. This fixes a regression when the [use-postgres.yml](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/use-postgres.yml) ops file is applied before [use-compiled-releases.yml](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/use-compiled-releases.yml).

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The "cf-deployment" validation passes and the [update-pxc](https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/update-releases/jobs/update-pxc) Concourse job works.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

