### PR TITLE
Cflinuxfs5 pipeline validation

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2888,9 +2888,9 @@ releases:
   version: 57.5.0
   sha1: sha256:5a4e80cc36657fb9df50fae5deea40373f43fa16cd7eefd36fe4479204c45a20
 - name: nginx-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.2.36
-  version: 1.2.36
-  sha1: sha256:eaa706d45dac4ad5dbcc303d15ff723208bc16aec7af442e5f5dd84901e50ea0
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.2.37
+  version: 1.2.37
+  sha1: sha256:cfb4d31b9238814d1708d11d395f7a65adf2a322025dfd2c96207d2f79fe8029
 - name: r-buildpack
   url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.2.27
   version: 1.2.27

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2912,9 +2912,9 @@ releases:
   version: 1.9.0
   sha1: sha256:4d0793b92bc1ec2e86f276b5ffb905381abc25af378e213d185e3b70c4d22b51
 - name: routing
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.380.0
-  version: 0.380.0
-  sha1: sha256:1fb74d44ab86aadb733e27d120329c1d5a527855764863322b7e319e99cffc66
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.381.0
+  version: 0.381.0
+  sha1: sha256:f2c84187e01df101610cec479471678370f863606149d18779b1a0abc97a7b60
 - name: ruby-buildpack
   url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.11.0
   version: 1.11.0

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2924,9 +2924,9 @@ releases:
   version: 3.112.1
   sha1: sha256:b5ab4bdcfccdc1763b5cb1fab151743e1c165afa27718ed238cb04ebacb08394
 - name: staticfile-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.6.36
-  version: 1.6.36
-  sha1: sha256:8c3ec1dd4a25ef8d2aebaef51b07222503e260f38442031d693a90a0abeadf90
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.6.37
+  version: 1.6.37
+  sha1: sha256:68f67b94dc8ea459333119d0a47216aed2248f45e0938eccb2d3ef273997f28f
 - name: statsd-injector
   url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.54
   version: 1.11.54

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2884,9 +2884,9 @@ releases:
   version: 107.0.29
   sha1: sha256:78bc23eaf2f57f675d35b6af8504e7af8a7e15a2ef42e882bdc7aff9e6a9576e
 - name: nats
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=57.5.0
-  version: 57.5.0
-  sha1: sha256:5a4e80cc36657fb9df50fae5deea40373f43fa16cd7eefd36fe4479204c45a20
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=57.6.0
+  version: 57.6.0
+  sha1: sha256:8ca728b98ac7a0915adb0d2bcc7e7c1176434c64183d13bd90c50d05270eb45c
 - name: nginx-buildpack
   url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.2.37
   version: 1.2.37

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2856,9 +2856,9 @@ releases:
   version: 1.321.0
   sha1: sha256:9a47c31a806e725bb52d49c5c7b436904c8d1b567986e765a40b60de260ed467
 - name: credhub
-  url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.15.6
-  version: 2.15.6
-  sha1: sha256:220afbd53237b53bfa84cdf01b0563369cf2810d07e8d9a9fd0d5921496ca7bc
+  url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.15.7
+  version: 2.15.7
+  sha1: sha256:017f1baae6f477db90075d722f196aa6386954a4c60c9cb4d8eed6d598cc9ad1
 - name: diego
   url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.135.0
   version: 2.135.0

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2900,9 +2900,9 @@ releases:
   version: 1.9.1
   sha1: sha256:fd52b9441b0cf9659ccaced37bdc396bab61ded65dcf2115547bfcbd268f48bc
 - name: php-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=5.0.4
-  version: 5.0.4
-  sha1: sha256:68396c33b1c95a2d6075b8bad11f20e7611e2fe81ca74c0718888b0c9f334e90
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=5.0.5
+  version: 5.0.5
+  sha1: sha256:771f6ced0ec51f591dcd90d132a196080fbe1c71e72fd832fbf99736ae9839b1
 - name: pxc
   url: https://bosh.io/d/github.com/cloudfoundry/pxc-release?v=2.0.3
   version: 2.0.3

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2844,9 +2844,9 @@ releases:
   version: 1.234.0
   sha1: sha256:6d90ccb4fe16dd6d7abb550c480ffb37e5a3675ff9e5df8cefbc9e379bb10f4b
 - name: cf-networking
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=3.112.1
-  version: 3.112.1
-  sha1: sha256:c02c03238e9e7e00f5b6bcd0e8f9d5941d280b58ec41d29e9c9e1197db8b7e21
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=3.113.0
+  version: 3.113.0
+  sha1: sha256:98b92dc83680aa94e74e1cc94060ca2aabf28d5c69c321cb0e0a1bfd6a18b710
 - name: cf-smoke-tests
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=42.0.260
   version: 42.0.260

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2920,9 +2920,9 @@ releases:
   version: 1.11.0
   sha1: sha256:a3b389cec7c441e4a19734fe6e5884b220a3b0ce147563977fce91d393f5f7e0
 - name: silk
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=3.112.1
-  version: 3.112.1
-  sha1: sha256:b5ab4bdcfccdc1763b5cb1fab151743e1c165afa27718ed238cb04ebacb08394
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=3.113.0
+  version: 3.113.0
+  sha1: sha256:ca09c67aa73ea45f0e810e5854a80b32f9e2936586ab060a97ca56dd547ccdba
 - name: staticfile-buildpack
   url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.6.37
   version: 1.6.37

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2848,9 +2848,9 @@ releases:
   version: 3.112.1
   sha1: sha256:c02c03238e9e7e00f5b6bcd0e8f9d5941d280b58ec41d29e9c9e1197db8b7e21
 - name: cf-smoke-tests
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=42.0.259
-  version: 42.0.259
-  sha1: sha256:2249b569315d73558a58b78218dd209e1a7f5eddd274c7fe36b8b71b04644507
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=42.0.260
+  version: 42.0.260
+  sha1: sha256:3f47778dc2dffc53ae116fc13be8753ae588e5fce048a60664cb5a54723fd7ac
 - name: cflinuxfs4
   url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs4-release?v=1.321.0
   version: 1.321.0

--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2876,9 +2876,9 @@ releases:
   version: 1.10.46
   sha1: sha256:c32334de7a7a1a07c6471ed93a1670d6ec2d48aab96b89c29b90d589bfeb0185
 - name: java-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=5.0.2
-  version: 5.0.2
-  sha1: sha256:c2fcac9bafb831b664a3e5fe9478644177c5bcae28a237429523a7fc25031762
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=5.0.3
+  version: 5.0.3
+  sha1: sha256:0f93b41785c4f33ef68621b7833d573c9333688f5d05ee787cd7d3576e7c31c7
 - name: loggregator
   url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=107.0.29
   version: 107.0.29

--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -69,6 +69,8 @@ opsReleases:
   repository: cloudfoundry-incubator/backup-and-restore-sdk-release
 - name: cflinuxfs4-compat
   repository: cloudfoundry/cflinuxfs4-compat-release
+- name: cflinuxfs5
+  repository: cloudfoundry/cflinuxfs5-release
 - name: haproxy
   repository: cloudfoundry-incubator/haproxy-boshrelease
   varsFiles: "environments/test/pre-dev/haproxy-vars.yml"

--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -22,6 +22,7 @@ groups:
   - experimental-deploy
   - experimental-smoke-tests
   - experimental-cats
+  - experimental-cats-cflinuxfs5
   - experimental-delete-deployment
   - lite-acquire-pool
   - lite-deploy
@@ -80,6 +81,7 @@ groups:
   - lint-cf-deployment-manifest
   - experimental-acquire-pool
   - experimental-cats
+  - experimental-cats-cflinuxfs5
   - experimental-deploy
   - experimental-delete-deployment
   - experimental-release-pool-manual
@@ -1111,7 +1113,7 @@ jobs:
       params: {release: experimental-pool}
 
 - name: experimental-deploy
-  serial_groups: [ experimental-cats, experimental-smokes ]
+  serial_groups: [ experimental-cats, experimental-cats-cflinuxfs5, experimental-smokes ]
   public: true
   plan:
   - get: experimental-pool
@@ -1168,6 +1170,7 @@ jobs:
         operations/experimental/enable-containerd-for-processes.yml
         operations/experimental/disable-cf-credhub.yml
         operations/experimental/disable-interpolate-service-bindings.yml
+        operations/experimental/add-cflinuxfs5.yml
         operations/increase-doppler-vm-type-from-minimal-to-small.yml
         operations/scale-diego-cell-to-8.yml
         operations/test/speed-up-dynamic-asgs.yml
@@ -1224,6 +1227,7 @@ jobs:
         operations/experimental/disable-cf-credhub.yml
         operations/experimental/disable-interpolate-service-bindings.yml
         operations/experimental/use-mysql-version-8.4.yml
+        operations/experimental/add-cflinuxfs5.yml
         operations/increase-doppler-vm-type-from-minimal-to-small.yml
         operations/scale-diego-cell-to-8.yml
         operations/test/speed-up-dynamic-asgs.yml
@@ -1332,6 +1336,39 @@ jobs:
         RELINT_VERBOSE_AUTH: "true"
         SKIP_REGEXP: "shows logs and metrics"
 
+- name: experimental-cats-cflinuxfs5
+  serial_groups: [ experimental-cats-cflinuxfs5 ]
+  public: true
+  plan:
+  - timeout: 4h
+    do:
+    - get: experimental-pool
+      trigger: true
+      passed: [ experimental-deploy ]
+    - in_parallel:
+      - get: cf-acceptance-tests-rc
+      - get: relint-envs
+      - get: cf-deployment-develop
+        passed: [ experimental-deploy ]
+      - get: cf-deployment-concourse-tasks
+    - task: update-integration-configs
+      file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+      params:
+        BBL_STATE_DIR: environments/test/hermione/bbl-state
+        CATS_INTEGRATION_CONFIG_FILE: environments/test/hermione/cflinuxfs5_integration_config.json
+      input_mapping:
+        bbl-state: relint-envs
+        integration-configs: relint-envs
+    - task: run-cats
+      input_mapping:
+        integration-config: updated-integration-configs
+        cf-acceptance-tests: cf-acceptance-tests-rc
+      file: cf-deployment-concourse-tasks/run-cats/task.yml
+      params:
+        CONFIG_FILE_PATH: environments/test/hermione/cflinuxfs5_integration_config.json
+        REPORTER_CONFIG_FILE_PATH: environments/test/hermione/reporter_config.json
+        RELINT_VERBOSE_AUTH: "true"
+
 - name: experimental-delete-deployment
   serial: true
   public: true
@@ -1340,6 +1377,7 @@ jobs:
     trigger: true
     passed:
     - experimental-cats
+    - experimental-cats-cflinuxfs5
     - experimental-smoke-tests
   - in_parallel:
     - get: cf-deployment-concourse-tasks

--- a/operations/backup-and-restore/enable-backup-restore.yml
+++ b/operations/backup-and-restore/enable-backup-restore.yml
@@ -2,9 +2,9 @@
   path: /releases/-
   value:
     name: backup-and-restore-sdk
-    sha1: sha256:5b10f62e1f83912e4228eec0c9de820455da0feb3f56b73bcea712c230b986a7
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/backup-and-restore-sdk-release?v=1.19.55
-    version: 1.19.55
+    sha1: sha256:16cd3a5e83e6db2ef9870666fcee19de8e6915f788986765b16756194654f6c2
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/backup-and-restore-sdk-release?v=1.19.56
+    version: 1.19.56
 - type: replace
   path: /instance_groups/-
   value:

--- a/operations/community/use-haproxy.yml
+++ b/operations/community/use-haproxy.yml
@@ -2,9 +2,9 @@
   path: /releases/-
   value:
     name: haproxy
-    sha1: sha256:0f33e753b25a1868baab249e7129b1ee152132a50234069c257942ab67e9ec67
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/haproxy-boshrelease?v=16.8.0%2B3.2.16
-    version: 16.8.0+3.2.16
+    sha1: sha256:6a24d295477f2d6a46b996d1195133188a4c10b3634e16f14d2ec784892e29bd
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/haproxy-boshrelease?v=16.9.0%2B3.2.17
+    version: 16.9.0+3.2.17
 - type: replace
   path: /instance_groups/name=smoke-tests
   value:

--- a/operations/enable-nfs-volume-service.yml
+++ b/operations/enable-nfs-volume-service.yml
@@ -142,6 +142,6 @@
   path: /releases/-
   value:
     name: nfs-volume
-    sha1: sha256:055b75b9bdc40b961479872ce7b40c4bbf11ed72fdecf0bf341614cf209d9eb2
-    url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=7.58.0
-    version: 7.58.0
+    sha1: sha256:c964f45bc82d244b2850326319a878744c3eab93c5704d98ca44df07cda904e0
+    url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=7.59.0
+    version: 7.59.0

--- a/operations/test/fips-stemcell.yml
+++ b/operations/test/fips-stemcell.yml
@@ -3,4 +3,4 @@
   value:
     alias: default
     os: ubuntu-jammy
-    version: "1.1193"
+    version: "1.1202"

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -242,12 +242,12 @@
   path: /releases/name=routing
   value:
     name: routing
-    sha1: sha256:df5624b1401ac082a1e27ff88e82e03a3c0df15119283590a52d90f0dbca2560
+    sha1: sha256:0e62134601a774536f0ca36ab75bf81ee098772cc63c10b3c2c53cff680dc4c1
     stemcell:
       os: ubuntu-noble
       version: "1.333"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/routing-0.380.0-ubuntu-noble-1.333-20260501-230729-340777623.tgz
-    version: 0.380.0
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/routing-0.381.0-ubuntu-noble-1.333-20260508-232501-200306635.tgz
+    version: 0.381.0
 - type: replace
   path: /releases/name=ruby-buildpack
   value:

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -202,12 +202,12 @@
   path: /releases/name=php-buildpack
   value:
     name: php-buildpack
-    sha1: sha256:bf13608ee32c16200e5a392ffa2c8c34782f6c9244bbaa599573f35a62e27a45
+    sha1: sha256:6298b2ca150fd8f570ac2cec35a9cc92aca38cc0c38fa6404fb4f531d0dd0a26
     stemcell:
       os: ubuntu-noble
       version: "1.333"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/php-buildpack-5.0.4-ubuntu-noble-1.333-20260505-083211-40953348.tgz
-    version: 5.0.4
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/php-buildpack-5.0.5-ubuntu-noble-1.333-20260508-123625-289383115.tgz
+    version: 5.0.5
 - type: replace
   path: /releases/name=pxc
   value:

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -52,12 +52,12 @@
   path: /releases/name=cf-networking
   value:
     name: cf-networking
-    sha1: d2fa50c3f5c2791dca97dd07c8d4b5dcc2d188a0
+    sha1: sha256:0116627ae63efa5324b6fe6198bace47d0d493d79abac51404682ee5f04b38c0
     stemcell:
       os: ubuntu-noble
       version: "1.333"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/cf-networking-3.112.1-ubuntu-noble-1.333-20260427-092525-227515949.tgz
-    version: 3.112.1
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/cf-networking-3.113.0-ubuntu-noble-1.333-20260508-215811-502913638.tgz
+    version: 3.113.0
 - type: replace
   path: /releases/name=cf-smoke-tests
   value:

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -132,12 +132,12 @@
   path: /releases/name=java-buildpack
   value:
     name: java-buildpack
-    sha1: sha256:99756353b798c044280d0ae76a92c053be4269df2a5751dd9c93bf0f969c4c3e
+    sha1: sha256:b898c5cfacb9dde2b30fd2665d8ab30204f298d0732bd31ee00f99b5166a6c36
     stemcell:
       os: ubuntu-noble
       version: "1.333"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/java-buildpack-5.0.2-ubuntu-noble-1.333-20260505-083908-397194211.tgz
-    version: 5.0.2
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/java-buildpack-5.0.3-ubuntu-noble-1.333-20260508-123631-970235009.tgz
+    version: 5.0.3
 - type: replace
   path: /releases/name=log-cache
   value:

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -172,12 +172,12 @@
   path: /releases/name=nats
   value:
     name: nats
-    sha1: sha256:ebe11130a39ac8944c7cf1a895f7cb407ca422d3887ce87fce4f26e1b58771ea
+    sha1: sha256:0b98c32f363e1499ce1cbce99a64fa371eaf44ce8bbd2c06f683589a3195b81a
     stemcell:
       os: ubuntu-noble
       version: "1.333"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/nats-57.5.0-ubuntu-noble-1.333-20260504-174952-839459577.tgz
-    version: 57.5.0
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/nats-57.6.0-ubuntu-noble-1.333-20260508-220012-85676988.tgz
+    version: 57.6.0
 - type: replace
   path: /releases/name=nginx-buildpack
   value:

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -182,12 +182,12 @@
   path: /releases/name=nginx-buildpack
   value:
     name: nginx-buildpack
-    sha1: sha256:dc5dde7de7b531fe415509493637a2ff7954ff581e9a5baff5868ec6028dfa54
+    sha1: sha256:b5d003a5cada52854e326d510c6c93cf39db1596db9c9ccf8d8da029e9e0071f
     stemcell:
       os: ubuntu-noble
       version: "1.333"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/nginx-buildpack-1.2.36-ubuntu-noble-1.333-20260504-120240-660271706.tgz
-    version: 1.2.36
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/nginx-buildpack-1.2.37-ubuntu-noble-1.333-20260508-124215-547792486.tgz
+    version: 1.2.37
 - type: replace
   path: /releases/name=nodejs-buildpack
   value:

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -262,12 +262,12 @@
   path: /releases/name=silk
   value:
     name: silk
-    sha1: 712a9e8c9dc2e13b284833238de4edf27ea458a5
+    sha1: sha256:16d5da6189d96c664c550c2f61356bbe0820d612a9ee5ab726b7fda82737a4ea
     stemcell:
       os: ubuntu-noble
       version: "1.333"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/silk-3.112.1-ubuntu-noble-1.333-20260427-092544-319737703.tgz
-    version: 3.112.1
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/silk-3.113.0-ubuntu-noble-1.333-20260508-222042-064372432.tgz
+    version: 3.113.0
 - type: replace
   path: /releases/name=staticfile-buildpack
   value:

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -62,12 +62,12 @@
   path: /releases/name=cf-smoke-tests
   value:
     name: cf-smoke-tests
-    sha1: sha256:1734843d902e6df38d5dd2b838cde00dd15d49a15bb1412e5b14276fec7a62d8
+    sha1: sha256:f9332fb4007b6196186f4432ad11fc3d1d6e490ea920589b07051cf9511b4d1b
     stemcell:
       os: ubuntu-noble
       version: "1.333"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/cf-smoke-tests-42.0.259-ubuntu-noble-1.333-20260505-160749-785341716.tgz
-    version: 42.0.259
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/cf-smoke-tests-42.0.260-ubuntu-noble-1.333-20260508-172345-551845552.tgz
+    version: 42.0.260
 - type: replace
   path: /releases/name=cflinuxfs4
   value:

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -82,12 +82,12 @@
   path: /releases/name=credhub
   value:
     name: credhub
-    sha1: sha256:0f6f9d5e2bcba5d9071013b062ec5490c7320169ebb09b9b330eb4de747136cb
+    sha1: sha256:f1e5f423b9598b9619745d26073592188072fd3ee621a81fa7ac609361b9e359
     stemcell:
       os: ubuntu-noble
       version: "1.333"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/credhub-2.15.6-ubuntu-noble-1.333-20260501-211526-548505289.tgz
-    version: 2.15.6
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/credhub-2.15.7-ubuntu-noble-1.333-20260508-051126-894396771.tgz
+    version: 2.15.7
 - type: replace
   path: /releases/name=diego
   value:

--- a/operations/use-compiled-releases.yml
+++ b/operations/use-compiled-releases.yml
@@ -272,12 +272,12 @@
   path: /releases/name=staticfile-buildpack
   value:
     name: staticfile-buildpack
-    sha1: sha256:c73b0d214e14b54cdf5395d4ef8552bb9b7d51c5ee5af297425f67a9126c4c33
+    sha1: sha256:3441f973f80d371ba96b40486c43deecac54a90fd84b43eafb4c703dd9158026
     stemcell:
       os: ubuntu-noble
       version: "1.333"
-    url: https://storage.googleapis.com/cf-deployment-compiled-releases/staticfile-buildpack-1.6.36-ubuntu-noble-1.333-20260504-115034-957226245.tgz
-    version: 1.6.36
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/staticfile-buildpack-1.6.37-ubuntu-noble-1.333-20260508-123855-804030131.tgz
+    version: 1.6.37
 - type: replace
   path: /releases/name=statsd-injector
   value:

--- a/operations/use-haproxy.yml
+++ b/operations/use-haproxy.yml
@@ -2,9 +2,9 @@
   path: /releases/-
   value:
     name: haproxy
-    sha1: sha256:0f33e753b25a1868baab249e7129b1ee152132a50234069c257942ab67e9ec67
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/haproxy-boshrelease?v=16.8.0%2B3.2.16
-    version: 16.8.0+3.2.16
+    sha1: sha256:6a24d295477f2d6a46b996d1195133188a4c10b3634e16f14d2ec784892e29bd
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/haproxy-boshrelease?v=16.9.0%2B3.2.17
+    version: 16.9.0+3.2.17
 - type: remove
   path: /instance_groups/name=router/vm_extensions
 - type: remove

--- a/operations/windows2019-cell.yml
+++ b/operations/windows2019-cell.yml
@@ -198,9 +198,9 @@
   path: /releases/name=hwc-buildpack?
   value:
     name: hwc-buildpack
-    sha1: sha256:8ca837a53738fc5383f10a48c6c14ee0d9a1959da94a1046215f574f3e9574d5
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=3.1.47
-    version: 3.1.47
+    sha1: sha256:25f3e5aeac9bd043e55eb891ec2b3d0039da104c52d174290b6b040cb4f6e56f
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/hwc-buildpack-release?v=3.1.48
+    version: 3.1.48
 - type: replace
   path: /releases/name=winc?
   value:


### PR DESCRIPTION
### WHAT is this change about?

Adds cflinuxfs5 stack validation to the experimental Concourse pipeline (hermione). This includes adding cflinuxfs5-release to the update-releases pipeline inputs, applying the add-cflinuxfs5.yml ops file in the experimental deploy jobs, and introducing a new experimental-cats-cflinuxfs5 job to run cf-acceptance-tests against the cflinuxfs5 stack.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

George (CF operator) needs confidence that the upcoming cflinuxfs5 stack works correctly with cf-deployment before it is promoted as a default or GA'd stack. Without this pipeline validation, there is no automated signal that cflinuxfs5 is stable and compatible with current cf-deployment.

### Please provide any contextual information.

Part of https://github.com/cloudfoundry/cf-deployment/issues/1323. Follows the same experimental validation approach previously used for cflinuxfs4 before it became the default stack. Depends on operations/experimental/add-cflinuxfs5.yml (introduced in [Attila's PR](https://github.com/cloudfoundry/cf-deployment/pull/1335)) and the cflinuxfs5_integration_config.json in relint-envs.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

Add cflinuxfs5-release to experimental pipeline validation; introduces experimental-cats-cflinuxfs5 job to run CATs against the cflinuxfs5 stack.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [X] YES - cflinuxfs5-release is added to opsReleases in inputs.yml
- [ ] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

1.) The experimental-deploy job in the hermione pipeline applies operations/experimental/add-cflinuxfs5.yml without errors.
2.) After a successful experimental-deploy, the new experimental-cats-cflinuxfs5 job triggers and completes CATs against the cflinuxfs5 stack using cflinuxfs5_integration_config.json.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@oliver-heinrich @jochenehret 
