### PR TITLE
Revert stemcell downgrade

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -2954,4 +2954,4 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-noble
-  version: "1.333"
+  version: "1.383"


### PR DESCRIPTION
### WHAT is this change about?

We had to pin the Noble stemcell version to 1.333 because that version vanished from the Concourse resource. It is however required as input for the "update-bosh-release-xyz" jobs (they depend on the update-stemcell-and-recompile-releases job). To unblock the cf-deployment validation, we revert the downgrade manually.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have working community pipelines that ship new releases.

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/commit/34a3f0f84df7ee24248e2e14dc4553823c89ca00

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The cf-deployment validation pipeline passes.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
