### PR TITLE
Revert BOSH Lite bbl v9.0.36 pinning

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -259,13 +259,6 @@ resources:
   source:
     uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
 
-- name: cf-deployment-concourse-tasks-bbl-9.0.36
-  type: git
-  icon: github
-  source:
-    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
-    branch: bbl-9.0.36
-
 - name: runtime-ci
   type: git
   icon: github
@@ -1515,7 +1508,6 @@ jobs:
       - lite-smoke-tests
     - in_parallel:
       - get: cf-deployment-concourse-tasks
-      - get: cf-deployment-concourse-tasks-bbl-9.0.36
       - get: relint-envs
       - get: runtime-ci
       - get: bosh-bootloader
@@ -1541,8 +1533,7 @@ jobs:
         FIRST_DIR: plan-patches/bosh-lite-gcp
         SECOND_DIR: environments/test/snitch/bbl-config
     - task: update-infrastructure
-      # temporary workaround for https://github.com/cloudfoundry/bosh-bootloader/issues/672
-      file: cf-deployment-concourse-tasks-bbl-9.0.36/bbl-up/task.yml
+      file: cf-deployment-concourse-tasks/bbl-up/task.yml
       params:
         BBL_CONFIG_DIR: .
         BBL_ENV_NAME: snitch-lite


### PR DESCRIPTION
### WHAT is this change about?

Revert bosh-bootloader pinning to v9.0.36 for BOSH Lite.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to use the latest bbl version for her validation environments.

### Please provide any contextual information.

https://github.com/cloudfoundry/bosh-bootloader/issues/672

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [x] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The "lite-recreate-director" job works and uses the latest bbl version:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/lite-recreate-director

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
