### PR TITLE
Change the update release pipeline for cflinuxfs5

### DIFF
--- a/ci/input/inputs.yml
+++ b/ci/input/inputs.yml
@@ -13,6 +13,8 @@ baseReleases:
   repository: cloudfoundry/cf-smoke-tests-release
 - name: cflinuxfs4
   repository: cloudfoundry/cflinuxfs4-release
+- name: cflinuxfs5
+  repository: cloudfoundry/cflinuxfs5-release
 - name: diego
   repository: cloudfoundry/diego-release
 - name: garden-runc

--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -80,6 +80,8 @@ groups:
   - update-backup-and-restore-sdk
   - acquire-cflinuxfs4-compat-pre-dev-lock
   - update-cflinuxfs4-compat
+  - acquire-cflinuxfs5-pre-dev-lock
+  - update-cflinuxfs5
   - acquire-haproxy-pre-dev-lock
   - update-haproxy
   - acquire-nfs-volume-pre-dev-lock
@@ -385,6 +387,10 @@ resources:
   type: bosh-io-release
   source:
     repository: cloudfoundry/cflinuxfs4-compat-release
+- name: cflinuxfs5-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry/cflinuxfs5-release
 - name: haproxy-release
   type: bosh-io-release
   source:
@@ -825,6 +831,12 @@ resources:
     bucket: component-bump-logs
     json_key: ((greengrass_gcp_service_account_json))
     regexp: cflinuxfs4-compat/cf-(\d+)-(\d+)-(\d+)\.tgz
+- name: cflinuxfs5-component-bump-logs-gcs
+  type: gcs-resource
+  source:
+    bucket: component-bump-logs
+    json_key: ((greengrass_gcp_service_account_json))
+    regexp: cflinuxfs5/cf-(\d+)-(\d+)-(\d+)\.tgz
 - name: haproxy-component-bump-logs-gcs
   type: gcs-resource
   source:
@@ -9942,6 +9954,243 @@ jobs:
             file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
             params:
               RELEASE_REPOSITORY: cloudfoundry/cflinuxfs4-compat-release
+          - put: slack-alert
+            params:
+              channel_file: slack-channel/channel.txt
+              icon_emoji: ':cloudfoundrylogo:'
+              text: |
+                $TEXT_FILE_CONTENT
+
+                CI job: https://concourse.wg-ard.ci.cloudfoundry.org/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+                If you're unfamiliar with the update-release pre-validation, please review the following FAQ: https://docs.google.com/document/d/1dUIk2HWbUzdxWs-pNZ-cCqH7CuSNDBixIUoXIFkFpz0
+              text_file: slack-message/message.txt
+              username: Release Integration
+      ensure:
+        do:
+        - task: delete-deployment
+          file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+            IGNORE_ERRORS: true
+          attempts: 3
+        - task: remove-gcp-dns
+          file: runtime-ci/tasks/manage-gcp-dns/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+            GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
+            GCP_DNS_ZONE_NAME: wg-ard
+            ACTION: remove
+        - task: bbl-down
+          file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+          on_failure:
+            do:
+            - task: bbl-cleanup-leftovers
+              file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
+              input_mapping:
+                bbl-state: updated-bbl-state
+                pool-lock: pre-dev-pool
+              output_mapping:
+                updated-bbl-state: clean-bbl-state
+              params:
+                BBL_JSON_CONFIG: pool-lock/metadata
+            ensure:
+              put: relint-envs
+              params:
+                repository: clean-bbl-state
+                rebase: true
+          on_success:
+            put: relint-envs
+            params:
+              repository: updated-bbl-state
+              rebase: true
+    ensure:
+      do:
+      - put: pre-dev-pool
+        params:
+          release: pre-dev-pool
+- name: acquire-cflinuxfs5-pre-dev-lock
+  public: true
+  plan:
+  - in_parallel:
+    - get: cflinuxfs5-release
+      trigger: true
+      params:
+        tarball: false
+  - put: pre-dev-pool
+    params:
+      acquire: true
+    timeout: 4h
+- name: update-cflinuxfs5
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: pre-dev-pool
+      passed:
+      - acquire-cflinuxfs5-pre-dev-lock
+      trigger: true
+    - get: cflinuxfs5-release
+      params:
+        tarball: false
+      passed:
+      - acquire-cflinuxfs5-pre-dev-lock
+    - get: cf-deployment-release-candidate
+    - get: cf-deployment-develop
+    - get: stemcell
+      params:
+        tarball: false
+    - get: cf-deployment-concourse-tasks
+    - get: runtime-ci
+    - get: relint-envs
+    - get: relint-team
+  - task: update-additional-ops-files-cflinuxfs5-release-candidate
+    file: runtime-ci/tasks/update-single-opsfile-release/task.yml
+    input_mapping:
+      original-ops-file: cf-deployment-release-candidate
+      release: cflinuxfs5-release
+    output_mapping:
+      updated-ops-file: updated-cf-deployment-cflinuxfs5-release-candidate
+    params:
+      RELEASE_NAME: cflinuxfs5
+  - do:
+    - task: bbl-up
+      file: cf-deployment-concourse-tasks/bbl-up/task.yml
+      params:
+        BBL_JSON_CONFIG: pool-lock/metadata
+      input_mapping:
+        bbl-state: relint-envs
+        bbl-config: relint-envs
+        pool-lock: pre-dev-pool
+      on_failure:
+        do:
+        - task: bbl-cleanup-leftovers
+          file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
+          input_mapping:
+            bbl-state: updated-bbl-state
+            pool-lock: pre-dev-pool
+          output_mapping:
+            updated-bbl-state: clean-bbl-state
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+        ensure:
+          put: relint-envs
+          params:
+            repository: clean-bbl-state
+            rebase: true
+      on_success:
+        put: relint-envs
+        params:
+          repository: updated-bbl-state
+          rebase: true
+    - task: add-gcp-dns
+      file: runtime-ci/tasks/manage-gcp-dns/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+        pool-lock: pre-dev-pool
+      params:
+        BBL_JSON_CONFIG: pool-lock/metadata
+        GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
+        GCP_DNS_ZONE_NAME: wg-ard
+        ACTION: add
+    - do:
+      - task: combine-vars-files
+        file: runtime-ci/tasks/combine-inputs/task.yml
+        input_mapping:
+          first-input: cf-deployment-release-candidate
+          second-input: relint-envs
+        output_mapping:
+          combined-inputs: combined-vars-files
+      - task: deploy-cf
+        file: runtime-ci/tasks/bosh-deploy-with-first-ops/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          cf-deployment: updated-cf-deployment-cflinuxfs5-release-candidate
+          ops-files: updated-cf-deployment-cflinuxfs5-release-candidate
+          vars-files: combined-vars-files
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          OPS_FILES: |
+            operations/scale-to-one-az.yml
+            operations/use-compiled-releases.yml
+            operations/experimental/use-compiled-releases-windows.yml
+          REGENERATE_CREDENTIALS: false
+          BOSH_DEPLOY_ARGS: --parallel 50
+      - task: ensure-api-healthy
+        file: runtime-ci/tasks/ensure-api-healthy/task.yml
+        input_mapping:
+          cats-integration-config: relint-envs
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+      - task: run-errand-smoke-tests
+        file: cf-deployment-concourse-tasks/run-errand/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          ERRAND_NAME: smoke_tests
+      on_success:
+        do:
+        - task: update-additional-ops-files-cflinuxfs5-develop
+          file: runtime-ci/tasks/update-single-opsfile-release/task.yml
+          input_mapping:
+            original-ops-file: cf-deployment-develop
+            release: cflinuxfs5-release
+          output_mapping:
+            updated-ops-file: updated-cf-deployment-cflinuxfs5-develop
+          params:
+            RELEASE_NAME: cflinuxfs5
+        - put: cf-deployment-develop
+          params:
+            rebase: true
+            repository: updated-cf-deployment-cflinuxfs5-develop
+      on_failure:
+        do:
+        - task: push-to-release-branch
+          file: runtime-ci/tasks/push-to-release-branch/task.yml
+          input_mapping:
+            updated-cf-deployment: updated-cf-deployment-cflinuxfs5-release-candidate
+            release: cflinuxfs5-release
+          params:
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
+            RELEASE_NAME: cflinuxfs5
+        - task: retrieve-bosh-logs
+          file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+        - put: cflinuxfs5-component-bump-logs-gcs
+          params:
+            file: bosh-logs/cf-*.tgz
+        ensure:
+          do:
+          - task: create-slack-message
+            file: runtime-ci/tasks/create-slack-message/task.yml
+            input_mapping:
+              release: cflinuxfs5-release
+            params:
+              BOSH_LOGS_PREFIX: https://storage.cloud.google.com/component-bump-logs/cflinuxfs5
+              RELEASE_NAME: cflinuxfs5
+          - task: lookup-slack-channel-for-release-owner
+            file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
+            params:
+              RELEASE_REPOSITORY: cloudfoundry/cflinuxfs5-release
           - put: slack-alert
             params:
               channel_file: slack-channel/channel.txt


### PR DESCRIPTION
### WHAT is this change about?

This change introduces the cflinuxfs5 release into the cf-deployment pipeline. It updates the inputs.yml file to include the cflinuxfs5 release and modifies the update-releases.yml pipeline to add jobs for acquiring and updating the cflinuxfs5 release.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana, a platform operator, needs to ensure that the latest Linux stack (cflinuxfs5) is integrated into the deployment pipeline to support modern application requirements and security updates. This change enables the pipeline to manage and update the cflinuxfs5 release seamlessly.

### Please provide any contextual information.

Part of https://github.com/cloudfoundry/cf-deployment/issues/1323.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [X] NO

The cflinuxfs5 release is newly added and requires further testing.

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

> **Types of breaking changes:**
> 1. **causes app or operator downtime**
> 2. increases VM footprint of cf-deployment - e.g. new jobs, new add ons, increases # of instances etc.
> 3. modifies, deletes or moves the name of a job or instance group in the main manifest
> 4. modifies the name or deletes a property of a job or instance group in the main manifest
> 5. changes the name of credentials in the main manifest
> 6. requires out-of-band manual intervention on the part of the operator
> 7. modifies the ops-file path, changes the type, changes the values or removes ops-files from the following folders
>    - `./operations/` or `./operations/experimental`
>    - `./addons`
>    - `./backup-and-restore/`
>
> _If you're promoting an experimental Ops-file (or removing one), Please follow the [Ops-file workflows](https://github.com/cloudfoundry/cf-deployment/blob/main/ops-file-promotion-workflow.md)._

> Ops files changes in the following folders are considered as NON BREAKING CHANGES
> `./community`, `./example-vars-files`, `./test`

### How should this change be described in cf-deployment release notes?

Added support for the cflinuxfs5 release in the cf-deployment pipeline. This includes pipeline jobs for acquiring and updating the release.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [X] YES - cflinuxfs5
- [ ] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [X] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Verify that the cflinuxfs5 release is listed in the inputs.yml file:

`grep "cflinuxfs5" ci/input/inputs.yml`

Verify that the update-cflinuxfs5 job is present in the update-releases.yml pipeline:

`grep "update-cflinuxfs5" ci/pipelines/update-releases.yml`

Run the pipeline and ensure the update-cflinuxfs5 job completes successfully.


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@oliver-heinrich @jochenehret 
