### PR TITLE
Use native storage-cli type names for blobstore providers

### DIFF
--- a/operations/use-alicloud-oss-blobstore-to-multi-bucket.yml
+++ b/operations/use-alicloud-oss-blobstore-to-multi-bucket.yml
@@ -7,7 +7,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/connection_config?
   value: &buildpack-blobstore-properties
@@ -24,7 +24,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/connection_config?
   value: &droplet-blobstore-properties
@@ -41,7 +41,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/connection_config?
   value: &package-blobstore-properties
@@ -58,7 +58,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/connection_config?
   value: &resource-pool-blobstore-properties
@@ -76,7 +76,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/connection_config?
   value: *buildpack-blobstore-properties
@@ -88,7 +88,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/connection_config?
   value: *droplet-blobstore-properties
@@ -100,7 +100,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/connection_config?
   value: *package-blobstore-properties
@@ -112,7 +112,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/connection_config?
   value: *resource-pool-blobstore-properties
@@ -125,7 +125,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/connection_config?
   value: *buildpack-blobstore-properties
@@ -137,7 +137,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/connection_config?
   value: *droplet-blobstore-properties
@@ -149,7 +149,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/connection_config?
   value: *package-blobstore-properties
@@ -161,7 +161,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/connection_config?
   value: *resource-pool-blobstore-properties

--- a/operations/use-alicloud-oss-blobstore.yml
+++ b/operations/use-alicloud-oss-blobstore.yml
@@ -7,7 +7,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/connection_config?
   value: &blobstore-properties
@@ -24,7 +24,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/connection_config?
   value: *blobstore-properties
@@ -36,7 +36,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/connection_config?
   value: *blobstore-properties
@@ -48,7 +48,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/connection_config?
   value: *blobstore-properties
@@ -61,7 +61,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/connection_config?
   value: *blobstore-properties
@@ -73,7 +73,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/connection_config?
   value: *blobstore-properties
@@ -85,7 +85,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/connection_config?
   value: *blobstore-properties
@@ -97,7 +97,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/connection_config?
   value: *blobstore-properties
@@ -110,7 +110,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/connection_config?
   value: *blobstore-properties
@@ -122,7 +122,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/connection_config?
   value: *blobstore-properties
@@ -134,7 +134,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/connection_config?
   value: *blobstore-properties
@@ -146,7 +146,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/blobstore_provider?
-  value: aliyun
+  value: alioss
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/connection_config?
   value: *blobstore-properties

--- a/operations/use-azure-storage-blobstore.yml
+++ b/operations/use-azure-storage-blobstore.yml
@@ -7,7 +7,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/connection_config?
   value: &buildpack-blobstore-properties
@@ -23,7 +23,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/connection_config?
   value: &droplet-blobstore-properties
@@ -39,7 +39,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/connection_config?
   value: &package-blobstore-properties
@@ -55,7 +55,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/connection_config?
   value: &resource-pool-blobstore-properties
@@ -72,7 +72,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/connection_config?
   value: *buildpack-blobstore-properties
@@ -84,7 +84,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/connection_config?
   value: *droplet-blobstore-properties
@@ -96,7 +96,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/connection_config?
   value: *package-blobstore-properties
@@ -108,7 +108,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/connection_config?
   value: *resource-pool-blobstore-properties
@@ -121,7 +121,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/connection_config?
   value: *buildpack-blobstore-properties
@@ -133,7 +133,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/connection_config?
   value: *droplet-blobstore-properties
@@ -145,7 +145,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/connection_config?
   value: *package-blobstore-properties
@@ -157,7 +157,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/blobstore_provider?
-  value: AzureRM
+  value: azurebs
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/connection_config?
   value: *resource-pool-blobstore-properties

--- a/operations/use-gcs-blobstore-service-account.yml
+++ b/operations/use-gcs-blobstore-service-account.yml
@@ -9,7 +9,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/connection_config?
   value: &buildpack-blobstore-properties
@@ -23,7 +23,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/connection_config?
   value: &droplet-blobstore-properties
@@ -37,7 +37,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/connection_config?
   value: &resource-pool-blobstore-properties
@@ -51,7 +51,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/connection_config?
   value: &package-blobstore-properties
@@ -66,7 +66,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/connection_config?
   value: *buildpack-blobstore-properties
@@ -78,7 +78,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/connection_config?
   value: *droplet-blobstore-properties
@@ -90,7 +90,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/connection_config?
   value: *resource-pool-blobstore-properties
@@ -102,7 +102,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/connection_config?
   value: *package-blobstore-properties
@@ -115,7 +115,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/connection_config?
   value: *buildpack-blobstore-properties
@@ -127,7 +127,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/connection_config?
   value: *droplet-blobstore-properties
@@ -139,7 +139,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/connection_config?
   value: *resource-pool-blobstore-properties
@@ -151,7 +151,7 @@
   value: storage-cli
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/blobstore_provider?
-  value: Google
+  value: gcs
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/connection_config?
   value: *package-blobstore-properties


### PR DESCRIPTION
Update ops files to use native storage-cli type names instead of
  legacy fog provider names:

  - use-azure-storage-blobstore.yml: AzureRM → azurebs
  - use-gcs-blobstore-service-account.yml: Google → gcs
  - use-alicloud-oss-blobstore.yml: aliyun → alioss
  - use-alicloud-oss-blobstore-to-multi-bucket.yml: aliyun → alioss

  Requires capi-release with native storage-cli type support: https://github.com/cloudfoundry/capi-release/pull/624

### WHAT is this change about?
>Aligns cf-deployment with the native storage-cli naming conventions. This prepares for the removal of fog gem dependencies from Cloud Controller. Requires capi-release with native storage-cli type support (cloudfoundry/capi-release#XXX).

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...
>Alana (platform operator) is confused by the mismatch between blobstore provider names in cf-deployment configuration (AzureRM, Google, aliyun) and the actual storage-cli tool type names (azurebs, gcs, alioss). This inconsistency makes troubleshooting harder and creates unnecessary cognitive overhead when configuring blobstore backends. Additionally, the legacy fog provider names will be deprecated in Cloud Controller, so operators need to migrate to the native storage-cli type names.

### Please provide any contextual information.
https://github.com/cloudfoundry/capi-release/pull/624
https://github.com/cloudfoundry/cloud_controller_ng/pull/4908

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

> Blobstore storage-cli ops files now use native type names (azurebs, gcs, alioss) instead of legacy fog provider names. Legacy names remain supported in capi-release some months.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Please provide Acceptance Criteria for this change?
The jobs "experimental-deploy" and "experimental-cats" are green.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

