### PR TITLE
Add cflinuxfs4 backward-compatibility validation to jammy-stemcell pipeline

### DIFF
--- a/ci/pipelines/jammy-stemcell.md
+++ b/ci/pipelines/jammy-stemcell.md
@@ -1,6 +1,13 @@
 # jammy-stemcell
 
-Test cf-d on the Ubuntu Jammy stemcell.
+Backward-compatibility pipeline ensuring `cflinuxfs4` keeps working on the
+Ubuntu **Jammy** stemcell after the base `cf-deployment.yml` default stack
+migrates to `cflinuxfs5`.
+
+The default stack is explicitly pinned to `cflinuxfs4` via
+[`set-cflinuxfs4-default-stack.yml`](../../operations/set-cflinuxfs4-default-stack.yml)
+so the pipeline remains meaningful even after the fs5 flip.
+
 
 ## Triggers
 

--- a/ci/pipelines/jammy-stemcell.yml
+++ b/ci/pipelines/jammy-stemcell.yml
@@ -55,6 +55,7 @@ jobs:
             operations/use-internal-lookup-for-route-services.yml
             operations/experimental/colocate-smoke-tests-on-cc-worker.yml
             operations/use-postgres.yml
+            operations/set-cflinuxfs4-default-stack.yml
           SYSTEM_DOMAIN: cf.bellatrix.env.wg-ard.ci.cloudfoundry.org
           SKIP_STEMCELL_UPLOAD: true
         task: deploy-cf

--- a/operations/README.md
+++ b/operations/README.md
@@ -56,6 +56,7 @@ This is the README for Ops-files. To learn more about `cf-deployment`, go to the
 | [`scale-database-cluster.yml`](scale-database-cluster.yml) | Scales cf-deployment database to 3 nodes across 3 zones (z1, z2, z3). | Cannot be used with postgres as it will not scale. | **YES** |
 | [`scale-to-one-az.yml`](scale-to-one-az.yml) | Scales cf-deployment down to a single instance per instance group, placing them all into a single AZ. | Effectively halves the deployment's footprint. Should be applied before other ops files. | **NO** |
 | [`set-bbs-active-key.yml`](set-bbs-active-key.yml) | Allows a deployer to set the `bbs` active key label by passing a variable `diego_bbs_active_key_label` |  | **YES** |
+| [`set-cflinuxfs4-default-stack.yml`](set-cflinuxfs4-default-stack.yml) | Sets `cflinuxfs4` as the default stack for Cloud Controller and Diego's Docker staging. | | **YES** |
 | [`set-cpu-weight.yml`](set-cpu-weight.yml) | CPU shares for each garden container are proportional to its memory limits. | | **YES** |
 | [`set-router-static-ips.yml`](set-router-static-ips.yml) | Allows a deployer to set the static IPs for the `router` VMs by passing a variable `router_static_ips` | `router_static_ips` variable must be provided as a compacted YAML array, e.g. `-v router_static_ips=[10.0.16.4,10.0.47.5]` | **NO** |
 | [`stop-skipping-tls-validation.yml`](stop-skipping-tls-validation.yml) | Enforces `TLS` validation for all components which skip it in the base `cf-deployment.yml` manifest. | See the base [README](../README.md#tls) for details. | **YES** |

--- a/operations/set-cflinuxfs4-default-stack.yml
+++ b/operations/set-cflinuxfs4-default-stack.yml
@@ -1,0 +1,7 @@
+---
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_stack?
+  value: cflinuxfs4
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego/docker_staging_stack
+  value: cflinuxfs4

--- a/units/tests/standard_test/operations.yml
+++ b/units/tests/standard_test/operations.yml
@@ -46,6 +46,10 @@ scale-to-one-az.yml: {}
 set-bbs-active-key.yml:
   vars:
   - diego_bbs_active_key_label=my_key_name
+set-cflinuxfs4-default-stack.yml:
+  pathvalidator:
+    path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_stack
+    expectedvalue: cflinuxfs4
 set-cpu-weight.yml: {}
 set-router-static-ips.yml:
   vars:


### PR DESCRIPTION
## WHAT is this change about?

Extends the jammy-stemcell-backward-compatibility pipeline to explicitly pin cflinuxfs4 as the default stack, so SAP customers who stay on the Jammy stemcell and the cflinuxfs4 stack continue to be covered after the base cf-deployment.yml default migrates to cflinuxfs5.

Jobs are renamed with a `-cflinuxfs4` suffix to make it unambiguous in the Concourse UI which stack is under test. The cflinuxfs4-compat release is not added to this pipeline — it is already fully validated on every cf-d release by fresh-deploy (main cf-deployment pipeline, luna environment, Noble stemcell).

## What customer problem is being addressed?

Alana is an SAP operator running cf-deployment on the Jammy stemcell with the cflinuxfs4 stack. She needs confidence that every new CF community release continues to work with her stack, even after the community default moves to cflinuxfs5. Without an explicit stack pin in the backward-compatibility pipeline, the pipeline would silently start testing cflinuxfs5 after the default flip, leaving cflinuxfs4 on Jammy unvalidated.

## Please provide any contextual information.

- The jammy-stemcell-backward-compatibility pipeline already existed to validate Jammy stemcell backward compatibility; this change focuses its purpose and makes the cflinuxfs4 pin explicit.
- cflinuxfs4-compat coverage boundary is documented: validated on Noble by fresh-deploy in the main pipeline; Jammy + standard cflinuxfs4 is the gap filled here.
- See `jammy-stemcell.md` for the updated pipeline documentation.

## Has a cf-deployment including this change passed cf-acceptance-tests?

- [ ] YES
- [x] NO

## Does this PR introduce a breaking change?

- [] YES - please choose the category from below. Feel free to provide additional details.
- [x] NO - this is a CI pipeline and documentation change only; no ops files or the base manifest are changed.

## How should this change be described in cf-deployment release notes?

Extended the jammy-stemcell-backward-compatibility pipeline to explicitly validate the cflinuxfs4 release on the Jammy stemcell, ensuring backward compatibility is maintained after the default stack migrates to cflinuxfs5.

## Does this PR introduce a new BOSH release into the base cf-deployment.yml manifest or any ops-files?

- [ ] YES - please specify
- [x] NO

## Does this PR make a change to an experimental or GA'd feature/component?

- [ ] experimental feature/component
- [x] GA'd feature/component - cflinuxfs4 is the current default stack.

## Acceptance Criteria

jammy-stemcell-backward-compatibility pipeline runs green end-to-end (`deploy-cf-cflinuxfs4` → `run-smoke-tests-cflinuxfs4` → `run-cats-cflinuxfs4`)


## What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**


> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
@jochenehret @oliver-heinrich @iaftab-alam 