### PR TITLE
Add ubuntu-noble stemcell to enable-component-syslog ops file

### DIFF
--- a/operations/addons/enable-component-syslog.yml
+++ b/operations/addons/enable-component-syslog.yml
@@ -5,6 +5,7 @@
       stemcell:
       - os: ubuntu-bionic
       - os: ubuntu-jammy
+      - os: ubuntu-noble
     jobs:
     - name: syslog_forwarder
       properties:


### PR DESCRIPTION
### WHAT is this change about?

Add ubuntu-noble to the stemcell include filter in operations/addons/enable-component-syslog.yml.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

alana applies enable-component-syslog.yml as a BOSH runtime config to forward component logs to a syslog endpoint. Since ubuntu-noble is now the default stemcell in cf-deployment, all VMs run Noble , but the ops file's include.stemcell filter only lists ubuntu-bionic and ubuntu-jammy. BOSH silently skips the syslog_forwarder job on any Noble VM, meaning receives no component logs without any error or warning.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component

### Please provide Acceptance Criteria for this change?

syslog_forwarder should appear on Noble VMs. Verify logs are received at the configured syslog endpoint.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**