### PR TITLE
Configure "ubuntu-noble" for BOSH addons

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -13,6 +13,7 @@ addons:
     stemcell:
     - os: ubuntu-bionic
     - os: ubuntu-jammy
+    - os: ubuntu-noble
   exclude:
     jobs:
     - name: smoke_tests
@@ -40,6 +41,7 @@ addons:
     stemcell:
     - os: ubuntu-bionic
     - os: ubuntu-jammy
+    - os: ubuntu-noble
   jobs:
   - name: loggr-forwarder-agent
     release: loggregator-agent
@@ -59,6 +61,7 @@ addons:
     stemcell:
     - os: ubuntu-bionic
     - os: ubuntu-jammy
+    - os: ubuntu-noble
   exclude:
     jobs:
     - name: smoke_tests
@@ -89,6 +92,7 @@ addons:
     stemcell:
       - os: ubuntu-bionic
       - os: ubuntu-jammy
+      - os: ubuntu-noble
   exclude:
     jobs:
     - name: smoke_tests
@@ -114,6 +118,7 @@ addons:
     stemcell:
     - os: ubuntu-bionic
     - os: ubuntu-jammy
+    - os: ubuntu-noble
   jobs:
   - name: bpm
     release: bpm


### PR DESCRIPTION
### WHAT is this change about?

Now that "ubuntu-noble" is the default stemcell, configure noble for all BOSH addons.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to use "noble" as the default stemcell, without any additional ops files.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/1224

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

BOSH addons have been configured for "ubuntu-noble".

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The "deploy" jobs stay green when the "use-noble-stemcell" ops file is removed.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
