### PR TITLE
Adding an experimental ops file to enable cflinuxfs5.

### DIFF
--- a/operations/experimental/README.md
+++ b/operations/experimental/README.md
@@ -14,6 +14,7 @@ This is the README for Experimental Ops-files. To learn more about `cf-deploymen
 | Name | Purpose | Notes | Currently validated in Release Integration CI pipelines? |
 |:---  |:---     |:---   |:---   |
 | [`add-cflinuxfs4.yml`](add-cflinuxfs4.yml) | Add [cflinuxfs4](https://github.com/cloudfoundry/cflinuxfs4) stack. | ***Deprecated as we integrate cflinuxfs4 directly into cf-deployment.yml*** | **NO** |
+| [`add-cflinuxfs5.yml`](add-cflinuxfs5.yml) | Add [cflinuxfs5](https://github.com/cloudfoundry/cflinuxfs5) stack. | Only adds cflinuxfs5 stack; does NOT make it the default stack. | **NO** |
 | [`add-metric-store.yml`](add-metric-store.yml) | **PROMOTED: use `../use-metric-store.yml`** | | **NO** |
 | [`add-otel-collector.yml`](add-otel-collector.yml) | Adds an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) to all Linux VMs to egress metrics and traces. | `otel_collector_config` must be filled in with valid OTel Collector configuration. | **NO** |
 | [`add-otel-collector-windows.yml`](add-otel-collector-windows.yml) | Adds an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) to all Windows 2019 VMs to egress metrics and traces. | `otel_collector_config` must be filled in with valid OTel Collector configuration. Requires `./add-otel-collector.yml` and `../windows2019-cell.yml`.  | **NO** |

--- a/operations/experimental/add-cflinuxfs5.yml
+++ b/operations/experimental/add-cflinuxfs5.yml
@@ -1,0 +1,134 @@
+---
+- type: replace
+  path: /releases/-
+  value:
+    name: cflinuxfs5
+    url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs5-release?v=0.31.0-beta
+    version: 0.31.0-beta
+    sha1: sha256:64cdfd873e259e60537a396e2050f6fc3ea795c8f8875d63558e563c6ae0f4e5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks/-
+  value:
+    name: cflinuxfs5
+    description: Cloud Foundry Linux-based filesystem (Ubuntu 24.04)
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: staticfile_buildpack
+    package: staticfile-buildpack-cflinuxfs5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: java_buildpack
+    package: java-buildpack-cflinuxfs5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: ruby_buildpack
+    package: ruby-buildpack-cflinuxfs5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: dotnet_core_buildpack
+    package: dotnet-core-buildpack-cflinuxfs5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: nodejs_buildpack
+    package: nodejs-buildpack-cflinuxfs5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: go_buildpack
+    package: go-buildpack-cflinuxfs5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: python_buildpack
+    package: python-buildpack-cflinuxfs5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: php_buildpack
+    package: php-buildpack-cflinuxfs5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: nginx_buildpack
+    package: nginx-buildpack-cflinuxfs5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: r_buildpack
+    package: r-buildpack-cflinuxfs5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks/-
+  value:
+    name: binary_buildpack
+    package: binary-buildpack-cflinuxfs5
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego/droplet_destinations?
+  value:
+    cflinuxfs4: /home/vcap
+    cflinuxfs5: /home/vcap
+    windows: /Users/vcap
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/diego?/droplet_destinations
+  value:
+    cflinuxfs4: /home/vcap
+    cflinuxfs5: /home/vcap
+    windows: /Users/vcap
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/diego?/droplet_destinations
+  value:
+    cflinuxfs4: /home/vcap
+    cflinuxfs5: /home/vcap
+    windows: /Users/vcap
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/diego?/droplet_destinations
+  value:
+    cflinuxfs4: /home/vcap
+    cflinuxfs5: /home/vcap
+    windows: /Users/vcap
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego/lifecycle_bundles?
+  value:
+    buildpack/cflinuxfs4: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    buildpack/cflinuxfs5: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    buildpack/windows: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    docker: docker_app_lifecycle/docker_app_lifecycle.tgz
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/diego?/lifecycle_bundles
+  value:
+    buildpack/cflinuxfs4: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    buildpack/cflinuxfs5: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    buildpack/windows: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    docker: docker_app_lifecycle/docker_app_lifecycle.tgz
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/diego?/lifecycle_bundles
+  value:
+    buildpack/cflinuxfs4: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    buildpack/cflinuxfs5: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    buildpack/windows: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    docker: docker_app_lifecycle/docker_app_lifecycle.tgz
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/diego?/lifecycle_bundles
+  value:
+    buildpack/cflinuxfs4: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    buildpack/cflinuxfs5: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    buildpack/windows: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    docker: docker_app_lifecycle/docker_app_lifecycle.tgz
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/-
+  value:
+    name: cflinuxfs5-rootfs-setup
+    release: cflinuxfs5
+    properties:
+      cflinuxfs5-rootfs:
+        trusted_certs:
+        - ((diego_instance_identity_ca.ca))
+        - ((credhub_tls.ca))
+        - ((uaa_ssl.ca))
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/rep/preloaded_rootfses/-
+  value: cflinuxfs5:/var/vcap/packages/cflinuxfs5/rootfs.tar

--- a/units/tests/experimental_test/operations.yml
+++ b/units/tests/experimental_test/operations.yml
@@ -1,5 +1,6 @@
 ---
 add-cflinuxfs4.yml: {}
+add-cflinuxfs5.yml: {}
 add-ipv6-security-group.yml: {}
 add-metric-store.yml: {}
 add-otel-collector-windows.yml:


### PR DESCRIPTION
### WHAT is this change about?
As part of the validation process for the new cflinuxfs5 stack we introduce a new experimental ops file which will serve alongside the cflinuxfs4 stack. 

> _Please describe the change._
- Added new add-cflinuxfs5.yml ops file. j
- Updated the README.md 
- added the new file reference to the tests

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...
Since cflinuxfs4 is based on Jammy which is end of life in 2027 we need to introduce the new cflinuxfs5 stack which is based on Ubuntu Noble.

### Please provide any contextual information.

> _Include any links to other PRs, stories, slack discussions, etc... that will help establish context._
https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0039-noble-based-cflinuxfs5.md 

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?
Added experimental ops file for cflinuxfs5

> _Something brief that conveys the change and is written with the **persona (Alana, Cody...)** in mind. See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?
CATs test should be running green. 
Apps are deployable with the cflinuxfs5 stack

> _Please specify either bosh cli or cf cli commands for our team (and cf operators) to verify the changes._

> _Few examples_
> 1. For a PR with a new job in the manifest, `bosh instances` can verify the job is running after upgrade. You can provide additional commands to verify the job is running as specified.
> 2. For a PR with new variables, `bosh variables | grep <var-name>` command can verify the variable exists. This is the simplest varification but you can also provide additional commands to test that the variable holds the desired value.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@cloudfoundry/wg-app-runtime-deployments 

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
@oliver-heinrich @iaftab-alam @jochenehret
