### PR TITLE
Use storage-cli for WebDAV blobstore

### DIFF
--- a/cf-deployment.yml
+++ b/cf-deployment.yml
@@ -954,14 +954,15 @@ instance_groups:
           private_key: "((cc_logcache_tls.private_key))"
           certificate: "((cc_logcache_tls.certificate))"
         buildpacks: &blobstore-properties
-          blobstore_type: webdav
-          webdav_config:
-            ca_cert: "((blobstore_tls.ca))"
-            blobstore_timeout: 5
+          blobstore_type: storage-cli
+          blobstore_provider: dav
+          connection_config:
+            username: blobstore-user
             password: "((blobstore_admin_users_password))"
             private_endpoint: https://blobstore.service.cf.internal:4443
             public_endpoint: https://blobstore.((system_domain))
-            username: blobstore-user
+            secret: "((blobstore_secure_link_secret))"
+            ca_cert: "((blobstore_tls.ca))"
         resource_pool: *blobstore-properties
         packages: *blobstore-properties
         droplets: *blobstore-properties


### PR DESCRIPTION
### WHAT is this change about?

Enable "storage-cli" for the default WebDAV blobstore setup.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana wants to use a supported blobstore client.

### Please provide any contextual information.

RFC0043: https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0043-cc-blobstore-storage-cli.md
Requires capi 1.238.0: requires capi 1.238.0: https://github.com/cloudfoundry/capi-release/releases/tag/1.238.0

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

### How should this change be described in cf-deployment release notes?

The default WebDAV blobstore setup ("singleton-blobstore") now uses the [storage-cli](https://github.com/cloudfoundry/storage-cli) client. There is no migration procedure required.

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The cf-deployment validation pipeline is green, in particular the environments with the "singleton-blobstore" setup:

- luna (fresh-deploy)
- snitch (lite-deploy)
- bbr / baba-yaga (bbr-deploy)
- cedric (windows-deploy)
- snape (fips-deploy)

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
