### PR TITLE
Add runtime DNS configuration task for snitch/lite

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -1552,6 +1552,15 @@ jobs:
         params:
           repository: updated-bbl-state
           rebase: true
+    - task: bosh-extend-runtime-config
+      file: runtime-ci/tasks/bosh-extend-runtime-config/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+        ops-file: relint-envs
+      params:
+        BBL_STATE_DIR: environments/test/snitch/bbl-state
+        OPS_FILE_PATH: environments/test/snitch/bbl-config/warden-noble-dns.yml
+        RUNTIME_CONFIG_NAME: dns
     - put: lite-pool
       params: {release: lite-pool}
 


### PR DESCRIPTION
### WHAT is this change about?

Fix runtime DNS configuration for BOSH Lite on Noble Warden stemcell.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to have a green validation for BOSH Lite on Noble.

### Please provide any contextual information.

https://github.com/cloudfoundry/runtime-ci/pull/676

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

N/A (only running smoke tests on BOSH Lite)

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The [lite-smoke-tests job](https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/lite-smoke-tests) is green after the [lite-recreate-director job](https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/lite-recreate-director) has been executed.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
