### PR TITLE
Wire loggregator mTLS certs to CC api and worker jobs

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -964,6 +964,10 @@ instance_groups:
           ca_cert: "((cc_tls.ca))"
           public_cert: "((cc_tls.certificate))"
           private_key: "((cc_tls.private_key))"
+        loggregator_tls: &cc_loggregator_tls
+          ca_cert: "((loggregator_tls_agent.ca))"
+          certificate: "((loggregator_tls_agent.certificate))"
+          private_key: "((loggregator_tls_agent.private_key))"
         prom_scraper_tls:
           ca_cert: ((cc_prom_scraper_scrape_tls.ca))
           private_key: ((cc_prom_scraper_scrape_tls.private_key))
@@ -1176,6 +1180,7 @@ instance_groups:
         droplets: *blobstore-properties
         buildpacks: *blobstore-properties
         mutual_tls: *cc_mutual_tls
+        loggregator_tls: *cc_loggregator_tls
       ccdb: *ccdb
       system_domain: "((system_domain))"
       routing_api: *routing_api


### PR DESCRIPTION


## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Adds cc.loggregator_tls mTLS credentials (ca/cert/key) to the cloud_controller_ng (api) and cloud_controller_worker (cc-worker) jobs, enabling CC to emit logs directly to the loggr-forwarder-agent gRPC endpoint (:3458) using the loggregator v2 API.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

**cloud_controller_ng** and **cloud_controller_worker** rely on the [loggregator_emitter](https://github.com/cloudfoundry/loggregator_emitter) gem, which has been archived and is no longer maintained. This gem uses the legacy loggregator v1 API (UDP) to emit logs via loggr-udp-forwarder. By wiring loggregator mTLS credentials into the CC jobs, capi-release can migrate to the modern loggregator v2 gRPC API, eliminating the dependency on the unmaintained gem.

### Please provide any contextual information.

https://github.com/cloudfoundry/cloud_controller_ng/pull/5043
https://github.com/cloudfoundry/capi-release/pull/644
https://github.com/cloudfoundry/cf-acceptance-tests/pull/1920

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

Operators: cloud_controller_ng and cloud_controller_worker now receive loggregator mTLS credentials to emit logs directly via gRPC to loggr-forwarder-agent, replacing the legacy UDP forwarder path.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [X] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [X] GA'd feature/component

### Please provide Acceptance Criteria for this change?

_# Verify jobs are running_
bosh -d cf instances --ps | grep cloud_controller

_# Push an app and verify API/0 log entries appear via gRPC path_
cf push <app>
cf logs <app> --recent | grep "API/0"

_# Expected output should include entries like:_
 2026-04-21T17:02:30.04+0200 [API/0] OUT Added process: "web"
 2026-04-21T17:02:30.06+0200 [API/0] OUT Created app with guid ...


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
