### PR TITLE
Fix "update-releases" pipeline

### DIFF
--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -14701,8 +14701,6 @@ jobs:
     - get: relint-envs
     - get: cf-deployment-develop
     - get: cf-deployment-concourse-tasks
-      params:
-        tarball: false
     - get: windows2019fs-offline-release
       trigger: true
       params:

--- a/ci/template/update-releases.yml
+++ b/ci/template/update-releases.yml
@@ -1053,8 +1053,6 @@ jobs:
     - get: relint-envs
     - get: cf-deployment-develop
     - get: cf-deployment-concourse-tasks
-      params:
-        tarball: false
     - get: #@ r.name + "-offline-release"
       trigger: true
       params:


### PR DESCRIPTION
### WHAT is this change about?

Fix "update-releases" pipeline. Concourse v8 has stricter checking for resource configurations.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have a working "update-releases" pipeline.

### Please provide any contextual information.

Broken job: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/update-releases/jobs/update-windows2019fs-offline-release/builds/51

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The abovementioned "update-windows2019fs-offline-release" job passes.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
