### PR TITLE
Add cflinuxfs5 stack to experimental pipeline validation

### DIFF
--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -69,6 +69,8 @@ opsReleases:
   repository: cloudfoundry-incubator/backup-and-restore-sdk-release
 - name: cflinuxfs4-compat
   repository: cloudfoundry/cflinuxfs4-compat-release
+- name: cflinuxfs5
+  repository: cloudfoundry/cflinuxfs5-release
 - name: haproxy
   repository: cloudfoundry-incubator/haproxy-boshrelease
   varsFiles: "environments/test/pre-dev/haproxy-vars.yml"

--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -69,8 +69,6 @@ opsReleases:
   repository: cloudfoundry-incubator/backup-and-restore-sdk-release
 - name: cflinuxfs4-compat
   repository: cloudfoundry/cflinuxfs4-compat-release
-- name: cflinuxfs5
-  repository: cloudfoundry/cflinuxfs5-release
 - name: haproxy
   repository: cloudfoundry-incubator/haproxy-boshrelease
   varsFiles: "environments/test/pre-dev/haproxy-vars.yml"

--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1344,12 +1344,12 @@ jobs:
     do:
     - get: experimental-pool
       trigger: true
-      passed: [ experimental-cats ]
+      passed: [ experimental-deploy ]
     - in_parallel:
       - get: cf-acceptance-tests-rc
       - get: relint-envs
       - get: cf-deployment-develop
-        passed: [ experimental-cats ]
+        passed: [ experimental-deploy ]
       - get: cf-deployment-concourse-tasks
     - task: update-integration-configs
       file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
@@ -1368,10 +1368,10 @@ jobs:
         CONFIG_FILE_PATH: environments/test/hermione/cflinuxfs5_integration_config.json
         REPORTER_CONFIG_FILE_PATH: environments/test/hermione/reporter_config.json
         RELINT_VERBOSE_AUTH: "true"
+    NODES: 6
 
 - name: experimental-delete-deployment
   serial: true
-  serial_groups: [ experimental-cats-cflinuxfs5 ]
   public: true
   plan:
   - get: experimental-pool

--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1335,6 +1335,7 @@ jobs:
         REPORTER_CONFIG_FILE_PATH: environments/test/hermione/reporter_config.json
         RELINT_VERBOSE_AUTH: "true"
         SKIP_REGEXP: "shows logs and metrics"
+        NODES: 6
 
 - name: experimental-cats-cflinuxfs5
   serial_groups: [ experimental-cats-cflinuxfs5 ]
@@ -1368,7 +1369,7 @@ jobs:
         CONFIG_FILE_PATH: environments/test/hermione/cflinuxfs5_integration_config.json
         REPORTER_CONFIG_FILE_PATH: environments/test/hermione/reporter_config.json
         RELINT_VERBOSE_AUTH: "true"
-    NODES: 6
+        NODES: 6
 
 - name: experimental-delete-deployment
   serial: true

--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -22,6 +22,7 @@ groups:
   - experimental-deploy
   - experimental-smoke-tests
   - experimental-cats
+  - experimental-cats-cflinuxfs5
   - experimental-delete-deployment
   - lite-acquire-pool
   - lite-deploy
@@ -80,6 +81,7 @@ groups:
   - lint-cf-deployment-manifest
   - experimental-acquire-pool
   - experimental-cats
+  - experimental-cats-cflinuxfs5
   - experimental-deploy
   - experimental-delete-deployment
   - experimental-release-pool-manual
@@ -1111,7 +1113,7 @@ jobs:
       params: {release: experimental-pool}
 
 - name: experimental-deploy
-  serial_groups: [ experimental-cats, experimental-smokes ]
+  serial_groups: [ experimental-cats, experimental-cats-cflinuxfs5, experimental-smokes ]
   public: true
   plan:
   - get: experimental-pool
@@ -1168,6 +1170,7 @@ jobs:
         operations/experimental/enable-containerd-for-processes.yml
         operations/experimental/disable-cf-credhub.yml
         operations/experimental/disable-interpolate-service-bindings.yml
+        operations/experimental/add-cflinuxfs5.yml
         operations/increase-doppler-vm-type-from-minimal-to-small.yml
         operations/scale-diego-cell-to-8.yml
         operations/test/speed-up-dynamic-asgs.yml
@@ -1224,6 +1227,7 @@ jobs:
         operations/experimental/disable-cf-credhub.yml
         operations/experimental/disable-interpolate-service-bindings.yml
         operations/experimental/use-mysql-version-8.4.yml
+        operations/experimental/add-cflinuxfs5.yml
         operations/increase-doppler-vm-type-from-minimal-to-small.yml
         operations/scale-diego-cell-to-8.yml
         operations/test/speed-up-dynamic-asgs.yml
@@ -1332,6 +1336,39 @@ jobs:
         RELINT_VERBOSE_AUTH: "true"
         SKIP_REGEXP: "shows logs and metrics"
 
+- name: experimental-cats-cflinuxfs5
+  serial_groups: [ experimental-cats-cflinuxfs5 ]
+  public: true
+  plan:
+  - timeout: 4h
+    do:
+    - get: experimental-pool
+      trigger: true
+      passed: [ experimental-deploy ]
+    - in_parallel:
+      - get: cf-acceptance-tests-rc
+      - get: relint-envs
+      - get: cf-deployment-develop
+        passed: [ experimental-deploy ]
+      - get: cf-deployment-concourse-tasks
+    - task: update-integration-configs
+      file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+      params:
+        BBL_STATE_DIR: environments/test/hermione/bbl-state
+        CATS_INTEGRATION_CONFIG_FILE: environments/test/hermione/cflinuxfs5_integration_config.json
+      input_mapping:
+        bbl-state: relint-envs
+        integration-configs: relint-envs
+    - task: run-cats
+      input_mapping:
+        integration-config: updated-integration-configs
+        cf-acceptance-tests: cf-acceptance-tests-rc
+      file: cf-deployment-concourse-tasks/run-cats/task.yml
+      params:
+        CONFIG_FILE_PATH: environments/test/hermione/cflinuxfs5_integration_config.json
+        REPORTER_CONFIG_FILE_PATH: environments/test/hermione/reporter_config.json
+        RELINT_VERBOSE_AUTH: "true"
+
 - name: experimental-delete-deployment
   serial: true
   public: true
@@ -1340,6 +1377,7 @@ jobs:
     trigger: true
     passed:
     - experimental-cats
+    - experimental-cats-cflinuxfs5
     - experimental-smoke-tests
   - in_parallel:
     - get: cf-deployment-concourse-tasks

--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1344,12 +1344,12 @@ jobs:
     do:
     - get: experimental-pool
       trigger: true
-      passed: [ experimental-deploy ]
+      passed: [ experimental-cats ]
     - in_parallel:
       - get: cf-acceptance-tests-rc
       - get: relint-envs
       - get: cf-deployment-develop
-        passed: [ experimental-deploy ]
+        passed: [ experimental-cats ]
       - get: cf-deployment-concourse-tasks
     - task: update-integration-configs
       file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
@@ -1371,13 +1371,13 @@ jobs:
 
 - name: experimental-delete-deployment
   serial: true
+  serial_groups: [ experimental-cats-cflinuxfs5 ]
   public: true
   plan:
   - get: experimental-pool
     trigger: true
     passed:
     - experimental-cats
-    - experimental-cats-cflinuxfs5
     - experimental-smoke-tests
   - in_parallel:
     - get: cf-deployment-concourse-tasks


### PR DESCRIPTION
### WHAT is this change about?

Adds cflinuxfs5 stack validation to the experimental Concourse pipeline (hermione). This includes applying the add-cflinuxfs5.yml ops file in the experimental deploy jobs, and introducing a new experimental-cats-cflinuxfs5 job to run cf-acceptance-tests against the cflinuxfs5 stack.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

George (CF operator) needs confidence that the upcoming cflinuxfs5 stack works correctly with cf-deployment before it is promoted as a default or GA'd stack. Without this pipeline validation, there is no automated signal that cflinuxfs5 is stable and compatible with current cf-deployment.

### Please provide any contextual information.

Part of https://github.com/cloudfoundry/cf-deployment/issues/1323. Follows the same experimental validation approach previously used for cflinuxfs4 before it became the default stack. Depends on operations/experimental/add-cflinuxfs5.yml (introduced in [Attila's PR](https://github.com/cloudfoundry/cf-deployment/pull/1335)) and the cflinuxfs5_integration_config.json in relint-envs.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

Add cflinuxfs5-release to experimental pipeline validation; introduces experimental-cats-cflinuxfs5 job to run CATs against the cflinuxfs5 stack.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [X] YES - cflinuxfs5-release is added to opsReleases in inputs.yml
- [ ] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

1.) The experimental-deploy job in the hermione pipeline applies operations/experimental/add-cflinuxfs5.yml without errors.
2.) After a successful experimental-deploy, the new experimental-cats-cflinuxfs5 job triggers and completes CATs against the cflinuxfs5 stack using cflinuxfs5_integration_config.json.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@oliver-heinrich @jochenehret 
