### PR TITLE
Add scheduler/cloud_controller_clock job to stop-skip-tls-validation ops file

### DIFF
--- a/operations/stop-skipping-tls-validation.yml
+++ b/operations/stop-skipping-tls-validation.yml
@@ -10,3 +10,6 @@
 
 - type: remove
   path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/properties/ssl/skip_cert_verify
+
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ssl/skip_cert_verify


### PR DESCRIPTION
### WHAT is this change about?

Complete [stop-skipping-tls-validation.yml](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/stop-skipping-tls-validation.yml) ops file. Instance group "scheduler" / job "cloud_controller_clock" was missing.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have secure TLS communications for all components.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/906

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

The ops file [stop-skipping-tls-validation.yml](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/stop-skipping-tls-validation.yml) now also secures the "scheduler"/"cloud_controller_clock" job.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [ ] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

Validation pipeline is green.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
