### PR TITLE
fix: update isolated-diego-cell silk-cni dns to use systemd-resolved …

### DIFF
--- a/operations/add-persistent-isolation-segment-diego-cell.yml
+++ b/operations/add-persistent-isolation-segment-diego-cell.yml
@@ -163,7 +163,7 @@
       release: silk
       properties:
         dns_servers:
-        - 169.254.0.2
+        - 169.254.0.53
       provides: 
         cni_config:
           nil


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

On Ubuntu Noble, BOSH DNS (169.254.0.2) only handles internal CF service names and refuses external recursive queries. use-noble-stemcell.yml already updates diego-cell to use 169.254.0.53 (systemd-resolved, which resolves both internal and external names), but add-persistent-isolation-segment- diego-cell.yml was never updated to match.

Result: staging containers on isolated cells fail to resolve external hostnames (e.g. buildpacks.cloudfoundry.org) with "server misbehaving", causing any buildpack that downloads dependencies to fail.

Change dns_servers from 169.254.0.2 to 169.254.0.53 to match what use-noble-stemcell.yml sets for regular diego cells.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

These CATs tests are failing
```
  [FAIL] [isolation_segments] IsolationSegments [isolated tcp routing] When TCP routing is enabled external ports [BeforeEach] with a second external port maps both ports to the same application
  /tmp/build/d936608b/cf-acceptance-tests/isolation_segments/isolation_segments.go:292
  [FAIL] [isolation_segments] IsolationSegments [isolated tcp routing] When TCP routing is enabled external ports [BeforeEach] with two different apps maps single external port to both applications
  /tmp/build/d936608b/cf-acceptance-tests/isolation_segments/isolation_segments.go:292
  [FAIL] [isolation_segments] IsolationSegments [isolated tcp routing] When TCP routing is enabled external ports [BeforeEach] maps a single external port to an application's container port
  /tmp/build/d936608b/cf-acceptance-tests/isolation_segments/isolation_segments.go:292
 ```

### Please provide any contextual information.

This was changed for the main diego cells here: https://github.com/cloudfoundry/cf-deployment/commit/18435ad055807625c53900c0f5160d6399a3b53f

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

> _Something brief that conveys the change and is written with the **persona (Alana, Cody...)** in mind. See [previous release notes](https://github.com/cloudfoundry/cf-deployment/releases) for examples._

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

isolated tcp routing CATS pass

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
