### PR TITLE
Update postgres version to 17

### DIFF
--- a/operations/use-postgres.yml
+++ b/operations/use-postgres.yml
@@ -32,6 +32,7 @@
     name: postgres
     properties:
       databases:
+        version: 17
         databases:
         - citext: true
           name: cloud_controller

--- a/texts/deployment-guide.md
+++ b/texts/deployment-guide.md
@@ -294,15 +294,15 @@ will require the use of the [`use-external-dbs.yml`](/operations/use-external-db
 
 The following databases are tested as part of the cf-deployment pipeline:
 - MySQL 8.0 using [pxc-release](https://github.com/cloudfoundry/pxc-release) as singleton and as Galera cluster
-- PostgreSQL 16 using [postgres-release](https://github.com/cloudfoundry/postgres-release)
+- PostgreSQL 17 using [postgres-release](https://github.com/cloudfoundry/postgres-release)
 - GCP Cloud SQL for MySQL 8.0 as external database
 
 The following databases should work (not tested):
-- PostgreSQL 13..15
+- PostgreSQL 14..16
 
 The following databases are not supported:
 - MySQL <8.0
-- PostgreSQL <13
+- PostgreSQL <14
 - MariaDB
 - any other database system
 


### PR DESCRIPTION
### WHAT is this change about?

- use pg 17 in cf-deployment
- configure pg version explicitly in use-postgres ops file
- update docs
- mark pg 13 as not supported (reached EOL)

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Keep PostgreSQL version up-to-date.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

The version for the bosh deployed PostgreSQL database (ops file `operations/use-postgres.yml`) was updated from 16 to 17.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

green CATS when use-postgres.yml is applied (luna)

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
