### PR TITLE
retry updated-integration-configs task, to make it more resilient

### DIFF
--- a/ci/pipelines/cf-deployment.yml
+++ b/ci/pipelines/cf-deployment.yml
@@ -609,6 +609,7 @@ jobs:
       REGENERATE_CREDENTIALS: true
   - task: update-integration-configs
     file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+    attempts: 3
     params:
       BBL_STATE_DIR: environments/test/luna/bbl-state
       CATS_INTEGRATION_CONFIG_FILE: environments/test/luna/integration_config.json
@@ -711,6 +712,7 @@ jobs:
         passed: [ fresh-deploy ]
     - task: update-integration-configs
       file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+      attempts: 3
       params:
         BBL_STATE_DIR: environments/test/luna/bbl-state
         CATS_INTEGRATION_CONFIG_FILE: environments/test/luna/integration_config.json
@@ -1301,6 +1303,7 @@ jobs:
       - get: cf-deployment-concourse-tasks
     - task: update-integration-configs
       file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+      attempts: 3
       params:
         BBL_STATE_DIR: environments/test/hermione/bbl-state
         CATS_INTEGRATION_CONFIG_FILE: environments/test/hermione/integration_config.json
@@ -1999,6 +2002,7 @@ jobs:
         SKIP_STEMCELL_UPLOAD: true
     - task: update-integration-configs
       file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+      attempts: 3
       params:
         BBL_STATE_DIR: environments/test/snape/bbl-state
         CATS_INTEGRATION_CONFIG_FILE: environments/test/snape/integration_config.json
@@ -2083,6 +2087,7 @@ jobs:
               passed: [ fips-deploy ]
         - task: update-integration-configs
           file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+          attempts: 3
           params:
             BBL_STATE_DIR: environments/test/snape/bbl-state
             CATS_INTEGRATION_CONFIG_FILE: environments/test/snape/integration_config.json

--- a/ci/pipelines/jammy-stemcell.yml
+++ b/ci/pipelines/jammy-stemcell.yml
@@ -130,6 +130,7 @@ jobs:
                 - get: cf-deployment-concourse-tasks
                 - get: cf-acceptance-tests-rc
           - file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
+            attempts: 3
             input_mapping:
               bbl-state: relint-envs
               cf-acceptance-tests: cf-acceptance-tests-rc


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

> _Please describe the change._

Make the updated-integration-configs tasks, more resilient! retry 3 times...

### Please provide any contextual information.

[> _Include any links to other PRs, stories, slack discussions, etc... that will help establish context._](https://github.com/cloudfoundry/cf-deployment-concourse-tasks/pull/250)

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

All the update-integration-configs tasks must be green within 3 attempts..

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
