### PR TITLE
Run "windows-cats" only on 3 nodes

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1847,7 +1847,7 @@ jobs:
       CAPTURE_LOGS: true
       CONFIG_FILE_PATH: environments/test/cedric/integration_config.json
       SKIP_REGEXP: "shows logs and metrics"
-      NODES: 5
+      NODES: 3
 
 - name: windows-delete-deployment
   serial: true


### PR DESCRIPTION
### WHAT is this change about?

Stabilize "windows-cats" test job. With 5 nodes, CPU usage is at 100% for the single Windows cell and tests are flakey. The test should run more stable with 3 nodes. Longer execution time should be negligible as we only run a subset of about 30 tests.

Recent windows updates do not seem to be responsible for the failures. I reverted the [windowsfs-release update](https://github.com/cloudfoundry/cf-deployment/commit/a5a81e15434266af447c8cda25d87f1538c57c96) from 2.91.0 back to 2.90.0, but there was no notable difference in CPU usage or execution time.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have stable CATs test execution.

### Please provide any contextual information.

Recent failures:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/windows-cats/builds/2382
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/windows-cats/builds/2381
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/windows-cats/builds/2380
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/windows-cats/builds/2379

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The "windows-cats" job has less failures.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
