### PR TITLE
Fix dns_servers for Noble stemcell migration

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -1692,7 +1692,7 @@ instance_groups:
     release: silk
     properties:
       dns_servers:
-      - 169.254.0.2
+      - 169.254.0.53
   - name: silk-datastore-syncer
     release: silk
   - name: loggr-udp-forwarder

--- a/operations/use-jammy-stemcell.yml
+++ b/operations/use-jammy-stemcell.yml
@@ -4,3 +4,6 @@
     alias: default
     os: ubuntu-jammy
     version: latest
+- path: /instance_groups/name=diego-cell/jobs/name=silk-cni/properties/dns_servers/0
+  type: replace
+  value: 169.254.0.2

--- a/operations/use-noble-stemcell.yml
+++ b/operations/use-noble-stemcell.yml
@@ -24,7 +24,4 @@
   type: replace
   value:
     os: ubuntu-noble
-- path: /instance_groups/name=diego-cell/jobs/name=silk-cni/properties/dns_servers/0
-  type: replace
-  value: 169.254.0.53
 


### PR DESCRIPTION
### WHAT is this change about?

Noble is now the default stemcell in cf-deployment. BOSH DNS on Noble uses 169.254.0.53, while Jammy uses 169.254.0.2. This PR moves the correct Noble DNS address (169.254.0.53) into cf-deployment.yml as the default and restores the Jammy address (169.254.0.2) in use-jammy-stemcell.yml.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

 NATS TLS healthcheck failures after deploying CF on Noble stemcell because nats-tls-healthcheck cannot resolve nats.service.cf.internal

### Please provide any contextual information.

The Noble stemcell migration set Noble as the default in cf-deployment.yml but left the Jammy BOSH DNS address (169.254.0.2) in silk-cni's dns_servers property. The correct Noble DNS address is 169.254.0.53. This was discovered through failures in the update-uaa pipeline where nats-tls-wrapper and nats-tls-healthcheck timed out .

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

 successfully deploy CF on Noble stemcell without NATS TLS healthcheck failures. 

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

> _Please specify either bosh cli or cf cli commands for our team (and cf operators) to verify the changes._

Deploy CF using default Noble stemcell should show nats-tls-healthcheck and nats-tls-wrapper running healthy

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
