### PR TITLE
Enable REGENERATE_CREDENTIALS flag in deploy-cf for bellatrix jammy

### DIFF
--- a/ci/pipelines/jammy-stemcell.yml
+++ b/ci/pipelines/jammy-stemcell.yml
@@ -57,6 +57,7 @@ jobs:
             operations/use-postgres.yml
           SYSTEM_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org
           SKIP_STEMCELL_UPLOAD: true
+          REGENERATE_CREDENTIALS: true
         task: deploy-cf
       - in_parallel:
           steps:


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

certificates have expired for jammy validation pipeline. The REGENERATE_CREDENTIALS flag was missing this PR aims to enable this so the certs are renewed everytime.

### What customer problem is being addressed? Use customer persona to define the problem e.g. Alana is unable to...
N/A

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-deployment-concourse-tasks/blob/main/bosh-deploy/task.yml#L58_

### Has a cf-deployment including this change passed [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests)?

- [ ] YES
- [ ] NO
- [X] N/A
### Does this PR introduce a breaking change? Please take a moment to read through the examples before answering the question.

- [ ] YES - please choose the category from below. Feel free to provide additional details.
- [ ] NO
- [X] N/A

### How should this change be described in cf-deployment release notes?

- [X] N/A

### Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [ ] NO
- [X] N/A
- 
### Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [ ] GA'd feature/component

### Please provide Acceptance Criteria for this change?

The deploy-job should be green: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/jammy-stemcell-backward-compatibility/jobs/deploy-cf/

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
