### PR TITLE
add agent certificates to binding cache for syslog-drain valdation me…

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1372,10 +1372,11 @@ instance_groups:
         ca: "((log_cache_syslog_tls.ca))"
         cert: "((syslog_agent_log_cache_tls.certificate))"
         key: "((syslog_agent_log_cache_tls.private_key))"
-      agent:
-        ca_cert: ((loggregator_tls_agent.ca))
-        cert: ((loggregator_tls_agent.certificate))
-        key: ((loggregator_tls_agent.private_key))
+      loggregator:
+        tls:
+          ca_cert: ((loggregator_tls_agent.ca))
+          cert: ((loggregator_tls_agent.certificate))
+          key: ((loggregator_tls_agent.private_key))
   - name: loggr-udp-forwarder
     release: loggregator-agent
     properties: *loggr-udp-forwarder-properties

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1372,6 +1372,10 @@ instance_groups:
         ca: "((log_cache_syslog_tls.ca))"
         cert: "((syslog_agent_log_cache_tls.certificate))"
         key: "((syslog_agent_log_cache_tls.private_key))"
+      agent:
+        ca_cert: ((loggregator_tls_agent.ca))
+        cert: ((loggregator_tls_agent.certificate))
+        key: ((loggregator_tls_agent.private_key))
   - name: loggr-udp-forwarder
     release: loggregator-agent
     properties: *loggr-udp-forwarder-properties


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

This PR adds the loggregator agent TLS certificates (CA, cert, key) to the syslog-binding-cache job. These are required by the forwarder-agent to emit syslog drain configuration error messages as app logs via the AppLogEmitter, as introduced in loggregator-agent-release#633. Without this change, the forwarder-agent in the binding-cache cannot establish the TLS connection needed to surface drain errors to application developers.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

> _Understanding why this change is being made is fantastically helpful. Please do tell..._

### Please provide any contextual information.

https://github.com/cloudfoundry/loggregator-agent-release/issues/579
https://github.com/cloudfoundry/loggregator-agent-release/pull/633

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

> _Something brief that conveys the change and is written with the **persona (Alana, Cody...)** in mind. See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

Syslog drain configuration errors are now surfaced directly to application developers as app logs, helping diagnose issues when logs are not arriving at the configured syslog drain target.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

AC 1: Unreachable drain target shows error in app logs
Given I have an application deployed to Cloud Foundry And I have created a user-provided syslog drain service bound to my application with an unreachable host (e.g. syslog://unreachable-host:9999) When I run cf logs <app-name> Then I see an error message in the log stream indicating the drain target could not be reached And the error message includes the drain destination

AC 2: Invalid drain URL shows error in app logs
Given I have an application deployed to Cloud Foundry And I have created a user-provided syslog drain service bound to my application with an invalid URL (e.g. malformed scheme or missing port) When I run cf logs <app-name> Then I see an error message in the log stream indicating the drain binding is misconfigured And the error message identifies the nature of the misconfiguration

AC 3: TLS connection failure shows error in app logs
Given I have an application deployed to Cloud Foundry And I have created a syslog-tls drain service bound to my application where the target has an invalid or expired certificate When I run cf logs <app-name> Then I see an error message in the log stream indicating a TLS handshake failure And the error message references the drain endpoint

AC 4: Connection timeout shows error in app logs
Given I have an application deployed to Cloud Foundry And I have created a syslog drain service bound to my application where the target accepts connections but does not respond within the write timeout When the forwarder-agent attempts to write logs to the drain Then I see an error message in cf logs <app-name> indicating a write timeout And the error is attributed to the correct drain binding

AC 5: Healthy drain does not emit error messages
Given I have an application deployed to Cloud Foundry And I have created a correctly configured syslog drain service bound to my application with a reachable and healthy target When I run cf logs <app-name> Then I do not see any syslog drain error messages in the application log stream And logs are successfully delivered to the drain target

AC 6: Error messages are scoped to the bound application
Given I have two applications: app-A with a misconfigured drain and app-B with a healthy drain When I run cf logs app-A Then I see drain error messages for app-A only When I run cf logs app-B Then I do not see any drain error messages

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@chombium 
@jorbaum
