### PR TITLE
trelawney/upgrade: remove external ip ops files

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -842,7 +842,6 @@ jobs:
     params:
       BASE_OPS_FILE_DIR: operations
       NEW_OPS_FILES: |
-        environments/test/trelawney/add-external-ips-for-cloud-sql-db.yml
         environments/test/trelawney/scale-log-api-to-4.yml
   - task: setup-external-ip-db-vars
     file: runtime-ci/tasks/generate-external-ip-db-vars/task.yml
@@ -867,7 +866,6 @@ jobs:
       OPS_FILES: |
         operations/use-compiled-releases.yml
         operations/use-external-dbs.yml
-        operations/add-external-ips-for-cloud-sql-db.yml
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
         operations/set-cpu-weight.yml
         operations/enable-cpu-throttling.yml
@@ -879,7 +877,6 @@ jobs:
         operations/use-internal-lookup-for-route-services.yml
       VARS_FILES: |
         environments/test/trelawney/external-db-vars.yml
-        environments/test/trelawney/external-public-ip-vars.yml
         environments/test/trelawney/external-db-host-vars.yml
         environments/test/trelawney/gcs-vars.yml
       REGENERATE_CREDENTIALS: true
@@ -906,7 +903,6 @@ jobs:
     params:
       BASE_OPS_FILE_DIR: operations
       NEW_OPS_FILES: |
-        environments/test/trelawney/add-external-ips-for-cloud-sql-db.yml
         environments/test/trelawney/scale-log-api-to-4.yml
   - task: bosh-deploy-cf-develop
     attempts: 1
@@ -922,7 +918,6 @@ jobs:
       OPS_FILES: |
         operations/use-compiled-releases.yml
         operations/use-external-dbs.yml
-        operations/add-external-ips-for-cloud-sql-db.yml
         operations/experimental/colocate-smoke-tests-on-cc-worker.yml
         operations/set-cpu-weight.yml
         operations/enable-cpu-throttling.yml
@@ -935,7 +930,6 @@ jobs:
         operations/test/speed-up-dynamic-asgs.yml
       VARS_FILES: |
         environments/test/trelawney/external-db-vars.yml
-        environments/test/trelawney/external-public-ip-vars.yml
         environments/test/trelawney/external-db-host-vars.yml
         environments/test/trelawney/gcs-vars.yml
       DEPLOY_WITH_UPTIME_MEASUREMENTS: true


### PR DESCRIPTION
### WHAT is this change about?

* switching to private ip connectivity for db connection
* database host is now retrieved from Terraform state here: https://github.com/cloudfoundry/relint-envs/blob/4224860da9d25d2d15134f5b182ec649bb9ac400/environments/test/trelawney/bbl-config/terraform/external_db.tf#L126
* assigning external ips to CF VMs is not necessary anymore

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

Alana doesn't want to allocate external ips for the database connection.

### Please provide any contextual information.

https://github.com/cloudfoundry/runtime-ci/pull/685
https://github.com/cloudfoundry/relint-envs/blob/4224860da9d25d2d15134f5b182ec649bb9ac400/environments/test/trelawney/bbl-config/terraform/external_db.tf#L126

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [x] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO

> **Types of breaking changes:**

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The "upgrade" jobs succeed:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/upgrade-deploy
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/upgrade-cats

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
