### PR TITLE
Regenerate update-releases pipeline after cflinuxfs5 inlined and moved

### DIFF
--- a/ci/pipelines/update-releases.yml
+++ b/ci/pipelines/update-releases.yml
@@ -24,6 +24,8 @@ groups:
   - update-cf-smoke-tests
   - acquire-cflinuxfs4-pre-dev-lock
   - update-cflinuxfs4
+  - acquire-cflinuxfs5-pre-dev-lock
+  - update-cflinuxfs5
   - acquire-diego-pre-dev-lock
   - update-diego
   - acquire-garden-runc-pre-dev-lock
@@ -80,8 +82,6 @@ groups:
   - update-backup-and-restore-sdk
   - acquire-cflinuxfs4-compat-pre-dev-lock
   - update-cflinuxfs4-compat
-  - acquire-cflinuxfs5-pre-dev-lock
-  - update-cflinuxfs5
   - acquire-haproxy-pre-dev-lock
   - update-haproxy
   - acquire-nfs-volume-pre-dev-lock
@@ -283,6 +283,10 @@ resources:
   type: bosh-io-release
   source:
     repository: cloudfoundry/cflinuxfs4-release
+- name: cflinuxfs5-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry/cflinuxfs5-release
 - name: diego-release
   type: bosh-io-release
   source:
@@ -387,10 +391,6 @@ resources:
   type: bosh-io-release
   source:
     repository: cloudfoundry/cflinuxfs4-compat-release
-- name: cflinuxfs5-release
-  type: bosh-io-release
-  source:
-    repository: cloudfoundry/cflinuxfs5-release
 - name: haproxy-release
   type: bosh-io-release
   source:
@@ -531,6 +531,18 @@ resources:
     bucket: component-bump-logs
     json_key: ((greengrass_gcp_service_account_json))
     regexp: cflinuxfs4/cf-(\d+)-(\d+)-(\d+)\.tgz
+- name: cflinuxfs5-release-gcs
+  type: gcs-resource
+  source:
+    bucket: cf-deployment-compiled-releases
+    json_key: ((ci_dev_gcp_service_account_json))
+    regexp: cflinuxfs5-[^-]+-ubuntu-noble-[^-]+-(\d+)-(\d+)-(\d+).*\.tgz
+- name: cflinuxfs5-component-bump-logs-gcs
+  type: gcs-resource
+  source:
+    bucket: component-bump-logs
+    json_key: ((greengrass_gcp_service_account_json))
+    regexp: cflinuxfs5/cf-(\d+)-(\d+)-(\d+)\.tgz
 - name: diego-release-gcs
   type: gcs-resource
   source:
@@ -831,12 +843,6 @@ resources:
     bucket: component-bump-logs
     json_key: ((greengrass_gcp_service_account_json))
     regexp: cflinuxfs4-compat/cf-(\d+)-(\d+)-(\d+)\.tgz
-- name: cflinuxfs5-component-bump-logs-gcs
-  type: gcs-resource
-  source:
-    bucket: component-bump-logs
-    json_key: ((greengrass_gcp_service_account_json))
-    regexp: cflinuxfs5/cf-(\d+)-(\d+)-(\d+)\.tgz
 - name: haproxy-component-bump-logs-gcs
   type: gcs-resource
   source:
@@ -2640,6 +2646,291 @@ jobs:
             file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
             params:
               RELEASE_REPOSITORY: cloudfoundry/cflinuxfs4-release
+          - put: slack-alert
+            params:
+              channel_file: slack-channel/channel.txt
+              icon_emoji: ':cloudfoundrylogo:'
+              text: |
+                $TEXT_FILE_CONTENT
+
+                CI job: https://concourse.wg-ard.ci.cloudfoundry.org/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+                If you're unfamiliar with the update-release pre-validation, please review the following FAQ: https://docs.google.com/document/d/1dUIk2HWbUzdxWs-pNZ-cCqH7CuSNDBixIUoXIFkFpz0
+              text_file: slack-message/message.txt
+              username: Release Integration
+      ensure:
+        do:
+        - task: delete-deployment
+          file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+            IGNORE_ERRORS: true
+          attempts: 3
+        - task: remove-gcp-dns
+          file: runtime-ci/tasks/manage-gcp-dns/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+            GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
+            GCP_DNS_ZONE_NAME: wg-ard
+            ACTION: remove
+        - task: bbl-down
+          file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+          on_failure:
+            do:
+            - task: bbl-cleanup-leftovers
+              file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
+              input_mapping:
+                bbl-state: updated-bbl-state
+                pool-lock: pre-dev-pool
+              output_mapping:
+                updated-bbl-state: clean-bbl-state
+              params:
+                BBL_JSON_CONFIG: pool-lock/metadata
+            ensure:
+              put: relint-envs
+              params:
+                repository: clean-bbl-state
+                rebase: true
+          on_success:
+            put: relint-envs
+            params:
+              repository: updated-bbl-state
+              rebase: true
+    ensure:
+      do:
+      - put: pre-dev-pool
+        params:
+          release: pre-dev-pool
+- name: acquire-cflinuxfs5-pre-dev-lock
+  public: true
+  plan:
+  - in_parallel:
+    - get: cflinuxfs5-release
+      trigger: true
+      params:
+        tarball: false
+  - put: pre-dev-pool
+    params:
+      acquire: true
+    timeout: 4h
+- name: update-cflinuxfs5
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: pre-dev-pool
+      passed:
+      - acquire-cflinuxfs5-pre-dev-lock
+      trigger: true
+    - get: cflinuxfs5-release
+      params:
+        tarball: false
+      passed:
+      - acquire-cflinuxfs5-pre-dev-lock
+    - get: cf-deployment-release-candidate
+    - get: cf-deployment-develop
+    - get: stemcell
+      params:
+        tarball: false
+      passed:
+      - update-stemcell-and-recompile-releases
+    - get: cf-deployment-concourse-tasks
+    - get: runtime-ci
+    - get: relint-envs
+    - get: relint-team
+  - task: update-release-cflinuxfs5-release-candidate
+    file: runtime-ci/tasks/update-single-manifest-release/task.yml
+    input_mapping:
+      cf-deployment: cf-deployment-release-candidate
+      release: cflinuxfs5-release
+    output_mapping:
+      updated-cf-deployment: updated-cf-deployment-cflinuxfs5-release-candidate
+    params:
+      RELEASE_NAME: cflinuxfs5
+  - task: update-additional-ops-files-cflinuxfs5-release-candidate
+    file: runtime-ci/tasks/update-single-opsfile-release/task.yml
+    input_mapping:
+      original-ops-file: updated-cf-deployment-cflinuxfs5-release-candidate
+      release: cflinuxfs5-release
+    output_mapping:
+      updated-ops-file: updated-cf-deployment-cflinuxfs5-release-candidate
+    params:
+      RELEASE_NAME: cflinuxfs5
+  - do:
+    - task: bbl-up
+      file: cf-deployment-concourse-tasks/bbl-up/task.yml
+      params:
+        BBL_JSON_CONFIG: pool-lock/metadata
+      input_mapping:
+        bbl-state: relint-envs
+        bbl-config: relint-envs
+        pool-lock: pre-dev-pool
+      on_failure:
+        do:
+        - task: bbl-cleanup-leftovers
+          file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
+          input_mapping:
+            bbl-state: updated-bbl-state
+            pool-lock: pre-dev-pool
+          output_mapping:
+            updated-bbl-state: clean-bbl-state
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+        ensure:
+          put: relint-envs
+          params:
+            repository: clean-bbl-state
+            rebase: true
+      on_success:
+        put: relint-envs
+        params:
+          repository: updated-bbl-state
+          rebase: true
+    - task: add-gcp-dns
+      file: runtime-ci/tasks/manage-gcp-dns/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+        pool-lock: pre-dev-pool
+      params:
+        BBL_JSON_CONFIG: pool-lock/metadata
+        GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
+        GCP_DNS_ZONE_NAME: wg-ard
+        ACTION: add
+    - do:
+      - task: combine-vars-files
+        file: runtime-ci/tasks/combine-inputs/task.yml
+        input_mapping:
+          first-input: cf-deployment-release-candidate
+          second-input: relint-envs
+        output_mapping:
+          combined-inputs: combined-vars-files
+      - task: update-stemcell-for-deploy
+        file: runtime-ci/tasks/update-base-manifest-stemcell/task.yml
+        input_mapping:
+          cf-deployment: updated-cf-deployment-cflinuxfs5-release-candidate
+        output_mapping:
+          updated-cf-deployment: updated-cf-deployment-cflinuxfs5-release-candidate-with-stemcell
+      - task: deploy-cf
+        file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          cf-deployment: updated-cf-deployment-cflinuxfs5-release-candidate-with-stemcell
+          ops-files: updated-cf-deployment-cflinuxfs5-release-candidate-with-stemcell
+          vars-files: combined-vars-files
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          OPS_FILES: |
+            operations/scale-to-one-az.yml
+          REGENERATE_CREDENTIALS: false
+          BOSH_DEPLOY_ARGS: --parallel 50
+      - task: ensure-api-healthy
+        file: runtime-ci/tasks/ensure-api-healthy/task.yml
+        input_mapping:
+          pool-lock: pre-dev-pool
+          cats-integration-config: relint-envs
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+      - task: run-errand-smoke-tests
+        file: cf-deployment-concourse-tasks/run-errand/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          ERRAND_NAME: smoke_tests
+      - task: export-compiled-release-cflinuxfs5
+        file: runtime-ci/tasks/export-compiled-release-tarball/task.yml
+        input_mapping:
+          bbl-state: relint-envs
+          manifest: updated-cf-deployment-cflinuxfs5-release-candidate-with-stemcell
+          pool-lock: pre-dev-pool
+        params:
+          BBL_JSON_CONFIG: pool-lock/metadata
+          RELEASE_NAME: cflinuxfs5
+      on_success:
+        do:
+        - task: update-release-cflinuxfs5-develop
+          file: runtime-ci/tasks/update-single-manifest-release/task.yml
+          input_mapping:
+            cf-deployment: cf-deployment-develop
+            release: cflinuxfs5-release
+          output_mapping:
+            updated-cf-deployment: updated-cf-deployment-cflinuxfs5-develop
+          params:
+            RELEASE_NAME: cflinuxfs5
+        - task: update-additional-ops-files-cflinuxfs5-develop
+          file: runtime-ci/tasks/update-single-opsfile-release/task.yml
+          input_mapping:
+            original-ops-file: updated-cf-deployment-cflinuxfs5-develop
+            release: cflinuxfs5-release
+          output_mapping:
+            updated-ops-file: updated-cf-deployment-cflinuxfs5-develop
+          params:
+            RELEASE_NAME: cflinuxfs5
+        - task: update-compiled-releases-ops-file-cflinuxfs5-develop
+          file: runtime-ci/tasks/update-single-compiled-release/task.yml
+          input_mapping:
+            original-compiled-releases-ops-file: updated-cf-deployment-cflinuxfs5-develop
+            release: cflinuxfs5-release
+          output_mapping:
+            updated-compiled-releases-ops-file: updated-cf-deployment-cflinuxfs5-develop
+          params:
+            RELEASE_NAME: cflinuxfs5
+            ORIGINAL_OPS_FILE_PATH: operations/use-compiled-releases.yml
+            UPDATED_OPS_FILE_PATH: operations/use-compiled-releases.yml
+        - put: cflinuxfs5-release-gcs
+          params:
+            file: compiled-release-tarball/*.tgz
+            predefined_acl: publicRead
+        - put: cf-deployment-develop
+          params:
+            rebase: true
+            repository: updated-cf-deployment-cflinuxfs5-develop
+      on_failure:
+        do:
+        - task: push-to-release-branch
+          file: runtime-ci/tasks/push-to-release-branch/task.yml
+          input_mapping:
+            updated-cf-deployment: updated-cf-deployment-cflinuxfs5-release-candidate
+            release: cflinuxfs5-release
+          params:
+            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
+            RELEASE_NAME: cflinuxfs5
+        - task: retrieve-bosh-logs
+          file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
+          input_mapping:
+            bbl-state: relint-envs
+            pool-lock: pre-dev-pool
+          params:
+            BBL_JSON_CONFIG: pool-lock/metadata
+        - put: cflinuxfs5-component-bump-logs-gcs
+          params:
+            file: bosh-logs/cf-*.tgz
+        ensure:
+          do:
+          - task: create-slack-message
+            file: runtime-ci/tasks/create-slack-message/task.yml
+            input_mapping:
+              release: cflinuxfs5-release
+            params:
+              BOSH_LOGS_PREFIX: https://storage.cloud.google.com/component-bump-logs/cflinuxfs5
+              RELEASE_NAME: cflinuxfs5
+          - task: lookup-slack-channel-for-release-owner
+            file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
+            params:
+              RELEASE_REPOSITORY: cloudfoundry/cflinuxfs5-release
           - put: slack-alert
             params:
               channel_file: slack-channel/channel.txt
@@ -10020,243 +10311,6 @@ jobs:
       - put: pre-dev-pool
         params:
           release: pre-dev-pool
-- name: acquire-cflinuxfs5-pre-dev-lock
-  public: true
-  plan:
-  - in_parallel:
-    - get: cflinuxfs5-release
-      trigger: true
-      params:
-        tarball: false
-  - put: pre-dev-pool
-    params:
-      acquire: true
-    timeout: 4h
-- name: update-cflinuxfs5
-  public: true
-  serial: true
-  plan:
-  - in_parallel:
-    - get: pre-dev-pool
-      passed:
-      - acquire-cflinuxfs5-pre-dev-lock
-      trigger: true
-    - get: cflinuxfs5-release
-      params:
-        tarball: false
-      passed:
-      - acquire-cflinuxfs5-pre-dev-lock
-    - get: cf-deployment-release-candidate
-    - get: cf-deployment-develop
-    - get: stemcell
-      params:
-        tarball: false
-    - get: cf-deployment-concourse-tasks
-    - get: runtime-ci
-    - get: relint-envs
-    - get: relint-team
-  - task: update-additional-ops-files-cflinuxfs5-release-candidate
-    file: runtime-ci/tasks/update-single-opsfile-release/task.yml
-    input_mapping:
-      original-ops-file: cf-deployment-release-candidate
-      release: cflinuxfs5-release
-    output_mapping:
-      updated-ops-file: updated-cf-deployment-cflinuxfs5-release-candidate
-    params:
-      RELEASE_NAME: cflinuxfs5
-  - do:
-    - task: bbl-up
-      file: cf-deployment-concourse-tasks/bbl-up/task.yml
-      params:
-        BBL_JSON_CONFIG: pool-lock/metadata
-      input_mapping:
-        bbl-state: relint-envs
-        bbl-config: relint-envs
-        pool-lock: pre-dev-pool
-      on_failure:
-        do:
-        - task: bbl-cleanup-leftovers
-          file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
-          input_mapping:
-            bbl-state: updated-bbl-state
-            pool-lock: pre-dev-pool
-          output_mapping:
-            updated-bbl-state: clean-bbl-state
-          params:
-            BBL_JSON_CONFIG: pool-lock/metadata
-        ensure:
-          put: relint-envs
-          params:
-            repository: clean-bbl-state
-            rebase: true
-      on_success:
-        put: relint-envs
-        params:
-          repository: updated-bbl-state
-          rebase: true
-    - task: add-gcp-dns
-      file: runtime-ci/tasks/manage-gcp-dns/task.yml
-      input_mapping:
-        bbl-state: relint-envs
-        pool-lock: pre-dev-pool
-      params:
-        BBL_JSON_CONFIG: pool-lock/metadata
-        GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
-        GCP_DNS_ZONE_NAME: wg-ard
-        ACTION: add
-    - do:
-      - task: combine-vars-files
-        file: runtime-ci/tasks/combine-inputs/task.yml
-        input_mapping:
-          first-input: cf-deployment-release-candidate
-          second-input: relint-envs
-        output_mapping:
-          combined-inputs: combined-vars-files
-      - task: deploy-cf
-        file: runtime-ci/tasks/bosh-deploy-with-first-ops/task.yml
-        input_mapping:
-          bbl-state: relint-envs
-          cf-deployment: updated-cf-deployment-cflinuxfs5-release-candidate
-          ops-files: updated-cf-deployment-cflinuxfs5-release-candidate
-          vars-files: combined-vars-files
-          pool-lock: pre-dev-pool
-        params:
-          BBL_JSON_CONFIG: pool-lock/metadata
-          OPS_FILES: |
-            operations/scale-to-one-az.yml
-            operations/use-compiled-releases.yml
-            operations/experimental/use-compiled-releases-windows.yml
-          REGENERATE_CREDENTIALS: false
-          BOSH_DEPLOY_ARGS: --parallel 50
-      - task: ensure-api-healthy
-        file: runtime-ci/tasks/ensure-api-healthy/task.yml
-        input_mapping:
-          cats-integration-config: relint-envs
-          pool-lock: pre-dev-pool
-        params:
-          BBL_JSON_CONFIG: pool-lock/metadata
-      - task: run-errand-smoke-tests
-        file: cf-deployment-concourse-tasks/run-errand/task.yml
-        input_mapping:
-          bbl-state: relint-envs
-          pool-lock: pre-dev-pool
-        params:
-          BBL_JSON_CONFIG: pool-lock/metadata
-          ERRAND_NAME: smoke_tests
-      on_success:
-        do:
-        - task: update-additional-ops-files-cflinuxfs5-develop
-          file: runtime-ci/tasks/update-single-opsfile-release/task.yml
-          input_mapping:
-            original-ops-file: cf-deployment-develop
-            release: cflinuxfs5-release
-          output_mapping:
-            updated-ops-file: updated-cf-deployment-cflinuxfs5-develop
-          params:
-            RELEASE_NAME: cflinuxfs5
-        - put: cf-deployment-develop
-          params:
-            rebase: true
-            repository: updated-cf-deployment-cflinuxfs5-develop
-      on_failure:
-        do:
-        - task: push-to-release-branch
-          file: runtime-ci/tasks/push-to-release-branch/task.yml
-          input_mapping:
-            updated-cf-deployment: updated-cf-deployment-cflinuxfs5-release-candidate
-            release: cflinuxfs5-release
-          params:
-            DEPLOY_KEY: ((ard_wg_gitbot_ssh_key.private_key))
-            RELEASE_NAME: cflinuxfs5
-        - task: retrieve-bosh-logs
-          file: runtime-ci/tasks/retrieve-bosh-logs/task.yml
-          input_mapping:
-            bbl-state: relint-envs
-            pool-lock: pre-dev-pool
-          params:
-            BBL_JSON_CONFIG: pool-lock/metadata
-        - put: cflinuxfs5-component-bump-logs-gcs
-          params:
-            file: bosh-logs/cf-*.tgz
-        ensure:
-          do:
-          - task: create-slack-message
-            file: runtime-ci/tasks/create-slack-message/task.yml
-            input_mapping:
-              release: cflinuxfs5-release
-            params:
-              BOSH_LOGS_PREFIX: https://storage.cloud.google.com/component-bump-logs/cflinuxfs5
-              RELEASE_NAME: cflinuxfs5
-          - task: lookup-slack-channel-for-release-owner
-            file: runtime-ci/tasks/lookup-slack-channel-for-release-owner/task.yml
-            params:
-              RELEASE_REPOSITORY: cloudfoundry/cflinuxfs5-release
-          - put: slack-alert
-            params:
-              channel_file: slack-channel/channel.txt
-              icon_emoji: ':cloudfoundrylogo:'
-              text: |
-                $TEXT_FILE_CONTENT
-
-                CI job: https://concourse.wg-ard.ci.cloudfoundry.org/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
-
-                If you're unfamiliar with the update-release pre-validation, please review the following FAQ: https://docs.google.com/document/d/1dUIk2HWbUzdxWs-pNZ-cCqH7CuSNDBixIUoXIFkFpz0
-              text_file: slack-message/message.txt
-              username: Release Integration
-      ensure:
-        do:
-        - task: delete-deployment
-          file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
-          input_mapping:
-            bbl-state: relint-envs
-            pool-lock: pre-dev-pool
-          params:
-            BBL_JSON_CONFIG: pool-lock/metadata
-            IGNORE_ERRORS: true
-          attempts: 3
-        - task: remove-gcp-dns
-          file: runtime-ci/tasks/manage-gcp-dns/task.yml
-          input_mapping:
-            bbl-state: relint-envs
-            pool-lock: pre-dev-pool
-          params:
-            BBL_JSON_CONFIG: pool-lock/metadata
-            GCP_DNS_SERVICE_ACCOUNT_KEY: ((ci_dns_admin_gcp_service_account_json))
-            GCP_DNS_ZONE_NAME: wg-ard
-            ACTION: remove
-        - task: bbl-down
-          file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
-          input_mapping:
-            bbl-state: relint-envs
-            pool-lock: pre-dev-pool
-          params:
-            BBL_JSON_CONFIG: pool-lock/metadata
-          on_failure:
-            do:
-            - task: bbl-cleanup-leftovers
-              file: runtime-ci/tasks/bbl-cleanup-leftovers/task.yml
-              input_mapping:
-                bbl-state: updated-bbl-state
-                pool-lock: pre-dev-pool
-              output_mapping:
-                updated-bbl-state: clean-bbl-state
-              params:
-                BBL_JSON_CONFIG: pool-lock/metadata
-            ensure:
-              put: relint-envs
-              params:
-                repository: clean-bbl-state
-                rebase: true
-          on_success:
-            put: relint-envs
-            params:
-              repository: updated-bbl-state
-              rebase: true
-    ensure:
-      do:
-      - put: pre-dev-pool
-        params:
-          release: pre-dev-pool
 - name: acquire-haproxy-pre-dev-lock
   public: true
   plan:
@@ -14286,6 +14340,13 @@ jobs:
       - put: cflinuxfs4-release-gcs
         params:
           file: compiled-releases/cflinuxfs4-[0-9]*.tgz
+          predefined_acl: publicRead
+        get_params:
+          skip_download: "true"
+        attempts: 3
+      - put: cflinuxfs5-release-gcs
+        params:
+          file: compiled-releases/cflinuxfs5-[0-9]*.tgz
           predefined_acl: publicRead
         get_params:
           skip_download: "true"


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to develop branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Regenerate update-releases pipeline after cflinuxfs5 was inlined and moved. As of now it is still part of the update-ops-releases, which is not correct and the BOSH release is moved, we must update the pipeline!

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...

N/A

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment/pull/1354

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO

### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [X] NO

### How should this change be described in cf-deployment release notes?

N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The `update-cflinuxfs5`should be moved from `update-ops-releases group` to `update-base-releases`. The cflinuxfs5 release version must be updated in the main cf manifest.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
