### PR TITLE
Revert: reset APP_STATS_THRESHOLD back to 10

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -951,7 +951,7 @@ jobs:
       APP_PUSHABILITY_THRESHOLD: 10
       RECENT_LOGS_THRESHOLD: 10000
       STREAMING_LOGS_THRESHOLD: 10000
-      APP_STATS_THRESHOLD: 30
+      APP_STATS_THRESHOLD: 10
   - in_parallel:
     - task: open-asgs-for-credhub
       file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
@@ -1236,7 +1236,7 @@ jobs:
       APP_PUSHABILITY_THRESHOLD: 10
       RECENT_LOGS_THRESHOLD: 10000
       STREAMING_LOGS_THRESHOLD: 10000
-      APP_STATS_THRESHOLD: 30
+      APP_STATS_THRESHOLD: 10
   - in_parallel:
     - task: open-asgs-for-uaa
       file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml


### PR DESCRIPTION
## Summary
- Reverts the temporary change from #1334
- Resets `APP_STATS_THRESHOLD` from 30 back to 10 in both locations in `ci/pipelines/cf-deployment.yml`
- The original increase was a temporary workaround during the Noble stemcell migration and is no longer needed