### PR TITLE
Update jammy stemcell validation pipeline

### DIFF
--- a/ci/pipelines/jammy-stemcell.yml
+++ b/ci/pipelines/jammy-stemcell.yml
@@ -200,7 +200,7 @@ resources:
   - icon: dna
     name: jammy-stemcell
     source:
-      name: bosh-google-kvm-ubuntu-jammy
+      name: bosh-google-kvm-ubuntu-jammy-go_agent
     type: bosh-io-stemcell
   - icon: github
     name: cf-acceptance-tests-rc

--- a/operations/README.md
+++ b/operations/README.md
@@ -84,4 +84,4 @@ This is the README for Ops-files. To learn more about `cf-deployment`, go to the
 | [`windows2019-cell.yml`](windows2019-cell.yml) | Deploys a windows2019 cell. | Requires that a windows2019 stemcell is uploaded to the Bosh director, and be used together with `use-online-windows2019fs.yml` or a suitable opsfile. | **YES** |
 | [`use-cflinuxfs4-compat.yml`](use-cflinuxfs4-compat.yml) | Use the [cflinuxfs4 compatibility release](https://github.com/cloudfoundry/cflinuxfs4-compat-release) instead of the default [cflinuxfs4 release](https://github.com/cloudfoundry/cflinuxfs4-release).  | **YES** |
 | [`use-noble-stemcell.yml`](use-noble-stemcell.yml) | Use Noble stemcell instead of Jammy | This is incompatible with `use-compiled-releases.yml` | **NO** |
-| [`use-jammy-stemcell.yml`](use-jammy-stemcell.yml) | Use Jammy stemcell for backwards compatibility after stemcell migration to Noble | This is incompatible with `use-compiled-releases.yml` | **NO** |
+| [`use-jammy-stemcell.yml`](use-jammy-stemcell.yml) | Use Jammy stemcell for backwards compatibility after stemcell migration to Noble | This is incompatible with `use-compiled-releases.yml` | **YES** |


### PR DESCRIPTION
## WHAT is this change about?

This PR fixes the jammy stemcell validation pipeline by adding the `-go_agent` suffix to the BOSH resource name and marks the `use-jammy-stemcell.yml` ops-file as validated in the operations README.

## What customer problem is being addressed?

Alana is unable to deploy cf-deployment with the jammy stemcell validation pipeline because the pipeline fails to discover the correct stemcell resource on BOSH.io. This fix ensures the pipeline correctly identifies and uses `bosh-google-kvm-ubuntu-jammy-go_agent` stemcell, enabling backward compatibility testing as cf-deployment transitions from Jammy to Noble as the default stemcell.

## Please provide any contextual information

- Part of the stemcell migration strategy where cf-deployment will switch from Jammy to Noble as the default stemcell in upcoming releases
- The `use-jammy-stemcell.yml` ops-file provides backward compatibility for operators who need to remain on Jammy
- Related to cf-deployment backward compatibility testing on the Bellatrix environment (GCP)

## Has a cf-deployment including this change passed cf-acceptance-tests?

- [x] YES
- [ ] NO

## Does this PR introduce a breaking change?

- [ ] YES
- [x] NO

## How should this change be described in cf-deployment release notes?

"Fixed jammy stemcell validation pipeline to correctly discover the BOSH-compiled jammy stemcell. Alana can now validate cf-deployment deployments with the jammy stemcell for backward compatibility testing as we transition to Noble."

## Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES
- [x] NO

## Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

## Please provide Acceptance Criteria for this change

- The `jammy-stemcell-backward-compatibility` pipeline successfully discovers the jammy stemcell from BOSH.io
- The pipeline deploys cf-deployment to the Bellatrix environment using the jammy stemcell
- CATs pass successfully with the jammy stemcell deployment


## What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks the stemcell validation pipeline and migration strategy
- [x] **Slightly Less than Urgent**
