### PR TITLE
Remove add-cflinuxfs5 from bosh-deploy-cf-latest-release

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1170,7 +1170,6 @@ jobs:
         operations/experimental/enable-containerd-for-processes.yml
         operations/experimental/disable-cf-credhub.yml
         operations/experimental/disable-interpolate-service-bindings.yml
-        operations/experimental/add-cflinuxfs5.yml
         operations/increase-doppler-vm-type-from-minimal-to-small.yml
         operations/scale-diego-cell-to-8.yml
         operations/test/speed-up-dynamic-asgs.yml


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

This PR targets **develop** branch.

### WHAT is this change about?

Remove `operations/experimental/add-cflinuxfs5.yml` from the `bosh-deploy-cf-latest-release` CI step, while keeping it in the `bosh-deploy-cf-develop` step.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

The experimental `experimental-deploy` CI job is failing because the `bosh-deploy-cf-latest-release` step applies `operations/experimental/add-cflinuxfs5.yml` on top of the released main manifest, which does not yet contain the disable-credhub fix from PR #1345. This causes the job to break in CI, blocking validation of the cflinuxfs5 experimental feature.

### Please provide any contextual information.

- The disable-credhub fix was merged via PR #1345 and is present on the develop branch, but has not yet been released to main.
- The `bosh-deploy-cf-latest-release` step in `ci/pipelines/cf-deployment.yml` (around line 1150) applies the ops file against the latest released manifest, which is incompatible without the fix.
- By removing the ops file from the `latest-release` step and keeping it only in the `develop` step, we correctly model the operator use case: an operator adds `add-cflinuxfs5.yml` on top of an existing deployment. The upgrade scenario is validated via the develop path.

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

CI: Fixed the experimental cflinuxfs5 deploy job by removing `add-cflinuxfs5.yml` from the `bosh-deploy-cf-latest-release` step, so that the ops file is only applied on the develop branch path, correctly simulating an operator-initiated upgrade.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [x] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

1. The `experimental-deploy` CI job passes after this change.
2. Verify that `bosh-deploy-cf-latest-release` no longer includes `operations/experimental/add-cflinuxfs5.yml` in the pipeline config.
3. Verify that `bosh-deploy-cf-develop` still includes `operations/experimental/add-cflinuxfs5.yml`.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@jochenehret 